### PR TITLE
Improve ChEMBL data acquisition utilities

### DIFF
--- a/ChEMBL/get_chembl_data.py
+++ b/ChEMBL/get_chembl_data.py
@@ -23,7 +23,19 @@ from script import io_utils as io
 
 
 def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
-    """Parse command line arguments."""
+    """Parse command line arguments.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of argument strings. If ``None`` the arguments
+        are read from ``sys.argv``.
+
+    Returns
+    -------
+    argparse.Namespace
+        Parsed command line options.
+    """
     parser = argparse.ArgumentParser(description="Fetch data from ChEMBL API")
     parser.add_argument(
         "--type",
@@ -67,16 +79,35 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
 
 
 def configure_logging(level: str) -> None:
-    """Configure basic logging."""
+    """Configure basic logging.
+
+    Parameters
+    ----------
+    level:
+        Logging verbosity such as ``"INFO"`` or ``"DEBUG"``.
+    """
     logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO))
 
 
 def main(argv: Iterable[str] | None = None) -> int:
-    """Entry point for command line execution."""
+    """Entry point for command line execution.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command line arguments.
+
+    Returns
+    -------
+    int
+        Zero on success, non-zero on failure.
+    """
     args = parse_args(argv)
     configure_logging(args.log_level)
 
-    ids = io.read_ids(args.input, column=args.column, sep=args.sep, encoding=args.encoding)
+    ids = io.read_ids(
+        args.input, column=args.column, sep=args.sep, encoding=args.encoding
+    )
     if args.type == "target":
         df = cc.get_targets(ids)
     elif args.type == "assay":
@@ -84,7 +115,13 @@ def main(argv: Iterable[str] | None = None) -> int:
     else:
         df = cc.get_documents(ids)
 
-    df.to_csv(args.output, index=False)
+    try:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        df.to_csv(args.output, index=False, encoding=args.encoding)
+    except OSError as exc:
+        logging.error("Failed to write output to %s: %s", args.output, exc)
+        return 1
+
     logging.info("Wrote %d records to %s", len(df), args.output)
     return 0
 

--- a/ChEMBL/script/chembl_lib.py
+++ b/ChEMBL/script/chembl_lib.py
@@ -323,31 +323,52 @@ def get_assay(chembl_assay_id: str) -> pd.DataFrame:
     return df
 
 
-def get_assays(ids: Iterable[str]) -> pd.DataFrame:
-    """Fetch assay records for ``ids`` in a single request."""
+def get_assays(ids: Iterable[str], chunk_size: int = 50) -> pd.DataFrame:
+    """Fetch assay records for ``ids``.
+
+    Parameters
+    ----------
+    ids:
+        Assay identifiers to retrieve.
+    chunk_size:
+        Maximum number of IDs per HTTP request.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Combined assay records.
+    """
     valid = [i for i in ids if i not in {"", "#N/A"}]
     if not valid:
         return pd.DataFrame(columns=ASSAY_COLUMNS)
 
-    url = (
-        "https://www.ebi.ac.uk/chembl/api/data/assay.json?format=json&variant_sequence__isnull=false&assay_chembl_id__in="
-        + ",".join(valid)
-    )
-    try:
-        response = requests.get(url, timeout=30)
-        response.raise_for_status()
-    except requests.RequestException as exc:  # pragma: no cover - network
-        logger.warning("Bulk assay request failed: %s", exc)
+    records: list[pd.DataFrame] = []
+    for chunk in _chunked(valid, chunk_size):
+        url = (
+            "https://www.ebi.ac.uk/chembl/api/data/assay.json?format=json&variant_sequence__isnull=false&assay_chembl_id__in="
+            + ",".join(chunk)
+        )
+        try:
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - network
+            logger.warning("Bulk assay request failed for %s: %s", chunk, exc)
+            continue
+
+        try:
+            data = response.json()
+        except ValueError as exc:  # pragma: no cover - malformed JSON
+            logger.warning("Failed to decode JSON for assays %s: %s", chunk, exc)
+            continue
+
+        items = data.get("assays") or data.get("assay") or []
+        if items:
+            records.append(pd.json_normalize(items))
+
+    if not records:
         return pd.DataFrame(columns=ASSAY_COLUMNS)
 
