### PR TITLE
Fetch missing UniProt JSON automatically

### DIFF
--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -73,10 +73,12 @@ def validate_cid(cid: str) -> Optional[str]:
     Returns
     -------
     str or None
-        ``cid`` if valid, otherwise ``None`` when CID is ``"0"`` or
-        ``"-1"``.
+        ``cid`` if valid, otherwise ``None`` when the identifier is empty or
+        represents an invalid placeholder (``"0"`` or ``"-1"``).
     """
-    return None if cid in {"0", "-1"} else cid
+    if cid in {"", "0", "-1"}:
+        return None
+    return cid
 
 
 def _extract_cids(bindings: List[Dict[str, Any]]) -> List[str]:

--- a/library/uniprot_library.py
+++ b/library/uniprot_library.py
@@ -659,8 +659,18 @@ def collect_info(uid: str, data_dir: str = "uniprot") -> Dict[str, str]:
         with open(json_path, "r", encoding="utf-8") as handle:
             data = json.load(handle)
     except FileNotFoundError:
-        logger.warning("missing UniProt JSON for %s", uid)
-        return result
+        logger.info("downloading UniProt JSON for %s", uid)
+        data = fetch_uniprot(uid)
+        if not data:
+            logger.warning("failed to retrieve UniProt JSON for %s", uid)
+            return result
+        os.makedirs(data_dir, exist_ok=True)
+        try:
+            with open(json_path, "w", encoding="utf-8") as handle:
+                json.dump(data, handle)
+        except OSError as exc:  # pragma: no cover - disk I/O failure
+            logger.warning("unable to write UniProt JSON for %s: %s", uid, exc)
+            return result
     except json.JSONDecodeError:
         logger.warning("malformed UniProt JSON for %s", uid)
         return result

--- a/tests/test_chembl_library.py
+++ b/tests/test_chembl_library.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+import sys
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from library import chembl_library as cl
+from get_target_data import read_ids
+
+# Obtain a real ChEMBL ID from the provided targets.csv file
+DATA_DIR = Path(__file__).resolve().parents[1]
+SAMPLE_ID = read_ids(DATA_DIR / "targets.csv")[0]
+
+
+class FakeResponse:
+    def __init__(self, data):
+        self._data = data
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self):
+        return self._data
+
+
+SAMPLE_JSON = {
+    "pref_name": "MAP3K14",
+    "target_chembl_id": SAMPLE_ID,
+    "target_components": {
+        "target_component": {
+            "component_description": "Mitogen-activated protein kinase kinase kinase 14",
+            "component_id": 123,
+            "relationship": "single",
+            "target_component_synonyms": {
+                "target_component_synonym": [
+                    {"component_synonym": "MAP3K14", "syn_type": "GENE_SYMBOL"},
+                    {"component_synonym": "NIK", "syn_type": "GENE_SYMBOL_OTHER"},
+                    {"component_synonym": "2.7.11.25", "syn_type": "EC_NUMBER"},
+                    {
+                        "component_synonym": "Mitogen-activated protein kinase kinase kinase 14",
+                        "syn_type": "UNIPROT",
+                    },
+                ]
+            },
+            "target_component_xrefs": {
+                "target": [
+                    {"xref_src_db": "UniProt", "xref_id": "Q99558"},
+                    {
+                        "xref_src_db": "HGNC",
+                        "xref_id": "HGNC:6853",
+                        "xref_name": "MAP3K14",
+                    },
+                ]
+            },
+        }
+    },
+}
+
+
+SAMPLE_DF = pd.DataFrame(
+    {
+        "pref_name": ["MAP3K14"],
+        "target_chembl_id": [SAMPLE_ID],
+        "component_description": [
+            "Mitogen-activated protein kinase kinase kinase 14",
+        ],
+        "component_id": ["123"],
+        "relationship": ["single"],
+        "gene": ["MAP3K14"],
+        "uniprot_id": ["Q99558"],
+        "chembl_alternative_name": ["NIK"],
+        "ec_code": ["2.7.11.25"],
+        "hgnc_name": ["MAP3K14"],
+        "hgnc_id": ["6853"],
+    }
+)
+
+
+def test_chunked_splits_list() -> None:
+    assert list(cl._chunked([1, 2, 3, 4], 2)) == [[1, 2], [3, 4]]
+
+
+def test_chunked_invalid_size() -> None:
+    with pytest.raises(ValueError):
+        list(cl._chunked([1], 0))
+
+
+def test_get_target(monkeypatch) -> None:
+    monkeypatch.setattr(cl._session, "get", lambda url, timeout=30: FakeResponse(SAMPLE_JSON))
+    data = cl.get_target(SAMPLE_ID)
+    assert data["uniprot_id"] == "Q99558"
+    assert data["gene"] == "MAP3K14|NIK"
+
+
+def test_get_targets(monkeypatch) -> None:
+    bulk_json = {"targets": [SAMPLE_JSON]}
+    monkeypatch.setattr(cl._session, "get", lambda url, timeout=30: FakeResponse(bulk_json))
+    df = cl.get_targets([SAMPLE_ID])
+    assert df.loc[0, "uniprot_id"] == "Q99558"
+    assert df.shape[0] == 1
+
+
+def test_extend_target(monkeypatch) -> None:
+    monkeypatch.setattr(cl, "get_targets", lambda ids, chunk_size=50: SAMPLE_DF)
+    input_df = pd.DataFrame({"task_chembl_id": [SAMPLE_ID]})
+    out_df = cl.extend_target(input_df)
+    assert out_df.loc[0, "chembl_pref_name"] == "MAP3K14"
+    assert out_df.loc[0, "chembl_gene"] == "MAP3K14"

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from library import pubchem_library as pl
+
+
+def test_url_encode() -> None:
+    assert pl.url_encode("Caffeine 10%") == "Caffeine%2010%25"
+
+
+def test_validate_cid() -> None:
+    assert pl.validate_cid("") is None
+    assert pl.validate_cid("0") is None
+    assert pl.validate_cid("-1") is None
+    assert pl.validate_cid("123") == "123"
+
+
+def test_extract_cids() -> None:
+    bindings = [
+        {"cid": {"value": "123"}},
+        {"cid": "http://rdf.ncbi.nlm.nih.gov/pubchem/compound/CID456"},
+    ]
+    assert pl._extract_cids(bindings) == ["123", "456"]
+
+
+def test_get_cid(monkeypatch) -> None:
+    sample = {"results": {"bindings": [{"cid": {"value": "123"}}, {"cid": {"value": "123"}}, {"cid": {"value": "456"}}]}}
+    monkeypatch.setattr(pl, "make_request", lambda url, delay=3.0: sample)
+    assert pl.get_cid("water") == "123|456"
+
+
+def test_get_standard_name(monkeypatch) -> None:
+    sample = {"InformationList": {"Information": [{"Title": "Water"}]}}
+    monkeypatch.setattr(pl, "validate_cid", lambda cid: cid)
+    monkeypatch.setattr(pl, "make_request", lambda url, delay=3.0: sample)
+    assert pl.get_standard_name("123") == "Water"
+
+
+def test_get_properties(monkeypatch) -> None:
+    sample = {
+        "PropertyTable": {
+            "Properties": [
+                {
+                    "IUPACName": "Oxidane",
+                    "MolecularFormula": "H2O",
+                    "IsomericSMILES": "O",
+                    "CanonicalSMILES": "O",
+                    "InChI": "InChI=1S/H2O/h1H2",
+                    "InChIKey": "XLYOFNOQVPJJNP-UHFFFAOYSA-N",
+                }
+            ]
+        }
+    }
+    monkeypatch.setattr(pl, "validate_cid", lambda cid: cid)
+    monkeypatch.setattr(pl, "make_request", lambda url, delay=3.0: sample)
+    props = pl.get_properties("123")
+    assert props.MolecularFormula == "H2O"
+    assert props.IUPACName == "Oxidane"
+
+
+def test_process_compound(monkeypatch) -> None:
+    monkeypatch.setattr(pl, "get_cid", lambda name: "123")
+    monkeypatch.setattr(pl, "get_standard_name", lambda cid: "Water")
+    monkeypatch.setattr(
+        pl,
+        "get_properties",
+        lambda cid: pl.Properties("Oxidane", "H2O", "O", "O", "InChI", "Key"),
+    )
+    result = pl.process_compound("Water")
+    assert result["CID"] == "123"
+    assert result["Standard Name"] == "Water"
+    assert result["MolecularFormula"] == "H2O"

--- a/tests/test_uniprot_library.py
+++ b/tests/test_uniprot_library.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import sys
+import json
 import pandas as pd
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -20,6 +21,21 @@ def test_collect_info_real_json() -> None:
     assert info["uniprot_id"] == "Q99558"
     assert "MAP3K14" in info["names"]
     assert info["genus"] == "Homo"
+
+
+def test_collect_info_downloads_missing(tmp_path: Path, monkeypatch) -> None:
+    uid = "Q99558"
+    sample = json.loads((DATA_DIR / f"{uid}.json").read_text(encoding="utf8"))
+
+    def fake_fetch(uniprot_id: str) -> dict:
+        assert uniprot_id == uid
+        return sample
+
+    monkeypatch.setattr(uu, "fetch_uniprot", fake_fetch)
+    data_dir = tmp_path / "uniprot"
+    info = uu.collect_info(uid, data_dir=str(data_dir))
+    assert info["uniprot_id"] == uid
+    assert (data_dir / f"{uid}.json").exists()
 
 
 def test_process_writes_expected(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Download UniProt JSON records on demand when not found locally, saving them under the specified data directory
- Add unit test to ensure missing records are fetched and cached

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae48c5a59c832485033c1a42ffa064