### PR TITLE
Document dependencies and streamline test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,37 @@
 # ChEMBL_DataAcquisition
 
 
-Utilities for working with the IUPHAR, PubChem  db. Utilities and scripts for retrieving chemical data.
+Utilities for retrieving and processing chemical information from public
+sources such as ChEMBL, IUPHAR, PubChem and UniProt.  Each subdirectory
+contains a small library of helper functions and a command line script to
+perform common data acquisition tasks.
 
 
 ## Installation
+
+The project targets **Python 3.12**. Install the required dependencies:
 
 ```bash
 pip install -r requirements.txt
 ```
 
-## Usage IUPHAR
+Main dependencies
 
-The project ships both a reusable library and a small command line interface.
+- pandas >= 2.0
+- requests >= 2.31
+- urllib3 >= 1.26
+- responses >= 0.23 (tests)
+- pytest >= 7.4 (tests)
+- ruff >= 0.1 (lint)
+- black >= 23.0 (formatting)
+- mypy >= 1.8 (type checking)
+
+## Usage
+
+Each data source provides both a reusable library and a command line
+interface. Examples:
+
+### IUPHAR
 
 ```bash
 python get_IUPHAR.py \
@@ -21,7 +40,8 @@ python get_IUPHAR.py \
     --uniprot Q11111
 ```
 
-Batch process UniProt accessions from a CSV file containing a ``uniprot_id`` column and write the mapping to another CSV:
+Batch process UniProt accessions from a CSV file containing a
+``uniprot_id`` column and write the mapping to another CSV:
 
 ```bash
 python get_IUPHAR.py \
@@ -31,7 +51,40 @@ python get_IUPHAR.py \
     --output-file results.csv
 ```
 
-The resulting file includes the resolved ``target_id`` together with the IUPHAR classification (class, subclass and family chain) for each UniProt accession. If a UniProt lookup fails, the script optionally consults ``hgnc_name``, ``hgnc_id``, ``gene_name`` and ``synonyms`` columns (when
-present) to resolve the identifier. When no target can be found, an optional ``ec_number`` column is used to infer ``IUPHAR_type``, ``IUPHAR_class`` and ``IUPHAR_subclass``.
+The resulting file includes the resolved ``target_id`` together with the
+IUPHAR classification (class, subclass and family chain) for each
+UniProt accession. If a UniProt lookup fails, the script optionally
+consults ``hgnc_name``, ``hgnc_id``, ``gene_name`` and ``synonyms``
+columns (when present) to resolve the identifier. When no target can be
+found, an optional ``ec_number`` column is used to infer
+``IUPHAR_type``, ``IUPHAR_class`` and ``IUPHAR_subclass``.
+
+### UniProt
+
+```bash
+python get_uniprot_data.py tests/data/uniprot_input.csv results.csv
+```
+
+### PubChem
+
+```bash
+python get_PubChem.py --name "aspirin"
+```
+
+### ChEMBL
+
+```bash
+python get_chembl_data.py --target CHEMBL25
+```
+
+## Development
+
+Run quality checks and tests before submitting changes:
+
+```bash
+ruff check .
+mypy uniprot/get_uniprot_data.py  # adjust paths as needed
+pytest
+```
 
  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
+black>=23.0
+mypy>=1.8
 pandas>=2.0
+pytest>=7.4
 requests>=2.31
 responses>=0.23
-pytest>=7.4
 ruff>=0.1
-mypy>=1.8
+urllib3>=1.26

--- a/tests/test_pubchem_api.py
+++ b/tests/test_pubchem_api.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import responses
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from mylib import pubchem
+from PubChem.script import pubchem
 
 DATA_DIR = Path(__file__).parent / "data"
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from mylib.transforms import IUPHARData, IUPHARClassifier
+from IUPHAR.script.transforms import IUPHARData, IUPHARClassifier
 
 
 def load_data() -> IUPHARData:

--- a/uniprot/get_uniprot_data.py
+++ b/uniprot/get_uniprot_data.py
@@ -12,11 +12,7 @@ Usage:
 The input CSV must contain a column named ``UniProt_id``.
 """
 
-import csv
-import json
-import os
 import sys
-from typing import Iterable
 
 from script import uniprot_utils as uu
 


### PR DESCRIPTION
## Summary
- expand installation docs and dependency list
- remove temporary `mylib` shim and import IUPHAR/PubChem modules directly in tests
- remove unused imports in UniProt data script

## Testing
- `pip install -r requirements.txt`
- `ruff check .`
- `mypy IUPHAR/script/transforms.py` (fails: missing stubs and incompatible types)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae14514d10832487e4636155dc7724