-    try:
-        data = response.json()
-    except ValueError as exc:  # pragma: no cover - malformed JSON
-        logger.warning("Failed to decode JSON for assays: %s", exc)
-        return pd.DataFrame(columns=ASSAY_COLUMNS)
-
-    items = data.get("assays") or data.get("assay") or []
-    df = pd.json_normalize(items)
+    df = pd.concat(records, ignore_index=True)
     return df.reindex(columns=ASSAY_COLUMNS)
 
 
@@ -400,35 +421,58 @@ def get_document(chembl_document_id: str) -> pd.DataFrame:
     return df.reindex(columns=DOCUMENT_COLUMNS)
 
 
-def get_documents(ids: Iterable[str]) -> pd.DataFrame:
-    """Fetch document records for ``ids`` in a single request."""
+def get_documents(ids: Iterable[str], chunk_size: int = 50) -> pd.DataFrame:
+    """Fetch document records for ``ids``.
+
+    Parameters
+    ----------
+    ids:
+        Document identifiers to retrieve.
+    chunk_size:
+        Maximum number of IDs per HTTP request.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Combined document records.
+    """
     valid = [i for i in ids if i not in {"", "#N/A"}]
     if not valid:
         return pd.DataFrame(columns=DOCUMENT_COLUMNS)
 
-    url = (
-        "https://www.ebi.ac.uk/chembl/api/data/document.json?format=json&document_chembl_id__in="
-        + ",".join(valid)
-    )
-    try:
-        response = requests.get(url, timeout=30)
-        response.raise_for_status()
-    except requests.RequestException as exc:  # pragma: no cover - network
-        logger.warning("Bulk document request failed: %s", exc)
+    records: list[pd.DataFrame] = []
+    for chunk in _chunked(valid, chunk_size):
+        url = (
+            "https://www.ebi.ac.uk/chembl/api/data/document.json?format=json&document_chembl_id__in="
+            + ",".join(chunk)
+        )
+        try:
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - network
+            logger.warning("Bulk document request failed for %s: %s", chunk, exc)
+            continue
+
+        try:
+            data = response.json()
+        except ValueError as exc:  # pragma: no cover - malformed JSON
+            logger.warning("Failed to decode JSON for documents %s: %s", chunk, exc)
+            continue
+
+        items = data.get("documents") or data.get("document") or []
+        if items:
+            records.append(pd.json_normalize(items))
+
+    if not records:
         return pd.DataFrame(columns=DOCUMENT_COLUMNS)
 
-    try:
-        data = response.json()
-    except ValueError as exc:  # pragma: no cover - malformed JSON
-        logger.warning("Failed to decode JSON for documents: %s", exc)
-        return pd.DataFrame(columns=DOCUMENT_COLUMNS)
-
-    items = data.get("documents") or data.get("document") or []
-    df = pd.json_normalize(items)
+    df = pd.concat(records, ignore_index=True)
     return df.reindex(columns=DOCUMENT_COLUMNS)
 
 
-def extend_target(df: pd.DataFrame, chembl_column: str = "task_chembl_id") -> pd.DataFrame:
+def extend_target(
+    df: pd.DataFrame, chembl_column: str = "task_chembl_id", chunk_size: int = 50
+) -> pd.DataFrame:
     """Augment a DataFrame with target information.
 
     Parameters
@@ -438,14 +482,23 @@ def extend_target(df: pd.DataFrame, chembl_column: str = "task_chembl_id") -> pd
     chembl_column:
         Name of the column holding the target IDs. Default is
         ``"task_chembl_id"``.
+    chunk_size:
+        Maximum number of IDs per HTTP request when fetching targets.
 
     Returns
     -------
     pandas.DataFrame
         Original data combined with the expanded target information.
     """
