### PR TITLE
Expand helper test coverage and CID validation

### DIFF
--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -73,10 +73,12 @@ def validate_cid(cid: str) -> Optional[str]:
     Returns
     -------
     str or None
-        ``cid`` if valid, otherwise ``None`` when CID is ``"0"`` or
-        ``"-1"``.
+        ``cid`` if valid, otherwise ``None`` when the identifier is empty or
+        represents an invalid placeholder (``"0"`` or ``"-1"``).
     """
-    return None if cid in {"0", "-1"} else cid
+    if cid in {"", "0", "-1"}:
+        return None
+    return cid
 
 
 def _extract_cids(bindings: List[Dict[str, Any]]) -> List[str]:

--- a/tests/test_chembl_library.py
+++ b/tests/test_chembl_library.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+import sys
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from library import chembl_library as cl
+from get_target_data import read_ids
+
+# Obtain a real ChEMBL ID from the provided targets.csv file
+DATA_DIR = Path(__file__).resolve().parents[1]
+SAMPLE_ID = read_ids(DATA_DIR / "targets.csv")[0]
+
+
+class FakeResponse:
+    def __init__(self, data):
+        self._data = data
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self):
+        return self._data
+
+
+SAMPLE_JSON = {
+    "pref_name": "MAP3K14",
+    "target_chembl_id": SAMPLE_ID,
+    "target_components": {
+        "target_component": {
+            "component_description": "Mitogen-activated protein kinase kinase kinase 14",
+            "component_id": 123,
+            "relationship": "single",
+            "target_component_synonyms": {
+                "target_component_synonym": [
+                    {"component_synonym": "MAP3K14", "syn_type": "GENE_SYMBOL"},
+                    {"component_synonym": "NIK", "syn_type": "GENE_SYMBOL_OTHER"},
+                    {"component_synonym": "2.7.11.25", "syn_type": "EC_NUMBER"},
+                    {
+                        "component_synonym": "Mitogen-activated protein kinase kinase kinase 14",
+                        "syn_type": "UNIPROT",
+                    },
+                ]
+            },
+            "target_component_xrefs": {
+                "target": [
+                    {"xref_src_db": "UniProt", "xref_id": "Q99558"},
+                    {
+                        "xref_src_db": "HGNC",
+                        "xref_id": "HGNC:6853",
+                        "xref_name": "MAP3K14",
+                    },
+                ]
+            },
+        }
+    },
+}
+
+
+SAMPLE_DF = pd.DataFrame(
+    {
+        "pref_name": ["MAP3K14"],
+        "target_chembl_id": [SAMPLE_ID],
+        "component_description": [
+            "Mitogen-activated protein kinase kinase kinase 14",
+        ],
+        "component_id": ["123"],
+        "relationship": ["single"],
+        "gene": ["MAP3K14"],
+        "uniprot_id": ["Q99558"],
+        "chembl_alternative_name": ["NIK"],
+        "ec_code": ["2.7.11.25"],
+        "hgnc_name": ["MAP3K14"],
+        "hgnc_id": ["6853"],
+    }
+)
+
+
+def test_chunked_splits_list() -> None:
+    assert list(cl._chunked([1, 2, 3, 4], 2)) == [[1, 2], [3, 4]]
+
+
+def test_chunked_invalid_size() -> None:
+    with pytest.raises(ValueError):
+        list(cl._chunked([1], 0))
+
+
+def test_get_target(monkeypatch) -> None:
+    monkeypatch.setattr(cl._session, "get", lambda url, timeout=30: FakeResponse(SAMPLE_JSON))
+    data = cl.get_target(SAMPLE_ID)
+    assert data["uniprot_id"] == "Q99558"
+    assert data["gene"] == "MAP3K14|NIK"
+
+
+def test_get_targets(monkeypatch) -> None:
+    bulk_json = {"targets": [SAMPLE_JSON]}
+    monkeypatch.setattr(cl._session, "get", lambda url, timeout=30: FakeResponse(bulk_json))
+    df = cl.get_targets([SAMPLE_ID])
+    assert df.loc[0, "uniprot_id"] == "Q99558"
+    assert df.shape[0] == 1
+
+
+def test_extend_target(monkeypatch) -> None:
+    monkeypatch.setattr(cl, "get_targets", lambda ids, chunk_size=50: SAMPLE_DF)
+    input_df = pd.DataFrame({"task_chembl_id": [SAMPLE_ID]})
+    out_df = cl.extend_target(input_df)
+    assert out_df.loc[0, "chembl_pref_name"] == "MAP3K14"
+    assert out_df.loc[0, "chembl_gene"] == "MAP3K14"

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from library import pubchem_library as pl
+
+
+def test_url_encode() -> None:
+    assert pl.url_encode("Caffeine 10%") == "Caffeine%2010%25"
+
+
+def test_validate_cid() -> None:
+    assert pl.validate_cid("") is None
+    assert pl.validate_cid("0") is None
+    assert pl.validate_cid("-1") is None
+    assert pl.validate_cid("123") == "123"
+
+
+def test_extract_cids() -> None:
+    bindings = [
+        {"cid": {"value": "123"}},
+        {"cid": "http://rdf.ncbi.nlm.nih.gov/pubchem/compound/CID456"},
+    ]
+    assert pl._extract_cids(bindings) == ["123", "456"]
+
+
+def test_get_cid(monkeypatch) -> None:
+    sample = {"results": {"bindings": [{"cid": {"value": "123"}}, {"cid": {"value": "123"}}, {"cid": {"value": "456"}}]}}
+    monkeypatch.setattr(pl, "make_request", lambda url, delay=3.0: sample)
+    assert pl.get_cid("water") == "123|456"
+
+
+def test_get_standard_name(monkeypatch) -> None:
+    sample = {"InformationList": {"Information": [{"Title": "Water"}]}}
+    monkeypatch.setattr(pl, "validate_cid", lambda cid: cid)
+    monkeypatch.setattr(pl, "make_request", lambda url, delay=3.0: sample)
+    assert pl.get_standard_name("123") == "Water"
+
+
+def test_get_properties(monkeypatch) -> None:
+    sample = {
+        "PropertyTable": {
+            "Properties": [
+                {
+                    "IUPACName": "Oxidane",
+                    "MolecularFormula": "H2O",
+                    "IsomericSMILES": "O",
+                    "CanonicalSMILES": "O",
+                    "InChI": "InChI=1S/H2O/h1H2",
+                    "InChIKey": "XLYOFNOQVPJJNP-UHFFFAOYSA-N",
+                }
+            ]
+        }
+    }
+    monkeypatch.setattr(pl, "validate_cid", lambda cid: cid)
+    monkeypatch.setattr(pl, "make_request", lambda url, delay=3.0: sample)
+    props = pl.get_properties("123")
+    assert props.MolecularFormula == "H2O"
+    assert props.IUPACName == "Oxidane"
+
+
+def test_process_compound(monkeypatch) -> None:
+    monkeypatch.setattr(pl, "get_cid", lambda name: "123")
+    monkeypatch.setattr(pl, "get_standard_name", lambda cid: "Water")
+    monkeypatch.setattr(
+        pl,
+        "get_properties",
+        lambda cid: pl.Properties("Oxidane", "H2O", "O", "O", "InChI", "Key"),
+    )
+    result = pl.process_compound("Water")
+    assert result["CID"] == "123"
+    assert result["Standard Name"] == "Water"
+    assert result["MolecularFormula"] == "H2O"


### PR DESCRIPTION
## Summary
- Improve PubChem `validate_cid` to treat empty identifiers as invalid
- Add unit tests for ChEMBL helper functions (chunking, single/bulk fetch, DataFrame merge)
- Add unit tests for PubChem utilities such as CID lookup and compound processing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae48c5a59c832485033c1a42ffa064