### PR TITLE
Enhance CLI for target data acquisition and add tests

### DIFF
--- a/library/iuphar_library.py
+++ b/library/iuphar_library.py
@@ -283,6 +283,7 @@ class IUPHARData:
         output_path: str | Path,
         *,
         encoding: str = "utf-8",
+        sep: str = ",",
     ) -> pd.DataFrame:
         """Map UniProt IDs to classification data and write a CSV output.
 
@@ -304,6 +305,8 @@ class IUPHARData:
             Destination for the enriched CSV file.
         encoding:
             Encoding used for both reading and writing. Defaults to UTF-8.
+        sep:
+            Delimiter used when reading and writing CSV files. Defaults to a comma.
 
         Returns
         -------
@@ -311,7 +314,7 @@ class IUPHARData:
             DataFrame containing the mapping results.
         """
 
-        df = pd.read_csv(input_path, dtype=str, encoding=encoding).fillna("")
+        df = pd.read_csv(input_path, dtype=str, encoding=encoding, sep=sep).fillna("")
         if "uniprot_id" not in df.columns:
             raise ValueError("Input file must contain 'uniprot_id' column")
 
@@ -380,7 +383,7 @@ class IUPHARData:
         df["full_id_path"] = df["target_id"].apply(self.all_id)
         df["full_name_path"] = df["target_id"].apply(self.all_name)
 
-        df.to_csv(output_path, index=False, encoding=encoding)
+        df.to_csv(output_path, index=False, encoding=encoding, sep=sep)
         logger.info("Wrote %d rows to %s", len(df), output_path)
         return df
 

--- a/tests/test_iuphar_mapping.py
+++ b/tests/test_iuphar_mapping.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from library.iuphar_library import IUPHARData
+
+
+def test_map_uniprot_file(tmp_path: Path) -> None:
+    target_csv = tmp_path / "target.csv"
+    family_csv = tmp_path / "family.csv"
+    input_csv = tmp_path / "input.csv"
+    output_csv = tmp_path / "output.csv"
+
+    target_csv.write_text(
+        "target_id,swissprot,hgnc_name,hgnc_id,gene_name,synonyms,family_id,target_name,type\n"
+        "0001,Q12345,GeneX,1,GENE1,Syn1|Syn2,100,TargetX,Enzyme.Lyase\n",
+        encoding="utf-8",
+    )
+    family_csv.write_text(
+        "family_id,family_name,parent_family_id,target_id,type\n"
+        "100,FamilyX,,0001,Enzyme.Lyase\n",
+        encoding="utf-8",
+    )
+    input_csv.write_text("uniprot_id;hgnc_name\nQ12345;GeneX\n", encoding="utf-8")
+
+    data = IUPHARData.from_files(target_csv, family_csv)
+    df = data.map_uniprot_file(input_csv, output_csv, sep=";")
+
+    assert output_csv.exists()
+    out_df = pd.read_csv(output_csv, sep=";", dtype=str)
+    assert out_df.loc[0, "target_id"] == "0001"
+    assert df.loc[0, "target_id"] == "0001"

--- a/tests/test_read_ids.py
+++ b/tests/test_read_ids.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from get_target_data import read_ids
+
+
+def test_read_ids(tmp_path: Path) -> None:
+    csv_file = tmp_path / "ids.csv"
+    csv_file.write_text("chembl_id\nCHEMBL1\n#N/A\n\nCHEMBL2\n", encoding="utf8")
+    assert read_ids(csv_file) == ["CHEMBL1", "CHEMBL2"]
+
+
+def test_read_ids_missing_column(tmp_path: Path) -> None:
+    csv_file = tmp_path / "ids.csv"
+    csv_file.write_text("other\n1\n2\n", encoding="utf8")
+    with pytest.raises(ValueError):
+        read_ids(csv_file, column="chembl_id")


### PR DESCRIPTION
## Summary
- expand `get_target_data.py` into a multi-command CLI for ChEMBL, UniProt and IUPHAR pipelines
- add separator-aware mapping in `IUPHARData.map_uniprot_file`
- include unit tests for ID parsing and IUPHAR mapping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae35dcc04c8324a33778f74b0c21f4