-    target_data = df[chembl_column].apply(get_target).apply(pd.Series)
-    target_data = target_data.rename(
+    ids = df[chembl_column].astype(str).tolist()
+    targets = get_targets(ids, chunk_size=chunk_size)
+    merged = df.merge(
+        targets,
+        how="left",
+        left_on=chembl_column,
+        right_on="target_chembl_id",
+    )
+    return merged.rename(
         columns={
             "pref_name": "chembl_pref_name",
             "target_chembl_id": "chembl_target_chembl_id",
@@ -459,40 +512,3 @@ def extend_target(df: pd.DataFrame, chembl_column: str = "task_chembl_id") -> pd
             "HGNC_id": "chembl_HGNC_id",
         }
     )
-    return pd.concat([df.reset_index(drop=True), target_data], axis=1)
-def read_ids(
-    path: str | Path,
-    column: str = "chembl_id",
-    sep: str = ",",
-    encoding: str = "utf8",
-) -> List[str]:
-    """Read identifier values from a CSV file.
-
-    Parameters
-    ----------
-    path : str or Path
-        Path to the CSV file.
-    column : str, optional
-        Name of the column containing identifiers. Defaults to ``"chembl_id"``.
-    sep : str, optional
-        Field delimiter, by default a comma.
-    encoding : str, optional
-        File encoding, by default ``"utf8"``.
-
-    Returns
-    -------
-    list of str
-        Identifier values in the order they appear. Empty strings and ``"#N/A"``
-        markers are discarded.
-
-    Raises
-    ------
-    ValueError
-        If ``column`` is not present in the input file.
-    """
-    df = pd.read_csv(path, sep=sep, encoding=encoding, dtype=str)
-    if column not in df.columns:
-        raise ValueError(f"column '{column}' not found in {path}")
-
-    ids = df[column].dropna().astype(str)
-    return [i for i in ids if i and i != "#N/A"]

--- a/ChEMBL/script/io_utils.py
+++ b/ChEMBL/script/io_utils.py
@@ -36,7 +36,15 @@ def read_ids(
     ValueError
         If ``column`` is not present in the input file.
     """
-    df = pd.read_csv(path, sep=sep, encoding=encoding, dtype=str)
+    try:
+        df = pd.read_csv(path, sep=sep, encoding=encoding, dtype=str)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"input file not found: {path}") from exc
+    except pd.errors.EmptyDataError as exc:
+        raise ValueError(f"no data in file: {path}") from exc
+    except pd.errors.ParserError as exc:
+        raise ValueError(f"malformed CSV in file: {path}: {exc}") from exc
+
     if column not in df.columns:
         raise ValueError(f"column '{column}' not found in {path}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure the ChEMBL package is importable during tests
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "ChEMBL"))

--- a/tests/data/ids.csv
+++ b/tests/data/ids.csv
@@ -1,0 +1,4 @@
+chembl_id
+CHEMBL1
+CHEMBL2
+#N/A

--- a/tests/test_chembl_lib.py
+++ b/tests/test_chembl_lib.py
@@ -1,0 +1,35 @@
+import pandas as pd
+
+from script import chembl_lib
+
+
+def test_extend_target_uses_bulk(monkeypatch):
+    calls: list[list[str]] = []
+
+    def fake_get_targets(ids, chunk_size=50):  # noqa: D401 - test stub
+        calls.append(list(ids))
+        return pd.DataFrame(
+            [
+                {
+                    "target_chembl_id": "CHEMBL1",
+                    "pref_name": "name",
+                    "component_description": "desc",
+                    "component_id": 1,
+                    "relationship": "rel",
+                    "gene": "gene",
+                    "chembl_alternative_name": "alt",
+                    "ec_code": "ec",
+                    "HGNC_name": "hgnc",
+                    "HGNC_id": "123",
+                }
+            ]
+        )
+
+    monkeypatch.setattr(chembl_lib, "get_targets", fake_get_targets)
+
+    df = pd.DataFrame({"task_chembl_id": ["CHEMBL1"]})
+    result = chembl_lib.extend_target(df)
+
+    assert calls == [["CHEMBL1"]]
+    assert "chembl_pref_name" in result.columns
+    assert result.loc[0, "chembl_pref_name"] == "name"

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import pytest
+
+from script.io_utils import read_ids
+
+DATA_DIR = Path(__file__).parent / "data"
+
+
+def test_read_ids(tmp_path):
+    path = DATA_DIR / "ids.csv"
+    assert read_ids(path) == ["CHEMBL1", "CHEMBL2"]
+
+
+def test_read_ids_missing_column():
+    path = DATA_DIR / "ids.csv"
+    with pytest.raises(ValueError):
+        read_ids(path, column="missing")
+
+
+def test_read_ids_missing_file():
+    with pytest.raises(FileNotFoundError):
+        read_ids(Path("does_not_exist.csv"))


### PR DESCRIPTION
## Summary
- document CLI helpers and ensure writing uses explicit encoding and error handling
- chunk bulk ChEMBL requests and streamline DataFrame enrichment
- harden CSV ID reading and add basic tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad9327a40c832492d5034b5161d757