### PR TITLE
Add ChEMBL API client with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+tmp/
+.mypy_cache/
+requirements.lock
+
+# IDE settings
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# ChEMBL_DataAcquisition
+# ChEMBL Data Acquisition
+
+Utilities for retrieving target and assay information from the
+[ChEMBL](https://www.ebi.ac.uk/chembl/) REST API.
+
+## Installation
+
+The project requires Python 3.12 or later.  Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Fetch two targets and write the result to `targets.csv`:
+
+```bash
+python main.py --type target --ids CHEMBL25,CHEMBL26 --output targets.csv
+```
+
+Fetch a list of assays and write the result to `assays.csv`:
+
+```bash
+python main.py --type assay --ids CHEMBL1,CHEMBL2 --output assays.csv
+```
+
+## Development
+
+Code style and static analysis:
+
+```bash
+ruff check .
+black .
+mypy .
+```
+
+Run the tests:
+
+```bash
+pytest
+```
+
+## Dependencies
+
+- `requests >= 2.31`
+- `pandas >= 2.0`
+- `pytest >= 7.0` (for running tests)
+- `ruff`, `black`, `mypy` (optional, for development)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,75 @@
+"""Command line interface for ChEMBL data retrieval.
+
+The script provides a small CLI for downloading target or assay
+information from the ChEMBL REST API and storing the result as a CSV
+file.  It demonstrates the use of :mod:`mylib.chembl_client`.
+
+Example
+-------
+Fetch target records for two identifiers and write them to ``out.csv``::
+
+    python main.py --type target --ids CHEMBL1,CHEMBL2 --output out.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Iterable
+
+from mylib import chembl_client as cc
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Fetch data from ChEMBL API")
+    parser.add_argument(
+        "--type",
+        choices={"target", "assay"},
+        required=True,
+        help="Type of entity to retrieve",
+    )
+    parser.add_argument(
+        "--ids",
+        required=True,
+        help="Comma separated list of ChEMBL identifiers",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Path to the output CSV file",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (e.g. INFO, DEBUG)",
+    )
+    return parser.parse_args(argv)
+
+
+def configure_logging(level: str) -> None:
+    """Configure basic logging."""
+    logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO))
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    """Entry point for command line execution."""
+    args = parse_args(argv)
+    configure_logging(args.log_level)
+
+    ids = args.ids.split(",")
+    if args.type == "target":
+        df = cc.get_targets(ids)
+    else:
+        df = cc.get_assays(ids)
+
+    df.to_csv(args.output, index=False)
+    logging.info("Wrote %d records to %s", len(df), args.output)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())
+

--- a/mylib/__init__.py
+++ b/mylib/__init__.py
@@ -1,0 +1,18 @@
+"""Utility package for accessing ChEMBL data."""
+
+from .chembl_client import (
+    get_target,
+    get_targets,
+    get_assay,
+    get_assays,
+    extend_target,
+)
+
+__all__ = [
+    "get_target",
+    "get_targets",
+    "get_assay",
+    "get_assays",
+    "extend_target",
+]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas>=2.0
+requests>=2.31

--- a/tests/data/assays.json
+++ b/tests/data/assays.json
@@ -1,0 +1,37 @@
+{
+  "assays": [
+    {
+      "aidx": 1,
+      "assay_category": "B",
+      "assay_cell_type": "Cell",
+      "assay_chembl_id": "CHEMBL1",
+      "assay_classifications": [],
+      "assay_group": 1,
+      "assay_organism": "Human",
+      "assay_parameters": [],
+      "assay_strain": null,
+      "assay_subcellular_fraction": null,
+      "assay_tax_id": 9606,
+      "assay_test_type": null,
+      "assay_tissue": "Liver",
+      "assay_type": "B",
+      "assay_type_description": "Binding",
+      "bao_format": "format",
+      "bao_label": "label",
+      "cell_chembl_id": "CHEMBL_CELL",
+      "confidence_score": 9,
+      "description": "desc",
+      "document_chembl_id": "CHEMBL_DOC",
+      "src_assay_id": "SRC_ASSAY",
+      "src_id": 1,
+      "relationship_type": "type",
+      "target_chembl_id": "CHEMBL_TGT",
+      "tissue_chembl_id": "CHEMBL_TISSUE",
+      "variant_sequence": {
+        "isoform": "iso",
+        "mutation": "mut",
+        "sequence": "SEQ"
+      }
+    }
+  ]
+}

--- a/tests/data/target.json
+++ b/tests/data/target.json
@@ -1,0 +1,26 @@
+{
+  "pref_name": "Sample Target",
+  "target_chembl_id": "CHEMBL123",
+  "target_components": {
+    "target_component": {
+      "component_description": "Example component",
+      "component_id": 1,
+      "relationship": "SINGLE PROTEIN",
+      "target_component_synonyms": {
+        "target_component_synonym": [
+          {"component_synonym": "GENE1", "syn_type": "GENE_SYMBOL"},
+          {"component_synonym": "GENE_ONE", "syn_type": "GENE_SYMBOL_OTHER"},
+          {"component_synonym": "1.2.3.4", "syn_type": "EC_NUMBER"},
+          {"component_synonym": "ALT1", "syn_type": "UNIPROT"}
+        ]
+      },
+      "target_component_xrefs": {
+        "target": {
+          "xref_src_db": "HGNC",
+          "xref_name": "Gene1",
+          "xref_id": "HGNC:1"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -1,0 +1,101 @@
+import sys
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+import requests
+
+# Ensure project root is on the path for imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mylib import chembl_client as cc
+
+DATA_DIR = Path(__file__).parent / "data"
+
+
+class MockResponse:
+    def __init__(self, payload: Any, status: int = 200) -> None:
+        self.payload = payload
+        self.status = status
+
+    def json(self) -> Any:  # pragma: no cover - simple delegate
+        return self.payload
+
+    def raise_for_status(self) -> None:
+        if self.status >= 400:
+            raise requests.HTTPError(f"status: {self.status}")
+
+
+@pytest.fixture
+def target_payload() -> dict[str, Any]:
+    with (DATA_DIR / "target.json").open("r", encoding="utf8") as fh:
+        return json.load(fh)
+
+
+@pytest.fixture
+def assay_payload() -> dict[str, Any]:
+    with (DATA_DIR / "assays.json").open("r", encoding="utf8") as fh:
+        return json.load(fh)
+
+
+def test_parse_target_record(target_payload: dict[str, Any]) -> None:
+    record = cc._parse_target_record(target_payload)
+    assert record["pref_name"] == "Sample Target"
+    assert record["gene"] == "GENE1|GENE_ONE"
+    assert record["ec_code"] == "1.2.3.4"
+    assert record["chembl_alternative_name"] == "ALT1"
+    assert record["HGNC_id"] == "1"
+
+
+def test_get_target(monkeypatch: pytest.MonkeyPatch, target_payload: dict[str, Any]) -> None:
+    def fake_get(url: str, timeout: int = 30):
+        return MockResponse(target_payload)
+
+    monkeypatch.setattr(cc.requests, "get", fake_get)
+    result = cc.get_target("CHEMBL123")
+    assert result["pref_name"] == "Sample Target"
+
+
+def test_get_targets(monkeypatch: pytest.MonkeyPatch, target_payload: dict[str, Any]) -> None:
+    def fake_get(url: str, timeout: int = 30):
+        return MockResponse({"targets": [target_payload]})
+
+    monkeypatch.setattr(cc.requests, "get", fake_get)
+    df = cc.get_targets(["CHEMBL123", "", "#N/A"])
+    assert list(df.columns) == cc.TARGET_FIELDS
+    assert df.iloc[0]["pref_name"] == "Sample Target"
+
+
+def test_get_assay(monkeypatch: pytest.MonkeyPatch, assay_payload: dict[str, Any]) -> None:
+    assay = assay_payload["assays"][0]
+
+    def fake_get(url: str, timeout: int = 30):
+        return MockResponse(assay)
+
+    monkeypatch.setattr(cc.requests, "get", fake_get)
+    df = cc.get_assay("CHEMBL1")
+    assert df.iloc[0]["assay_chembl_id"] == "CHEMBL1"
+    assert list(df.columns) == cc.ASSAY_COLUMNS
+
+
+def test_get_assays(monkeypatch: pytest.MonkeyPatch, assay_payload: dict[str, Any]) -> None:
+    def fake_get(url: str, timeout: int = 30):
+        return MockResponse(assay_payload)
+
+    monkeypatch.setattr(cc.requests, "get", fake_get)
+    df = cc.get_assays(["CHEMBL1"])
+    assert df.iloc[0]["assay_chembl_id"] == "CHEMBL1"
+
+
+def test_extend_target(monkeypatch: pytest.MonkeyPatch, target_payload: dict[str, Any]) -> None:
+    def fake_get_target(tid: str) -> dict[str, Any]:
+        return cc._parse_target_record(target_payload)
+
+    monkeypatch.setattr(cc, "get_target", fake_get_target)
+    df = pd.DataFrame({"task_chembl_id": ["CHEMBL123"]})
+    extended = cc.extend_target(df)
+    assert "chembl_pref_name" in extended.columns
+    assert extended.loc[0, "chembl_pref_name"] == "Sample Target"
+


### PR DESCRIPTION
## Summary
- implement `chembl_client` with helpers for ChEMBL target and assay retrieval
- add CLI script `main.py` for fetching data and writing CSV output
- provide unit tests with fixtures and example JSON payloads
- ignore Python bytecode and cache artifacts via `.gitignore`

## Testing
- `ruff check mylib tests main.py`
- `mypy mylib/chembl_client.py`
- `pytest -q`
- `python main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68acb98ec6048324bd409e751eec4f6e