### PR TITLE
Normalize IUPHAR target column names and add local UniProt fixture

### DIFF
--- a/data/uniprot/Q99558.json
+++ b/data/uniprot/Q99558.json
@@ -1,0 +1,4701 @@
+{
+  "entryType": "UniProtKB reviewed (Swiss-Prot)",
+  "primaryAccession": "Q99558",
+  "secondaryAccessions": [
+    "A8K2D8",
+    "D3DX67",
+    "Q8IYN1"
+  ],
+  "uniProtkbId": "M3K14_HUMAN",
+  "entryAudit": {
+    "firstPublicDate": "2001-06-01",
+    "lastAnnotationUpdateDate": "2025-06-18",
+    "lastSequenceUpdateDate": "2006-04-04",
+    "entryVersion": 225,
+    "sequenceVersion": 2
+  },
+  "annotationScore": 5.0,
+  "organism": {
+    "scientificName": "Homo sapiens",
+    "commonName": "Human",
+    "taxonId": 9606,
+    "lineage": [
+      "Eukaryota",
+      "Metazoa",
+      "Chordata",
+      "Craniata",
+      "Vertebrata",
+      "Euteleostomi",
+      "Mammalia",
+      "Eutheria",
+      "Euarchontoglires",
+      "Primates",
+      "Haplorrhini",
+      "Catarrhini",
+      "Hominidae",
+      "Homo"
+    ]
+  },
+  "proteinExistence": "1: Evidence at protein level",
+  "proteinDescription": {
+    "recommendedName": {
+      "fullName": {
+        "evidences": [
+          {
+            "evidenceCode": "ECO:0000312",
+            "source": "HGNC",
+            "id": "HGNC:6853"
+          }
+        ],
+        "value": "Mitogen-activated protein kinase kinase kinase 14"
+      },
+      "ecNumbers": [
+        {
+          "value": "2.7.11.25"
+        }
+      ]
+    },
+    "alternativeNames": [
+      {
+        "fullName": {
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000303",
+              "source": "PubMed",
+              "id": "12853971"
+            }
+          ],
+          "value": "NF-kappa-beta-inducing kinase"
+        },
+        "shortNames": [
+          {
+            "evidences": [
+              {
+                "evidenceCode": "ECO:0000312",
+                "source": "HGNC",
+                "id": "HGNC:6853"
+              }
+            ],
+            "value": "HsNIK"
+          }
+        ]
+      },
+      {
+        "fullName": {
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000303",
+              "source": "PubMed",
+              "id": "15951441"
+            }
+          ],
+          "value": "Serine/threonine-protein kinase NIK"
+        }
+      }
+    ]
+  },
+  "genes": [
+    {
+      "geneName": {
+        "evidences": [
+          {
+            "evidenceCode": "ECO:0000312",
+            "source": "HGNC",
+            "id": "HGNC:6853"
+          }
+        ],
+        "value": "MAP3K14"
+      },
+      "synonyms": [
+        {
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000303",
+              "source": "PubMed",
+              "id": "12853971"
+            }
+          ],
+          "value": "NIK"
+        }
+      ]
+    }
+  ],
+  "comments": [
+    {
+      "texts": [
+        {
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000269",
+              "source": "PubMed",
+              "id": "15084608"
+            },
+            {
+              "evidenceCode": "ECO:0000269",
+              "source": "PubMed",
+              "id": "25406581"
+            }
+          ],
+          "value": "Lymphotoxin beta-activated kinase which seems to be exclusively involved in the activation of NF-kappa-B and its transcriptional activity. Phosphorylates CHUK/IKKA, thereby promoting proteolytic processing of NFKB2/P100, which leads to NF-kappa-B activation via the non-canonical pathway (PubMed:25406581, PubMed:29230214). Has an essential role in the non-canonical NF-kappa-B signaling that regulates genes encoding molecules involved in B-cell survival, lymphoid organogenesis, and immune response (PubMed:25406581). Could act in a receptor-selective manner"
+        }
+      ],
+      "commentType": "FUNCTION"
+    },
+    {
+      "commentType": "CATALYTIC ACTIVITY",
+      "reaction": {
+        "name": "L-seryl-[protein] + ATP = O-phospho-L-seryl-[protein] + ADP + H(+)",
+        "reactionCrossReferences": [
+          {
+            "database": "Rhea",
+            "id": "RHEA:17989"
+          },
+          {
+            "database": "Rhea",
+            "id": "RHEA-COMP:9863"
+          },
+          {
+            "database": "Rhea",
+            "id": "RHEA-COMP:11604"
+          },
+          {
+            "database": "ChEBI",
+            "id": "CHEBI:15378"
+          },
+          {
+            "database": "ChEBI",
+            "id": "CHEBI:29999"
+          },
+          {
+            "database": "ChEBI",
+            "id": "CHEBI:30616"
+          },
+          {
+            "database": "ChEBI",
+            "id": "CHEBI:83421"
+          },
+          {
+            "database": "ChEBI",
+            "id": "CHEBI:456216"
+          }
+        ],
+        "ecNumber": "2.7.11.25"
+      }
+    },
+    {
+      "commentType": "CATALYTIC ACTIVITY",
+      "reaction": {
+        "name": "L-threonyl-[protein] + ATP = O-phospho-L-threonyl-[protein] + ADP + H(+)",
+        "reactionCrossReferences": [
+          {
+            "database": "Rhea",
+            "id": "RHEA:46608"
+          },
+          {
+            "database": "Rhea",
+            "id": "RHEA-COMP:11060"
+          },
+          {
+            "database": "Rhea",
+            "id": "RHEA-COMP:11605"
+          },
+          {
+            "database": "ChEBI",
+            "id": "CHEBI:15378"
+          },
+          {
+            "database": "ChEBI",
+            "id": "CHEBI:30013"
+          },
+          {
+            "database": "ChEBI",
+            "id": "CHEBI:30616"
+          },
+          {
+            "database": "ChEBI",
+            "id": "CHEBI:61977"
+          },
+          {
+            "database": "ChEBI",
+            "id": "CHEBI:456216"
+          }
+        ],
+        "ecNumber": "2.7.11.25"
+      }
+    },
+    {
+      "texts": [
+        {
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000250"
+            },
+            {
+              "evidenceCode": "ECO:0000250",
+              "source": "UniProtKB",
+              "id": "Q9WUL6"
+            },
+            {
+              "evidenceCode": "ECO:0000269",
+              "source": "PubMed",
+              "id": "12853971"
+            },
+            {
+              "evidenceCode": "ECO:0000269",
+              "source": "PubMed",
+              "id": "12874243"
+            },
+            {
+              "evidenceCode": "ECO:0000269",
+              "source": "PubMed",
+              "id": "15084608"
+            },
+            {
+              "evidenceCode": "ECO:0000269",
+              "source": "PubMed",
+              "id": "15173580"
+            },
+            {
+              "evidenceCode": "ECO:0000269",
+              "source": "PubMed",
+              "id": "15951441"
+            },
+            {
+              "evidenceCode": "ECO:0000269",
+              "source": "PubMed",
+              "id": "17237370"
+            },
+            {
+              "evidenceCode": "ECO:0000269",
+              "source": "PubMed",
+              "id": "20682767"
+            },
+            {
+              "evidenceCode": "ECO:0000269",
+              "source": "PubMed",
+              "id": "30341167"
+            }
+          ],
+          "value": "Interacts with TRAF2, TRAF5, TRAF6, IKKA and NFKB2/P100 (By similarity). Interacts with TRAF3 and PELI3. Interacts with NIBP; the interaction is direct. Interacts with ARRB1 and ARRB2. Interacts with GRB10. Interacts with ZFP91. Interacts with NLRP12; this interaction promotes proteasomal degradation of MAP3K14. Directly interacts with DDX3X (PubMed:30341167). Interacts (via C-terminus and kinase domain) with PPPC3A (via N-terminus) and PPP3CB (By similarity)"
+        }
+      ],
+      "commentType": "SUBUNIT"
+    },
+    {
+      "commentType": "INTERACTION",
+      "interactions": [
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "Q16543",
+            "geneName": "CDC37",
+            "intActId": "EBI-295634"
+          },
+          "numberOfExperiments": 6,
+          "organismDiffer": false
+        },
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "O15111",
+            "geneName": "CHUK",
+            "intActId": "EBI-81249"
+          },
+          "numberOfExperiments": 13,
+          "organismDiffer": false
+        },
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "P01112",
+            "geneName": "HRAS",
+            "intActId": "EBI-350145"
+          },
+          "numberOfExperiments": 3,
+          "organismDiffer": false
+        },
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "P07900",
+            "geneName": "HSP90AA1",
+            "intActId": "EBI-296047"
+          },
+          "numberOfExperiments": 5,
+          "organismDiffer": false
+        },
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "P08238",
+            "geneName": "HSP90AB1",
+            "intActId": "EBI-352572"
+          },
+          "numberOfExperiments": 5,
+          "organismDiffer": false
+        },
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "O14920",
+            "geneName": "IKBKB",
+            "intActId": "EBI-81266"
+          },
+          "numberOfExperiments": 7,
+          "organismDiffer": false
+        },
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "Q9Y6K9",
+            "geneName": "IKBKG",
+            "intActId": "EBI-81279"
+          },
+          "numberOfExperiments": 5,
+          "organismDiffer": false
+        },
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "Q14974",
+            "geneName": "KPNB1",
+            "intActId": "EBI-286758"
+          },
+          "numberOfExperiments": 2,
+          "organismDiffer": false
+        },
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "P36578",
+            "geneName": "RPL4",
+            "intActId": "EBI-348313"
+          },
+          "numberOfExperiments": 3,
+          "organismDiffer": false
+        },
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "Q02878",
+            "geneName": "RPL6",
+            "intActId": "EBI-359655"
+          },
+          "numberOfExperiments": 3,
+          "organismDiffer": false
+        },
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "P62917",
+            "geneName": "RPL8",
+            "intActId": "EBI-438527"
+          },
+          "numberOfExperiments": 3,
+          "organismDiffer": false
+        },
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "P62280",
+            "geneName": "RPS11",
+            "intActId": "EBI-1047710"
+          },
+          "numberOfExperiments": 3,
+          "organismDiffer": false
+        },
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "P62277",
+            "geneName": "RPS13",
+            "intActId": "EBI-351850"
+          },
+          "numberOfExperiments": 3,
+          "organismDiffer": false
+        },
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "Q12933",
+            "geneName": "TRAF2",
+            "intActId": "EBI-355744"
+          },
+          "numberOfExperiments": 9,
+          "organismDiffer": false
+        },
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "Q13114",
+            "geneName": "TRAF3",
+            "intActId": "EBI-357631"
+          },
+          "numberOfExperiments": 9,
+          "organismDiffer": false
+        },
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "P62258",
+            "geneName": "YWHAE",
+            "intActId": "EBI-356498"
+          },
+          "numberOfExperiments": 2,
+          "organismDiffer": false
+        },
+        {
+          "interactantOne": {
+            "uniProtKBAccession": "Q99558",
+            "intActId": "EBI-358011"
+          },
+          "interactantTwo": {
+            "uniProtKBAccession": "Q60680-2",
+            "geneName": "Chuk",
+            "intActId": "EBI-646264"
+          },
+          "numberOfExperiments": 3,
+          "organismDiffer": true
+        }
+      ]
+    },
+    {
+      "commentType": "SUBCELLULAR LOCATION",
+      "subcellularLocations": [
+        {
+          "location": {
+            "value": "Cytoplasm",
+            "id": "SL-0086"
+          }
+        }
+      ]
+    },
+    {
+      "texts": [
+        {
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000269",
+              "source": "PubMed",
+              "id": "9020361"
+            }
+          ],
+          "value": "Weakly expressed in testis, small intestine, spleen, thymus, peripheral blood leukocytes, prostate, ovary and colon"
+        }
+      ],
+      "commentType": "TISSUE SPECIFICITY"
+    },
+    {
+      "texts": [
+        {
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000269",
+              "source": "PubMed",
+              "id": "20501937"
+            },
+            {
+              "evidenceCode": "ECO:0000269",
+              "source": "PubMed",
+              "id": "20682767"
+            }
+          ],
+          "value": "Autophosphorylated. Phosphorylation at Thr-559 is required to activate its kinase activity and 'Lys-63'-linked polyubiquitination. Phosphorylated by CHUK/IKKA leading to MAP3K14 destabilization"
+        }
+      ],
+      "commentType": "PTM"
+    },
+    {
+      "texts": [
+        {
+          "value": "Ubiquitinated. Undergoes both 'Lys-48'- and 'Lys-63'-linked polyubiquitination. 'Lys-48'-linked polyubiquitination leads to its degradation by the proteasome, while 'Lys-63'-linked polyubiquitination stabilizes and activates it"
+        }
+      ],
+      "commentType": "PTM"
+    },
+    {
+      "commentType": "DISEASE",
+      "disease": {
+        "diseaseId": "Immunodeficiency 112",
+        "diseaseAccession": "DI-06724",
+        "acronym": "IMD112",
+        "description": "An autosomal recessive, primary immunologic disorder characterized by variable abnormalities affecting lymphoid immunity, including hypogammaglobulinemia, lymphopenia or paradoxical lymphocytosis, and recurrent bacterial, viral, and fungal infections.",
+        "diseaseCrossReference": {
+          "database": "MIM",
+          "id": "620449"
+        },
+        "evidences": [
+          {
+            "evidenceCode": "ECO:0000269",
+            "source": "PubMed",
+            "id": "25406581"
+          },
+          {
+            "evidenceCode": "ECO:0000269",
+            "source": "PubMed",
+            "id": "29230214"
+          }
+        ]
+      },
+      "note": {
+        "texts": [
+          {
+            "value": "The disease is caused by variants affecting the gene represented in this entry"
+          }
+        ]
+      }
+    },
+    {
+      "texts": [
+        {
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000305"
+            }
+          ],
+          "value": "Belongs to the protein kinase superfamily. STE Ser/Thr protein kinase family. MAP kinase kinase kinase subfamily"
+        }
+      ],
+      "commentType": "SIMILARITY"
+    }
+  ],
+  "features": [
+    {
+      "type": "Chain",
+      "location": {
+        "start": {
+          "value": 1,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 947,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "Mitogen-activated protein kinase kinase kinase 14",
+      "featureId": "PRO_0000086266"
+    },
+    {
+      "type": "Domain",
+      "location": {
+        "start": {
+          "value": 400,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 655,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "Protein kinase",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000255",
+          "source": "PROSITE-ProRule",
+          "id": "PRU00159"
+        }
+      ]
+    },
+    {
+      "type": "Region",
+      "location": {
+        "start": {
+          "value": 1,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 37,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "Disordered",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000256",
+          "source": "SAM",
+          "id": "MobiDB-lite"
+        }
+      ]
+    },
+    {
+      "type": "Region",
+      "location": {
+        "start": {
+          "value": 135,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 171,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "Disordered",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000256",
+          "source": "SAM",
+          "id": "MobiDB-lite"
+        }
+      ]
+    },
+    {
+      "type": "Region",
+      "location": {
+        "start": {
+          "value": 401,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 653,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "Interaction with ZFP91",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000269",
+          "source": "PubMed",
+          "id": "20682767"
+        }
+      ]
+    },
+    {
+      "type": "Region",
+      "location": {
+        "start": {
+          "value": 662,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 766,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "Disordered",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000256",
+          "source": "SAM",
+          "id": "MobiDB-lite"
+        }
+      ]
+    },
+    {
+      "type": "Region",
+      "location": {
+        "start": {
+          "value": 805,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 830,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "Disordered",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000256",
+          "source": "SAM",
+          "id": "MobiDB-lite"
+        }
+      ]
+    },
+    {
+      "type": "Compositional bias",
+      "location": {
+        "start": {
+          "value": 135,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 151,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "Basic residues",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000256",
+          "source": "SAM",
+          "id": "MobiDB-lite"
+        }
+      ]
+    },
+    {
+      "type": "Compositional bias",
+      "location": {
+        "start": {
+          "value": 665,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 674,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "Basic and acidic residues",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000256",
+          "source": "SAM",
+          "id": "MobiDB-lite"
+        }
+      ]
+    },
+    {
+      "type": "Compositional bias",
+      "location": {
+        "start": {
+          "value": 713,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 727,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "Pro residues",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000256",
+          "source": "SAM",
+          "id": "MobiDB-lite"
+        }
+      ]
+    },
+    {
+      "type": "Compositional bias",
+      "location": {
+        "start": {
+          "value": 741,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 752,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "Low complexity",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000256",
+          "source": "SAM",
+          "id": "MobiDB-lite"
+        }
+      ]
+    },
+    {
+      "type": "Compositional bias",
+      "location": {
+        "start": {
+          "value": 814,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 829,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "Polar residues",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000256",
+          "source": "SAM",
+          "id": "MobiDB-lite"
+        }
+      ]
+    },
+    {
+      "type": "Active site",
+      "location": {
+        "start": {
+          "value": 515,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 515,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "Proton acceptor",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000255",
+          "source": "PROSITE-ProRule",
+          "id": "PRU00159"
+        },
+        {
+          "evidenceCode": "ECO:0000255",
+          "source": "PROSITE-ProRule",
+          "id": "PRU10027"
+        }
+      ]
+    },
+    {
+      "type": "Binding site",
+      "location": {
+        "start": {
+          "value": 406,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 414,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "featureCrossReferences": [
+        {
+          "database": "ChEBI",
+          "id": "CHEBI:30616"
+        }
+      ],
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000255",
+          "source": "PROSITE-ProRule",
+          "id": "PRU00159"
+        }
+      ],
+      "ligand": {
+        "name": "ATP",
+        "id": "ChEBI:CHEBI:30616"
+      }
+    },
+    {
+      "type": "Binding site",
+      "location": {
+        "start": {
+          "value": 429,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 429,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "featureCrossReferences": [
+        {
+          "database": "ChEBI",
+          "id": "CHEBI:30616"
+        }
+      ],
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000255",
+          "source": "PROSITE-ProRule",
+          "id": "PRU00159"
+        }
+      ],
+      "ligand": {
+        "name": "ATP",
+        "id": "ChEBI:CHEBI:30616"
+      }
+    },
+    {
+      "type": "Modified residue",
+      "location": {
+        "start": {
+          "value": 559,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 559,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "Phosphothreonine",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000269",
+          "source": "PubMed",
+          "id": "20682767"
+        }
+      ]
+    },
+    {
+      "type": "Natural variant",
+      "location": {
+        "start": {
+          "value": 140,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 140,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "in dbSNP:rs11574819",
+      "featureCrossReferences": [
+        {
+          "database": "dbSNP",
+          "id": "rs11574819"
+        }
+      ],
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000269",
+          "source": "PubMed",
+          "id": "17344846"
+        }
+      ],
+      "featureId": "VAR_040711",
+      "alternativeSequence": {
+        "originalSequence": "S",
+        "alternativeSequences": [
+          "N"
+        ]
+      }
+    },
+    {
+      "type": "Natural variant",
+      "location": {
+        "start": {
+          "value": 255,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 255,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "in dbSNP:rs11574820",
+      "featureCrossReferences": [
+        {
+          "database": "dbSNP",
+          "id": "rs11574820"
+        }
+      ],
+      "featureId": "VAR_051641",
+      "alternativeSequence": {
+        "originalSequence": "T",
+        "alternativeSequences": [
+          "M"
+        ]
+      }
+    },
+    {
+      "type": "Natural variant",
+      "location": {
+        "start": {
+          "value": 345,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 345,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "in IMD112; uncertain significance; decreased phosphorylation of CHUK/IKKA",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000269",
+          "source": "PubMed",
+          "id": "29230214"
+        }
+      ],
+      "featureId": "VAR_088815",
+      "alternativeSequence": {
+        "originalSequence": "V",
+        "alternativeSequences": [
+          "M"
+        ]
+      }
+    },
+    {
+      "type": "Natural variant",
+      "location": {
+        "start": {
+          "value": 514,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 514,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "in a lung neuroendocrine carcinoma sample; somatic mutation; requires 2 nucleotide substitutions",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000269",
+          "source": "PubMed",
+          "id": "17344846"
+        }
+      ],
+      "featureId": "VAR_040712",
+      "alternativeSequence": {
+        "originalSequence": "G",
+        "alternativeSequences": [
+          "K"
+        ]
+      }
+    },
+    {
+      "type": "Natural variant",
+      "location": {
+        "start": {
+          "value": 565,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 565,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "in IMD112; likely pathogenic; loss of function in non-canonical NF-kappaB signal transduction; unable to phosphorylate CHUK/IKKA",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000269",
+          "source": "PubMed",
+          "id": "25406581"
+        }
+      ],
+      "featureId": "VAR_088816",
+      "alternativeSequence": {
+        "originalSequence": "P",
+        "alternativeSequences": [
+          "R"
+        ]
+      }
+    },
+    {
+      "type": "Natural variant",
+      "location": {
+        "start": {
+          "value": 674,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 674,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "in dbSNP:rs11867907",
+      "featureCrossReferences": [
+        {
+          "database": "dbSNP",
+          "id": "rs11867907"
+        }
+      ],
+      "featureId": "VAR_051642",
+      "alternativeSequence": {
+        "originalSequence": "H",
+        "alternativeSequences": [
+          "Y"
+        ]
+      }
+    },
+    {
+      "type": "Natural variant",
+      "location": {
+        "start": {
+          "value": 764,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 764,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "in dbSNP:rs56302559",
+      "featureCrossReferences": [
+        {
+          "database": "dbSNP",
+          "id": "rs56302559"
+        }
+      ],
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000269",
+          "source": "PubMed",
+          "id": "17344846"
+        }
+      ],
+      "featureId": "VAR_040713",
+      "alternativeSequence": {
+        "originalSequence": "T",
+        "alternativeSequences": [
+          "A"
+        ]
+      }
+    },
+    {
+      "type": "Natural variant",
+      "location": {
+        "start": {
+          "value": 852,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 852,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "in an ovarian mucinous carcinoma sample; somatic mutation",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000269",
+          "source": "PubMed",
+          "id": "17344846"
+        }
+      ],
+      "featureId": "VAR_040714",
+      "alternativeSequence": {
+        "originalSequence": "T",
+        "alternativeSequences": [
+          "I"
+        ]
+      }
+    },
+    {
+      "type": "Natural variant",
+      "location": {
+        "start": {
+          "value": 928,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 928,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "in dbSNP:rs56036201",
+      "featureCrossReferences": [
+        {
+          "database": "dbSNP",
+          "id": "rs56036201"
+        }
+      ],
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000269",
+          "source": "PubMed",
+          "id": "17344846"
+        }
+      ],
+      "featureId": "VAR_040715",
+      "alternativeSequence": {
+        "originalSequence": "P",
+        "alternativeSequences": [
+          "H"
+        ]
+      }
+    },
+    {
+      "type": "Mutagenesis",
+      "location": {
+        "start": {
+          "value": 429,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 430,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "Loss of autophosphorylation and 'Lys-63'-linked ubiquitination. Unable to phosphorylate CHUK/IKKA.",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000269",
+          "source": "PubMed",
+          "id": "20682767"
+        },
+        {
+          "evidenceCode": "ECO:0000269",
+          "source": "PubMed",
+          "id": "25406581"
+        },
+        {
+          "evidenceCode": "ECO:0000269",
+          "source": "PubMed",
+          "id": "9020361"
+        }
+      ],
+      "alternativeSequence": {
+        "originalSequence": "KK",
+        "alternativeSequences": [
+          "AA"
+        ]
+      }
+    },
+    {
+      "type": "Mutagenesis",
+      "location": {
+        "start": {
+          "value": 559,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 559,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "Abolishes 'Lys-63'-linked ubiquitination.",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000269",
+          "source": "PubMed",
+          "id": "20682767"
+        }
+      ],
+      "alternativeSequence": {
+        "originalSequence": "T",
+        "alternativeSequences": [
+          "A"
+        ]
+      }
+    },
+    {
+      "type": "Sequence conflict",
+      "location": {
+        "start": {
+          "value": 25,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 25,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "in Ref. 1; CAA71306",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000305"
+        }
+      ],
+      "alternativeSequence": {
+        "originalSequence": "A",
+        "alternativeSequences": [
+          "P"
+        ]
+      }
+    },
+    {
+      "type": "Sequence conflict",
+      "location": {
+        "start": {
+          "value": 348,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 348,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "in Ref. 1; CAA71306",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000305"
+        }
+      ],
+      "alternativeSequence": {
+        "originalSequence": "G",
+        "alternativeSequences": [
+          "S"
+        ]
+      }
+    },
+    {
+      "type": "Sequence conflict",
+      "location": {
+        "start": {
+          "value": 880,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 880,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "in Ref. 2; BAF82892",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000305"
+        }
+      ],
+      "alternativeSequence": {
+        "originalSequence": "R",
+        "alternativeSequences": [
+          "G"
+        ]
+      }
+    },
+    {
+      "type": "Helix",
+      "location": {
+        "start": {
+          "value": 335,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 341,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Beta strand",
+      "location": {
+        "start": {
+          "value": 345,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 347,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Helix",
+      "location": {
+        "start": {
+          "value": 350,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 363,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Beta strand",
+      "location": {
+        "start": {
+          "value": 364,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 366,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Beta strand",
+      "location": {
+        "start": {
+          "value": 377,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 381,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Turn",
+      "location": {
+        "start": {
+          "value": 395,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 397,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Beta strand",
+      "location": {
+        "start": {
+          "value": 398,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 408,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Beta strand",
+      "location": {
+        "start": {
+          "value": 410,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 419,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Turn",
+      "location": {
+        "start": {
+          "value": 420,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 422,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Beta strand",
+      "location": {
+        "start": {
+          "value": 425,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 432,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Helix",
+      "location": {
+        "start": {
+          "value": 433,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 435,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Helix",
+      "location": {
+        "start": {
+          "value": 439,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 442,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Turn",
+      "location": {
+        "start": {
+          "value": 443,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 446,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Beta strand",
+      "location": {
+        "start": {
+          "value": 455,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 461,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Beta strand",
+      "location": {
+        "start": {
+          "value": 464,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 469,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Helix",
+      "location": {
+        "start": {
+          "value": 477,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 484,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Helix",
+      "location": {
+        "start": {
+          "value": 489,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 507,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Turn",
+      "location": {
+        "start": {
+          "value": 508,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 510,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Helix",
+      "location": {
+        "start": {
+          "value": 518,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 520,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Beta strand",
+      "location": {
+        "start": {
+          "value": 521,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 523,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Beta strand",
+      "location": {
+        "start": {
+          "value": 530,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 532,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Helix",
+      "location": {
+        "start": {
+          "value": 535,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 537,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDV"
+        }
+      ]
+    },
+    {
+      "type": "Beta strand",
+      "location": {
+        "start": {
+          "value": 543,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 547,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4G3D"
+        }
+      ]
+    },
+    {
+      "type": "Turn",
+      "location": {
+        "start": {
+          "value": 550,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 553,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4G3D"
+        }
+      ]
+    },
+    {
+      "type": "Helix",
+      "location": {
+        "start": {
+          "value": 560,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 562,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Helix",
+      "location": {
+        "start": {
+          "value": 565,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 568,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Helix",
+      "location": {
+        "start": {
+          "value": 576,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 591,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Turn",
+      "location": {
+        "start": {
+          "value": 595,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 599,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Helix",
+      "location": {
+        "start": {
+          "value": 605,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 610,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Helix",
+      "location": {
+        "start": {
+          "value": 614,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 617,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Helix",
+      "location": {
+        "start": {
+          "value": 624,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 633,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Turn",
+      "location": {
+        "start": {
+          "value": 638,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 640,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    },
+    {
+      "type": "Helix",
+      "location": {
+        "start": {
+          "value": 644,
+          "modifier": "EXACT"
+        },
+        "end": {
+          "value": 658,
+          "modifier": "EXACT"
+        }
+      },
+      "description": "",
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0007829",
+          "source": "PDB",
+          "id": "4IDT"
+        }
+      ]
+    }
+  ],
+  "keywords": [
+    {
+      "id": "KW-0002",
+      "category": "Technical term",
+      "name": "3D-structure"
+    },
+    {
+      "id": "KW-0067",
+      "category": "Ligand",
+      "name": "ATP-binding"
+    },
+    {
+      "id": "KW-0963",
+      "category": "Cellular component",
+      "name": "Cytoplasm"
+    },
+    {
+      "id": "KW-0225",
+      "category": "Disease",
+      "name": "Disease variant"
+    },
+    {
+      "id": "KW-0418",
+      "category": "Molecular function",
+      "name": "Kinase"
+    },
+    {
+      "id": "KW-0547",
+      "category": "Ligand",
+      "name": "Nucleotide-binding"
+    },
+    {
+      "id": "KW-0597",
+      "category": "PTM",
+      "name": "Phosphoprotein"
+    },
+    {
+      "id": "KW-1267",
+      "category": "Technical term",
+      "name": "Proteomics identification"
+    },
+    {
+      "id": "KW-1185",
+      "category": "Technical term",
+      "name": "Reference proteome"
+    },
+    {
+      "id": "KW-0723",
+      "category": "Molecular function",
+      "name": "Serine/threonine-protein kinase"
+    },
+    {
+      "id": "KW-0808",
+      "category": "Molecular function",
+      "name": "Transferase"
+    },
+    {
+      "id": "KW-0832",
+      "category": "PTM",
+      "name": "Ubl conjugation"
+    }
+  ],
+  "references": [
+    {
+      "referenceNumber": 1,
+      "citation": {
+        "id": "9020361",
+        "citationType": "journal article",
+        "authors": [
+          "Malinin N.L.",
+          "Boldin M.P.",
+          "Kovalenko A.V.",
+          "Wallach D."
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "9020361"
+          },
+          {
+            "database": "DOI",
+            "id": "10.1038/385540a0"
+          }
+        ],
+        "title": "MAP3K-related kinase involved in NF-kappaB induction by TNF, CD95 and IL-1.",
+        "publicationDate": "1997",
+        "journal": "Nature",
+        "firstPage": "540",
+        "lastPage": "544",
+        "volume": "385"
+      },
+      "referencePositions": [
+        "NUCLEOTIDE SEQUENCE [MRNA]",
+        "MUTAGENESIS OF 429-LYS-LYS-430",
+        "TISSUE SPECIFICITY"
+      ]
+    },
+    {
+      "referenceNumber": 2,
+      "citation": {
+        "id": "14702039",
+        "citationType": "journal article",
+        "authors": [
+          "Ota T.",
+          "Suzuki Y.",
+          "Nishikawa T.",
+          "Otsuki T.",
+          "Sugiyama T.",
+          "Irie R.",
+          "Wakamatsu A.",
+          "Hayashi K.",
+          "Sato H.",
+          "Nagai K.",
+          "Kimura K.",
+          "Makita H.",
+          "Sekine M.",
+          "Obayashi M.",
+          "Nishi T.",
+          "Shibahara T.",
+          "Tanaka T.",
+          "Ishii S.",
+          "Yamamoto J.",
+          "Saito K.",
+          "Kawai Y.",
+          "Isono Y.",
+          "Nakamura Y.",
+          "Nagahari K.",
+          "Murakami K.",
+          "Yasuda T.",
+          "Iwayanagi T.",
+          "Wagatsuma M.",
+          "Shiratori A.",
+          "Sudo H.",
+          "Hosoiri T.",
+          "Kaku Y.",
+          "Kodaira H.",
+          "Kondo H.",
+          "Sugawara M.",
+          "Takahashi M.",
+          "Kanda K.",
+          "Yokoi T.",
+          "Furuya T.",
+          "Kikkawa E.",
+          "Omura Y.",
+          "Abe K.",
+          "Kamihara K.",
+          "Katsuta N.",
+          "Sato K.",
+          "Tanikawa M.",
+          "Yamazaki M.",
+          "Ninomiya K.",
+          "Ishibashi T.",
+          "Yamashita H.",
+          "Murakawa K.",
+          "Fujimori K.",
+          "Tanai H.",
+          "Kimata M.",
+          "Watanabe M.",
+          "Hiraoka S.",
+          "Chiba Y.",
+          "Ishida S.",
+          "Ono Y.",
+          "Takiguchi S.",
+          "Watanabe S.",
+          "Yosida M.",
+          "Hotuta T.",
+          "Kusano J.",
+          "Kanehori K.",
+          "Takahashi-Fujii A.",
+          "Hara H.",
+          "Tanase T.-O.",
+          "Nomura Y.",
+          "Togiya S.",
+          "Komai F.",
+          "Hara R.",
+          "Takeuchi K.",
+          "Arita M.",
+          "Imose N.",
+          "Musashino K.",
+          "Yuuki H.",
+          "Oshima A.",
+          "Sasaki N.",
+          "Aotsuka S.",
+          "Yoshikawa Y.",
+          "Matsunawa H.",
+          "Ichihara T.",
+          "Shiohata N.",
+          "Sano S.",
+          "Moriya S.",
+          "Momiyama H.",
+          "Satoh N.",
+          "Takami S.",
+          "Terashima Y.",
+          "Suzuki O.",
+          "Nakagawa S.",
+          "Senoh A.",
+          "Mizoguchi H.",
+          "Goto Y.",
+          "Shimizu F.",
+          "Wakebe H.",
+          "Hishigaki H.",
+          "Watanabe T.",
+          "Sugiyama A.",
+          "Takemoto M.",
+          "Kawakami B.",
+          "Yamazaki M.",
+          "Watanabe K.",
+          "Kumagai A.",
+          "Itakura S.",
+          "Fukuzumi Y.",
+          "Fujimori Y.",
+          "Komiyama M.",
+          "Tashiro H.",
+          "Tanigami A.",
+          "Fujiwara T.",
+          "Ono T.",
+          "Yamada K.",
+          "Fujii Y.",
+          "Ozaki K.",
+          "Hirao M.",
+          "Ohmori Y.",
+          "Kawabata A.",
+          "Hikiji T.",
+          "Kobatake N.",
+          "Inagaki H.",
+          "Ikema Y.",
+          "Okamoto S.",
+          "Okitani R.",
+          "Kawakami T.",
+          "Noguchi S.",
+          "Itoh T.",
+          "Shigeta K.",
+          "Senba T.",
+          "Matsumura K.",
+          "Nakajima Y.",
+          "Mizuno T.",
+          "Morinaga M.",
+          "Sasaki M.",
+          "Togashi T.",
+          "Oyama M.",
+          "Hata H.",
+          "Watanabe M.",
+          "Komatsu T.",
+          "Mizushima-Sugano J.",
+          "Satoh T.",
+          "Shirai Y.",
+          "Takahashi Y.",
+          "Nakagawa K.",
+          "Okumura K.",
+          "Nagase T.",
+          "Nomura N.",
+          "Kikuchi H.",
+          "Masuho Y.",
+          "Yamashita R.",
+          "Nakai K.",
+          "Yada T.",
+          "Nakamura Y.",
+          "Ohara O.",
+          "Isogai T.",
+          "Sugano S."
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "14702039"
+          },
+          {
+            "database": "DOI",
+            "id": "10.1038/ng1285"
+          }
+        ],
+        "title": "Complete sequencing and characterization of 21,243 full-length human cDNAs.",
+        "publicationDate": "2004",
+        "journal": "Nat. Genet.",
+        "firstPage": "40",
+        "lastPage": "45",
+        "volume": "36"
+      },
+      "referencePositions": [
+        "NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA]"
+      ],
+      "referenceComments": [
+        {
+          "value": "Thalamus",
+          "type": "TISSUE"
+        }
+      ]
+    },
+    {
+      "referenceNumber": 3,
+      "citation": {
+        "id": "CI-APNV2K4FQRL2N",
+        "citationType": "submission",
+        "authoringGroup": [
+          "NHLBI resequencing and genotyping service (RS&G)"
+        ],
+        "publicationDate": "DEC-2005",
+        "submissionDatabase": "EMBL/GenBank/DDBJ databases"
+      },
+      "referencePositions": [
+        "NUCLEOTIDE SEQUENCE [GENOMIC DNA]"
+      ]
+    },
+    {
+      "referenceNumber": 4,
+      "citation": {
+        "id": "CI-5GBD0VIIJ7C63",
+        "citationType": "submission",
+        "authors": [
+          "Mural R.J.",
+          "Istrail S.",
+          "Sutton G.G.",
+          "Florea L.",
+          "Halpern A.L.",
+          "Mobarry C.M.",
+          "Lippert R.",
+          "Walenz B.",
+          "Shatkay H.",
+          "Dew I.",
+          "Miller J.R.",
+          "Flanigan M.J.",
+          "Edwards N.J.",
+          "Bolanos R.",
+          "Fasulo D.",
+          "Halldorsson B.V.",
+          "Hannenhalli S.",
+          "Turner R.",
+          "Yooseph S.",
+          "Lu F.",
+          "Nusskern D.R.",
+          "Shue B.C.",
+          "Zheng X.H.",
+          "Zhong F.",
+          "Delcher A.L.",
+          "Huson D.H.",
+          "Kravitz S.A.",
+          "Mouchard L.",
+          "Reinert K.",
+          "Remington K.A.",
+          "Clark A.G.",
+          "Waterman M.S.",
+          "Eichler E.E.",
+          "Adams M.D.",
+          "Hunkapiller M.W.",
+          "Myers E.W.",
+          "Venter J.C."
+        ],
+        "publicationDate": "SEP-2005",
+        "submissionDatabase": "EMBL/GenBank/DDBJ databases"
+      },
+      "referencePositions": [
+        "NUCLEOTIDE SEQUENCE [LARGE SCALE GENOMIC DNA]"
+      ]
+    },
+    {
+      "referenceNumber": 5,
+      "citation": {
+        "id": "15489334",
+        "citationType": "journal article",
+        "authoringGroup": [
+          "The MGC Project Team"
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "15489334"
+          },
+          {
+            "database": "DOI",
+            "id": "10.1101/gr.2596504"
+          }
+        ],
+        "title": "The status, quality, and expansion of the NIH full-length cDNA project: the Mammalian Gene Collection (MGC).",
+        "publicationDate": "2004",
+        "journal": "Genome Res.",
+        "firstPage": "2121",
+        "lastPage": "2127",
+        "volume": "14"
+      },
+      "referencePositions": [
+        "NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA]"
+      ],
+      "referenceComments": [
+        {
+          "value": "Lymph",
+          "type": "TISSUE"
+        }
+      ]
+    },
+    {
+      "referenceNumber": 6,
+      "citation": {
+        "id": "12874243",
+        "citationType": "journal article",
+        "authors": [
+          "Jensen L.E.",
+          "Whitehead A.S."
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "12874243"
+          },
+          {
+            "database": "DOI",
+            "id": "10.4049/jimmunol.171.3.1500"
+          }
+        ],
+        "title": "Pellino3, a novel member of the Pellino protein family, promotes activation of c-Jun and Elk-1 and may act as a scaffolding protein.",
+        "publicationDate": "2003",
+        "journal": "J. Immunol.",
+        "firstPage": "1500",
+        "lastPage": "1506",
+        "volume": "171"
+      },
+      "referencePositions": [
+        "INTERACTION WITH PELI3"
+      ]
+    },
+    {
+      "referenceNumber": 7,
+      "citation": {
+        "id": "12853971",
+        "citationType": "journal article",
+        "authors": [
+          "Chen D.",
+          "Xu L.G.",
+          "Chen L.",
+          "Li L.",
+          "Zhai Z.",
+          "Shu H.B."
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "12853971"
+          },
+          {
+            "database": "DOI",
+            "id": "10.1038/sj.onc.1206532"
+          }
+        ],
+        "title": "NIK is a component of the EGF/heregulin receptor signaling complexes.",
+        "publicationDate": "2003",
+        "journal": "Oncogene",
+        "firstPage": "4348",
+        "lastPage": "4355",
+        "volume": "22"
+      },
+      "referencePositions": [
+        "INTERACTION WITH GRB10"
+      ]
+    },
+    {
+      "referenceNumber": 8,
+      "citation": {
+        "id": "15084608",
+        "citationType": "journal article",
+        "authors": [
+          "Liao G.",
+          "Zhang M.",
+          "Harhaj E.W.",
+          "Sun S.C."
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "15084608"
+          },
+          {
+            "database": "DOI",
+            "id": "10.1074/jbc.m403286200"
+          }
+        ],
+        "title": "Regulation of the NF-kappaB-inducing kinase by tumor necrosis factor receptor-associated factor 3-induced degradation.",
+        "publicationDate": "2004",
+        "journal": "J. Biol. Chem.",
+        "firstPage": "26243",
+        "lastPage": "26250",
+        "volume": "279"
+      },
+      "referencePositions": [
+        "FUNCTION",
+        "UBIQUITINATION",
+        "INTERACTION WITH TRAF3"
+      ]
+    },
+    {
+      "referenceNumber": 9,
+      "citation": {
+        "id": "15173580",
+        "citationType": "journal article",
+        "authors": [
+          "Witherow D.S.",
+          "Garrison T.R.",
+          "Miller W.E.",
+          "Lefkowitz R.J."
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "15173580"
+          },
+          {
+            "database": "DOI",
+            "id": "10.1073/pnas.0402851101"
+          }
+        ],
+        "title": "beta-Arrestin inhibits NF-kappaB activity by means of its interaction with the NF-kappaB inhibitor IkappaBalpha.",
+        "publicationDate": "2004",
+        "journal": "Proc. Natl. Acad. Sci. U.S.A.",
+        "firstPage": "8603",
+        "lastPage": "8607",
+        "volume": "101"
+      },
+      "referencePositions": [
+        "INTERACTION WITH ARRB1 AND ARRB2"
+      ]
+    },
+    {
+      "referenceNumber": 10,
+      "citation": {
+        "id": "15951441",
+        "citationType": "journal article",
+        "authors": [
+          "Hu W.-H.",
+          "Pendergast J.S.",
+          "Mo X.-M.",
+          "Brambilla R.",
+          "Bracchi-Ricard V.",
+          "Li F.",
+          "Walters W.M.",
+          "Blits B.",
+          "He L.",
+          "Schaal S.M.",
+          "Bethea J.R."
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "15951441"
+          },
+          {
+            "database": "DOI",
+            "id": "10.1074/jbc.m501670200"
+          }
+        ],
+        "title": "NIBP, a novel NIK and IKK(beta)-binding protein that enhances NF-(kappa)B activation.",
+        "publicationDate": "2005",
+        "journal": "J. Biol. Chem.",
+        "firstPage": "29233",
+        "lastPage": "29241",
+        "volume": "280"
+      },
+      "referencePositions": [
+        "INTERACTION WITH NIBP"
+      ]
+    },
+    {
+      "referenceNumber": 11,
+      "citation": {
+        "id": "17237370",
+        "citationType": "journal article",
+        "authors": [
+          "Lich J.D.",
+          "Williams K.L.",
+          "Moore C.B.",
+          "Arthur J.C.",
+          "Davis B.K.",
+          "Taxman D.J.",
+          "Ting J.P."
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "17237370"
+          },
+          {
+            "database": "DOI",
+            "id": "10.4049/jimmunol.178.3.1256"
+          }
+        ],
+        "title": "Monarch-1 suppresses non-canonical NF-kappaB activation and p52-dependent chemokine expression in monocytes.",
+        "publicationDate": "2007",
+        "journal": "J. Immunol.",
+        "firstPage": "1256",
+        "lastPage": "1260",
+        "volume": "178"
+      },
+      "referencePositions": [
+        "INTERACTION WITH NLRP12"
+      ]
+    },
+    {
+      "referenceNumber": 12,
+      "citation": {
+        "id": "20501937",
+        "citationType": "journal article",
+        "authors": [
+          "Razani B.",
+          "Zarnegar B.",
+          "Ytterberg A.J.",
+          "Shiba T.",
+          "Dempsey P.W.",
+          "Ware C.F.",
+          "Loo J.A.",
+          "Cheng G."
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "20501937"
+          },
+          {
+            "database": "DOI",
+            "id": "10.1126/scisignal.2000778"
+          }
+        ],
+        "title": "Negative feedback in noncanonical NF-kappaB signaling modulates NIK stability through IKKalpha-mediated phosphorylation.",
+        "publicationDate": "2010",
+        "journal": "Sci. Signal.",
+        "firstPage": "RA41",
+        "lastPage": "RA41",
+        "volume": "3"
+      },
+      "referencePositions": [
+        "PHOSPHORYLATION BY CHUK/IKKA"
+      ]
+    },
+    {
+      "referenceNumber": 13,
+      "citation": {
+        "id": "30341167",
+        "citationType": "journal article",
+        "authors": [
+          "Fullam A.",
+          "Gu L.",
+          "Hoehn Y.",
+          "Schroeder M."
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "30341167"
+          },
+          {
+            "database": "DOI",
+            "id": "10.1042/bcj20180163"
+          }
+        ],
+        "title": "DDX3 directly facilitates IKKalpha activation and regulates downstream signalling pathways.",
+        "publicationDate": "2018",
+        "journal": "Biochem. J.",
+        "firstPage": "3595",
+        "lastPage": "3607",
+        "volume": "475"
+      },
+      "referencePositions": [
+        "INTERACTION WITH DDX3X"
+      ]
+    },
+    {
+      "referenceNumber": 14,
+      "citation": {
+        "id": "22718757",
+        "citationType": "journal article",
+        "authors": [
+          "Liu J.",
+          "Sudom A.",
+          "Min X.",
+          "Cao Z.",
+          "Gao X.",
+          "Ayres M.",
+          "Lee F.",
+          "Cao P.",
+          "Johnstone S.",
+          "Plotnikova O.",
+          "Walker N.",
+          "Chen G.",
+          "Wang Z."
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "22718757"
+          },
+          {
+            "database": "DOI",
+            "id": "10.1074/jbc.m112.366658"
+          }
+        ],
+        "title": "Structure of the nuclear factor kappaB-inducing kinase (NIK) kinase domain reveals a constitutively active conformation.",
+        "publicationDate": "2012",
+        "journal": "J. Biol. Chem.",
+        "firstPage": "27326",
+        "lastPage": "27334",
+        "volume": "287"
+      },
+      "referencePositions": [
+        "X-RAY CRYSTALLOGRAPHY (2.5 ANGSTROMS) OF 330-680"
+      ]
+    },
+    {
+      "referenceNumber": 15,
+      "citation": {
+        "id": "22921830",
+        "citationType": "journal article",
+        "authors": [
+          "de Leon-Boenig G.",
+          "Bowman K.K.",
+          "Feng J.A.",
+          "Crawford T.",
+          "Everett C.",
+          "Franke Y.",
+          "Oh A.",
+          "Stanley M.",
+          "Staben S.T.",
+          "Starovasnik M.A.",
+          "Wallweber H.J.",
+          "Wu J.",
+          "Wu L.C.",
+          "Johnson A.R.",
+          "Hymowitz S.G."
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "22921830"
+          },
+          {
+            "database": "DOI",
+            "id": "10.1016/j.str.2012.07.013"
+          }
+        ],
+        "title": "The crystal structure of the catalytic domain of the NF-kappaB inducing kinase reveals a narrow but flexible active site.",
+        "publicationDate": "2012",
+        "journal": "Structure",
+        "firstPage": "1704",
+        "lastPage": "1714",
+        "volume": "20"
+      },
+      "referencePositions": [
+        "X-RAY CRYSTALLOGRAPHY (2.9 ANGSTROMS) OF 308-673"
+      ]
+    },
+    {
+      "referenceNumber": 16,
+      "citation": {
+        "id": "17344846",
+        "citationType": "journal article",
+        "authors": [
+          "Greenman C.",
+          "Stephens P.",
+          "Smith R.",
+          "Dalgliesh G.L.",
+          "Hunter C.",
+          "Bignell G.",
+          "Davies H.",
+          "Teague J.",
+          "Butler A.",
+          "Stevens C.",
+          "Edkins S.",
+          "O'Meara S.",
+          "Vastrik I.",
+          "Schmidt E.E.",
+          "Avis T.",
+          "Barthorpe S.",
+          "Bhamra G.",
+          "Buck G.",
+          "Choudhury B.",
+          "Clements J.",
+          "Cole J.",
+          "Dicks E.",
+          "Forbes S.",
+          "Gray K.",
+          "Halliday K.",
+          "Harrison R.",
+          "Hills K.",
+          "Hinton J.",
+          "Jenkinson A.",
+          "Jones D.",
+          "Menzies A.",
+          "Mironenko T.",
+          "Perry J.",
+          "Raine K.",
+          "Richardson D.",
+          "Shepherd R.",
+          "Small A.",
+          "Tofts C.",
+          "Varian J.",
+          "Webb T.",
+          "West S.",
+          "Widaa S.",
+          "Yates A.",
+          "Cahill D.P.",
+          "Louis D.N.",
+          "Goldstraw P.",
+          "Nicholson A.G.",
+          "Brasseur F.",
+          "Looijenga L.",
+          "Weber B.L.",
+          "Chiew Y.-E.",
+          "DeFazio A.",
+          "Greaves M.F.",
+          "Green A.R.",
+          "Campbell P.",
+          "Birney E.",
+          "Easton D.F.",
+          "Chenevix-Trench G.",
+          "Tan M.-H.",
+          "Khoo S.K.",
+          "Teh B.T.",
+          "Yuen S.T.",
+          "Leung S.Y.",
+          "Wooster R.",
+          "Futreal P.A.",
+          "Stratton M.R."
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "17344846"
+          },
+          {
+            "database": "DOI",
+            "id": "10.1038/nature05610"
+          }
+        ],
+        "title": "Patterns of somatic mutation in human cancer genomes.",
+        "publicationDate": "2007",
+        "journal": "Nature",
+        "firstPage": "153",
+        "lastPage": "158",
+        "volume": "446"
+      },
+      "referencePositions": [
+        "VARIANTS [LARGE SCALE ANALYSIS] ASN-140; LYS-514; ALA-764; ILE-852 AND HIS-928"
+      ]
+    },
+    {
+      "referenceNumber": 17,
+      "citation": {
+        "id": "20682767",
+        "citationType": "journal article",
+        "authors": [
+          "Jin X.",
+          "Jin H.R.",
+          "Jung H.S.",
+          "Lee S.J.",
+          "Lee J.H.",
+          "Lee J.J."
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "20682767"
+          },
+          {
+            "database": "DOI",
+            "id": "10.1074/jbc.m110.129551"
+          }
+        ],
+        "title": "An atypical E3 ligase zinc finger protein 91 stabilizes and activates NF-kappaB-inducing kinase via Lys63-linked ubiquitination.",
+        "publicationDate": "2010",
+        "journal": "J. Biol. Chem.",
+        "firstPage": "30539",
+        "lastPage": "30547",
+        "volume": "285"
+      },
+      "referencePositions": [
+        "PHOSPHORYLATION AT THR-559",
+        "UBIQUITINATION",
+        "INTERACTION WITH ZFP91",
+        "MUTAGENESIS OF 429-LYS-LYS-430 AND THR-559"
+      ]
+    },
+    {
+      "referenceNumber": 18,
+      "citation": {
+        "id": "25406581",
+        "citationType": "journal article",
+        "authors": [
+          "Willmann K.L.",
+          "Klaver S.",
+          "Dogu F.",
+          "Santos-Valente E.",
+          "Garncarz W.",
+          "Bilic I.",
+          "Mace E.",
+          "Salzer E.",
+          "Conde C.D.",
+          "Sic H.",
+          "Majek P.",
+          "Banerjee P.P.",
+          "Vladimer G.I.",
+          "Haskologlu S.",
+          "Bolkent M.G.",
+          "Kuepesiz A.",
+          "Condino-Neto A.",
+          "Colinge J.",
+          "Superti-Furga G.",
+          "Pickl W.F.",
+          "van Zelm M.C.",
+          "Eibel H.",
+          "Orange J.S.",
+          "Ikinciogullari A.",
+          "Boztug K."
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "25406581"
+          },
+          {
+            "database": "DOI",
+            "id": "10.1038/ncomms6360"
+          }
+        ],
+        "title": "Biallelic loss-of-function mutation in NIK causes a primary immunodeficiency with multifaceted aberrant lymphoid immunity.",
+        "publicationDate": "2014",
+        "journal": "Nat. Commun.",
+        "firstPage": "5360",
+        "lastPage": "5360",
+        "volume": "5"
+      },
+      "referencePositions": [
+        "VARIANT IMD112 ARG-565",
+        "CHARACTERIZATION OF VARIANT IMD112 ARG-565",
+        "INVOLVEMENT IN IMD112",
+        "FUNCTION",
+        "MUTAGENESIS OF 429-LYS-LYS-430"
+      ]
+    },
+    {
+      "referenceNumber": 19,
+      "citation": {
+        "id": "29230214",
+        "citationType": "journal article",
+        "authors": [
+          "Schlechter N.",
+          "Glanzmann B.",
+          "Hoal E.G.",
+          "Schoeman M.",
+          "Petersen B.S.",
+          "Franke A.",
+          "Lau Y.L.",
+          "Urban M.",
+          "van Helden P.D.",
+          "Esser M.M.",
+          "Moeller M.",
+          "Kinnear C."
+        ],
+        "citationCrossReferences": [
+          {
+            "database": "PubMed",
+            "id": "29230214"
+          },
+          {
+            "database": "DOI",
+            "id": "10.3389/fimmu.2017.01624"
+          }
+        ],
+        "title": "Exome Sequencing Identifies a Novel MAP3K14 Mutation in Recessive Atypical Combined Immunodeficiency.",
+        "publicationDate": "2017",
+        "journal": "Front. Immunol.",
+        "firstPage": "1624",
+        "lastPage": "1624",
+        "volume": "8"
+      },
+      "referencePositions": [
+        "VARIANT IMD112 MET-345",
+        "CHARACTERIZATION OF VARIANT IMD112 MET-345",
+        "INVOLVEMENT IN IMD112",
+        "FUNCTION"
+      ]
+    }
+  ],
+  "uniProtKBCrossReferences": [
+    {
+      "database": "EMBL",
+      "id": "Y10256",
+      "properties": [
+        {
+          "key": "ProteinId",
+          "value": "CAA71306.1"
+        },
+        {
+          "key": "Status",
+          "value": "-"
+        },
+        {
+          "key": "MoleculeType",
+          "value": "mRNA"
+        }
+      ]
+    },
+    {
+      "database": "EMBL",
+      "id": "AK290203",
+      "properties": [
+        {
+          "key": "ProteinId",
+          "value": "BAF82892.1"
+        },
+        {
+          "key": "Status",
+          "value": "-"
+        },
+        {
+          "key": "MoleculeType",
+          "value": "mRNA"
+        }
+      ]
+    },
+    {
+      "database": "EMBL",
+      "id": "DQ314874",
+      "properties": [
+        {
+          "key": "ProteinId",
+          "value": "ABC40733.1"
+        },
+        {
+          "key": "Status",
+          "value": "-"
+        },
+        {
+          "key": "MoleculeType",
+          "value": "Genomic_DNA"
+        }
+      ]
+    },
+    {
+      "database": "EMBL",
+      "id": "CH471178",
+      "properties": [
+        {
+          "key": "ProteinId",
+          "value": "EAW51529.1"
+        },
+        {
+          "key": "Status",
+          "value": "-"
+        },
+        {
+          "key": "MoleculeType",
+          "value": "Genomic_DNA"
+        }
+      ]
+    },
+    {
+      "database": "EMBL",
+      "id": "CH471178",
+      "properties": [
+        {
+          "key": "ProteinId",
+          "value": "EAW51530.1"
+        },
+        {
+          "key": "Status",
+          "value": "-"
+        },
+        {
+          "key": "MoleculeType",
+          "value": "Genomic_DNA"
+        }
+      ]
+    },
+    {
+      "database": "EMBL",
+      "id": "BC035576",
+      "properties": [
+        {
+          "key": "ProteinId",
+          "value": "AAH35576.1"
+        },
+        {
+          "key": "Status",
+          "value": "-"
+        },
+        {
+          "key": "MoleculeType",
+          "value": "mRNA"
+        }
+      ]
+    },
+    {
+      "database": "CCDS",
+      "id": "CCDS74079.1",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "RefSeq",
+      "id": "NP_003945.2",
+      "properties": [
+        {
+          "key": "NucleotideSequenceId",
+          "value": "NM_003954.5"
+        }
+      ]
+    },
+    {
+      "database": "RefSeq",
+      "id": "XP_011523743.1",
+      "properties": [
+        {
+          "key": "NucleotideSequenceId",
+          "value": "XM_011525441.3"
+        }
+      ]
+    },
+    {
+      "database": "RefSeq",
+      "id": "XP_054173660.1",
+      "properties": [
+        {
+          "key": "NucleotideSequenceId",
+          "value": "XM_054317685.1"
+        }
+      ]
+    },
+    {
+      "database": "PDB",
+      "id": "4DN5",
+      "properties": [
+        {
+          "key": "Method",
+          "value": "X-ray"
+        },
+        {
+          "key": "Resolution",
+          "value": "2.50 A"
+        },
+        {
+          "key": "Chains",
+          "value": "A/B=330-680"
+        }
+      ]
+    },
+    {
+      "database": "PDB",
+      "id": "4G3D",
+      "properties": [
+        {
+          "key": "Method",
+          "value": "X-ray"
+        },
+        {
+          "key": "Resolution",
+          "value": "2.90 A"
+        },
+        {
+          "key": "Chains",
+          "value": "A/B/D/E=308-673"
+        }
+      ]
+    },
+    {
+      "database": "PDB",
+      "id": "4IDT",
+      "properties": [
+        {
+          "key": "Method",
+          "value": "X-ray"
+        },
+        {
+          "key": "Resolution",
+          "value": "2.40 A"
+        },
+        {
+          "key": "Chains",
+          "value": "A/B=330-680"
+        }
+      ]
+    },
+    {
+      "database": "PDB",
+      "id": "4IDV",
+      "properties": [
+        {
+          "key": "Method",
+          "value": "X-ray"
+        },
+        {
+          "key": "Resolution",
+          "value": "2.90 A"
+        },
+        {
+          "key": "Chains",
+          "value": "A/B/C/D=330-680"
+        }
+      ]
+    },
+    {
+      "database": "PDB",
+      "id": "6WPP",
+      "properties": [
+        {
+          "key": "Method",
+          "value": "X-ray"
+        },
+        {
+          "key": "Resolution",
+          "value": "2.55 A"
+        },
+        {
+          "key": "Chains",
+          "value": "A/B=343-686"
+        }
+      ]
+    },
+    {
+      "database": "PDB",
+      "id": "6Z1Q",
+      "properties": [
+        {
+          "key": "Method",
+          "value": "X-ray"
+        },
+        {
+          "key": "Resolution",
+          "value": "2.42 A"
+        },
+        {
+          "key": "Chains",
+          "value": "AAA/BBB=330-680"
+        }
+      ]
+    },
+    {
+      "database": "PDB",
+      "id": "6Z1T",
+      "properties": [
+        {
+          "key": "Method",
+          "value": "X-ray"
+        },
+        {
+          "key": "Resolution",
+          "value": "2.31 A"
+        },
+        {
+          "key": "Chains",
+          "value": "AAA/BBB=330-680"
+        }
+      ]
+    },
+    {
+      "database": "PDB",
+      "id": "8YHW",
+      "properties": [
+        {
+          "key": "Method",
+          "value": "X-ray"
+        },
+        {
+          "key": "Resolution",
+          "value": "2.90 A"
+        },
+        {
+          "key": "Chains",
+          "value": "A/B/C/D=330-679"
+        }
+      ]
+    },
+    {
+      "database": "PDBsum",
+      "id": "4DN5",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "PDBsum",
+      "id": "4G3D",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "PDBsum",
+      "id": "4IDT",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "PDBsum",
+      "id": "4IDV",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "PDBsum",
+      "id": "6WPP",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "PDBsum",
+      "id": "6Z1Q",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "PDBsum",
+      "id": "6Z1T",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "PDBsum",
+      "id": "8YHW",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "AlphaFoldDB",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "SMR",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "BioGRID",
+      "id": "114487",
+      "properties": [
+        {
+          "key": "Interactions",
+          "value": "173"
+        }
+      ]
+    },
+    {
+      "database": "CORUM",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "DIP",
+      "id": "DIP-27522N",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "FunCoup",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Number of interactors",
+          "value": "3346"
+        }
+      ]
+    },
+    {
+      "database": "IntAct",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Interactions",
+          "value": "151"
+        }
+      ]
+    },
+    {
+      "database": "MINT",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "STRING",
+      "id": "9606.ENSP00000482657",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "BindingDB",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "ChEMBL",
+      "id": "CHEMBL5888",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "GuidetoPHARMACOLOGY",
+      "id": "2074",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "GlyGen",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "glycosylation",
+          "value": "1 site, 1 O-linked glycan (1 site)"
+        }
+      ]
+    },
+    {
+      "database": "iPTMnet",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "PhosphoSitePlus",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "BioMuta",
+      "id": "MAP3K14",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "DMDM",
+      "id": "92090612",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "CPTAC",
+      "id": "non-CPTAC-5641",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "jPOST",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "MassIVE",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "PaxDb",
+      "id": "9606-ENSP00000482657",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "PeptideAtlas",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "ProteomicsDB",
+      "id": "78326",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "Antibodypedia",
+      "id": "3862",
+      "properties": [
+        {
+          "key": "antibodies",
+          "value": "358 antibodies from 41 providers"
+        }
+      ]
+    },
+    {
+      "database": "DNASU",
+      "id": "9020",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "Ensembl",
+      "id": "ENST00000344686.8",
+      "properties": [
+        {
+          "key": "ProteinId",
+          "value": "ENSP00000478552.1"
+        },
+        {
+          "key": "GeneId",
+          "value": "ENSG00000006062.18"
+        }
+      ]
+    },
+    {
+      "database": "Ensembl",
+      "id": "ENST00000376926.8",
+      "properties": [
+        {
+          "key": "ProteinId",
+          "value": "ENSP00000482657.1"
+        },
+        {
+          "key": "GeneId",
+          "value": "ENSG00000006062.18"
+        }
+      ]
+    },
+    {
+      "database": "Ensembl",
+      "id": "ENST00000617331.3",
+      "properties": [
+        {
+          "key": "ProteinId",
+          "value": "ENSP00000480974.3"
+        },
+        {
+          "key": "GeneId",
+          "value": "ENSG00000006062.18"
+        }
+      ]
+    },
+    {
+      "database": "GeneID",
+      "id": "9020",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "KEGG",
+      "id": "hsa:9020",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "MANE-Select",
+      "id": "ENST00000344686.8",
+      "properties": [
+        {
+          "key": "ProteinId",
+          "value": "ENSP00000478552.1"
+        },
+        {
+          "key": "RefSeqNucleotideId",
+          "value": "NM_003954.5"
+        },
+        {
+          "key": "RefSeqProteinId",
+          "value": "NP_003945.2"
+        }
+      ]
+    },
+    {
+      "database": "UCSC",
+      "id": "uc032fjy.2",
+      "properties": [
+        {
+          "key": "OrganismName",
+          "value": "human"
+        }
+      ]
+    },
+    {
+      "database": "AGR",
+      "id": "HGNC:6853",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "CTD",
+      "id": "9020",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "DisGeNET",
+      "id": "9020",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "GeneCards",
+      "id": "MAP3K14",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "HGNC",
+      "id": "HGNC:6853",
+      "properties": [
+        {
+          "key": "GeneName",
+          "value": "MAP3K14"
+        }
+      ]
+    },
+    {
+      "database": "HPA",
+      "id": "ENSG00000006062",
+      "properties": [
+        {
+          "key": "ExpressionPatterns",
+          "value": "Low tissue specificity"
+        }
+      ]
+    },
+    {
+      "database": "MalaCards",
+      "id": "MAP3K14",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "MIM",
+      "id": "604655",
+      "properties": [
+        {
+          "key": "Type",
+          "value": "gene"
+        }
+      ]
+    },
+    {
+      "database": "MIM",
+      "id": "620449",
+      "properties": [
+        {
+          "key": "Type",
+          "value": "phenotype"
+        }
+      ]
+    },
+    {
+      "database": "neXtProt",
+      "id": "NX_Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "OpenTargets",
+      "id": "ENSG00000006062",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "Orphanet",
+      "id": "447731",
+      "properties": [
+        {
+          "key": "Disease",
+          "value": "NIK deficiency"
+        }
+      ]
+    },
+    {
+      "database": "PharmGKB",
+      "id": "PA30597",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "VEuPathDB",
+      "id": "HostDB:ENSG00000006062",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "eggNOG",
+      "id": "KOG0198",
+      "properties": [
+        {
+          "key": "ToxonomicScope",
+          "value": "Eukaryota"
+        }
+      ]
+    },
+    {
+      "database": "GeneTree",
+      "id": "ENSGT00940000156497",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "HOGENOM",
+      "id": "CLU_010641_1_0_1",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "InParanoid",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "OMA",
+      "id": "IDIWSSC",
+      "properties": [
+        {
+          "key": "Fingerprint",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "OrthoDB",
+      "id": "5836549at2759",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "PAN-GO",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Number of GO annotations",
+          "value": "5 GO annotations based on evolutionary models"
+        }
+      ]
+    },
+    {
+      "database": "PhylomeDB",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "PathwayCommons",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "Reactome",
+      "id": "R-HSA-389357",
+      "properties": [
+        {
+          "key": "PathwayName",
+          "value": "CD28 dependent PI3K/Akt signaling"
+        }
+      ]
+    },
+    {
+      "database": "Reactome",
+      "id": "R-HSA-5607761",
+      "properties": [
+        {
+          "key": "PathwayName",
+          "value": "Dectin-1 mediated noncanonical NF-kB signaling"
+        }
+      ]
+    },
+    {
+      "database": "Reactome",
+      "id": "R-HSA-5668541",
+      "properties": [
+        {
+          "key": "PathwayName",
+          "value": "TNFR2 non-canonical NF-kB pathway"
+        }
+      ]
+    },
+    {
+      "database": "Reactome",
+      "id": "R-HSA-5676590",
+      "properties": [
+        {
+          "key": "PathwayName",
+          "value": "NIK-->noncanonical NF-kB signaling"
+        }
+      ]
+    },
+    {
+      "database": "Reactome",
+      "id": "R-HSA-5676594",
+      "properties": [
+        {
+          "key": "PathwayName",
+          "value": "TNF receptor superfamily (TNFSF) members mediating non-canonical NF-kB pathway"
+        }
+      ]
+    },
+    {
+      "database": "SignaLink",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "SIGNOR",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "BioGRID-ORCS",
+      "id": "9020",
+      "properties": [
+        {
+          "key": "hits",
+          "value": "10 hits in 303 CRISPR screens"
+        }
+      ]
+    },
+    {
+      "database": "ChiTaRS",
+      "id": "MAP3K14",
+      "properties": [
+        {
+          "key": "OrganismName",
+          "value": "human"
+        }
+      ]
+    },
+    {
+      "database": "EvolutionaryTrace",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "GeneWiki",
+      "id": "MAP3K14",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "GenomeRNAi",
+      "id": "9020",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "Pharos",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "DevelopmentLevel",
+          "value": "Tchem"
+        }
+      ]
+    },
+    {
+      "database": "PRO",
+      "id": "PR:Q99558",
+      "properties": [
+        {
+          "key": "Description",
+          "value": "-"
+        }
+      ]
+    },
+    {
+      "database": "Proteomes",
+      "id": "UP000005640",
+      "properties": [
+        {
+          "key": "Component",
+          "value": "Chromosome 17"
+        }
+      ]
+    },
+    {
+      "database": "RNAct",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "moleculeType",
+          "value": "protein"
+        }
+      ]
+    },
+    {
+      "database": "Bgee",
+      "id": "ENSG00000006062",
+      "properties": [
+        {
+          "key": "ExpressionPatterns",
+          "value": "Expressed in granulocyte and 110 other cell types or tissues"
+        }
+      ]
+    },
+    {
+      "database": "ExpressionAtlas",
+      "id": "Q99558",
+      "properties": [
+        {
+          "key": "ExpressionPatterns",
+          "value": "baseline and differential"
+        }
+      ]
+    },
+    {
+      "database": "GO",
+      "id": "GO:0005829",
+      "properties": [
+        {
+          "key": "GoTerm",
+          "value": "C:cytosol"
+        },
+        {
+          "key": "GoEvidenceType",
+          "value": "IDA:HPA"
+        }
+      ]
+    },
+    {
+      "database": "GO",
+      "id": "GO:0001650",
+      "properties": [
+        {
+          "key": "GoTerm",
+          "value": "C:fibrillar center"
+        },
+        {
+          "key": "GoEvidenceType",
+          "value": "IDA:HPA"
+        }
+      ]
+    },
+    {
+      "database": "GO",
+      "id": "GO:0043231",
+      "properties": [
+        {
+          "key": "GoTerm",
+          "value": "C:intracellular membrane-bounded organelle"
+        },
+        {
+          "key": "GoEvidenceType",
+          "value": "IDA:HPA"
+        }
+      ]
+    },
+    {
+      "database": "GO",
+      "id": "GO:0005654",
+      "properties": [
+        {
+          "key": "GoTerm",
+          "value": "C:nucleoplasm"
+        },
+        {
+          "key": "GoEvidenceType",
+          "value": "IDA:HPA"
+        }
+      ]
+    },
+    {
+      "database": "GO",
+      "id": "GO:0005524",
+      "properties": [
+        {
+          "key": "GoTerm",
+          "value": "F:ATP binding"
+        },
+        {
+          "key": "GoEvidenceType",
+          "value": "IEA:UniProtKB-KW"
+        }
+      ]
+    },
+    {
+      "database": "GO",
+      "id": "GO:0004709",
+      "properties": [
+        {
+          "key": "GoTerm",
+          "value": "F:MAP kinase kinase kinase activity"
+        },
+        {
+          "key": "GoEvidenceType",
+          "value": "IEA:UniProtKB-EC"
+        }
+      ]
+    },
+    {
+      "database": "GO",
+      "id": "GO:0004672",
+      "properties": [
+        {
+          "key": "GoTerm",
+          "value": "F:protein kinase activity"
+        },
+        {
+          "key": "GoEvidenceType",
+          "value": "IDA:MGI"
+        }
+      ],
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000314",
+          "source": "PubMed",
+          "id": "15001576"
+        }
+      ]
+    },
+    {
+      "database": "GO",
+      "id": "GO:0106310",
+      "properties": [
+        {
+          "key": "GoTerm",
+          "value": "F:protein serine kinase activity"
+        },
+        {
+          "key": "GoEvidenceType",
+          "value": "IEA:RHEA"
+        }
+      ]
+    },
+    {
+      "database": "GO",
+      "id": "GO:0004674",
+      "properties": [
+        {
+          "key": "GoTerm",
+          "value": "F:protein serine/threonine kinase activity"
+        },
+        {
+          "key": "GoEvidenceType",
+          "value": "EXP:Reactome"
+        }
+      ],
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000269",
+          "source": "PubMed",
+          "id": "9520446"
+        }
+      ]
+    },
+    {
+      "database": "GO",
+      "id": "GO:0071260",
+      "properties": [
+        {
+          "key": "GoTerm",
+          "value": "P:cellular response to mechanical stimulus"
+        },
+        {
+          "key": "GoEvidenceType",
+          "value": "IEP:UniProtKB"
+        }
+      ],
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000270",
+          "source": "PubMed",
+          "id": "19593445"
+        }
+      ]
+    },
+    {
+      "database": "GO",
+      "id": "GO:0051607",
+      "properties": [
+        {
+          "key": "GoTerm",
+          "value": "P:defense response to virus"
+        },
+        {
+          "key": "GoEvidenceType",
+          "value": "IDA:UniProtKB"
+        }
+      ],
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000314",
+          "source": "PubMed",
+          "id": "21478870"
+        }
+      ]
+    },
+    {
+      "database": "GO",
+      "id": "GO:0006955",
+      "properties": [
+        {
+          "key": "GoTerm",
+          "value": "P:immune response"
+        },
+        {
+          "key": "GoEvidenceType",
+          "value": "ISS:UniProtKB"
+        }
+      ]
+    },
+    {
+      "database": "GO",
+      "id": "GO:0000165",
+      "properties": [
+        {
+          "key": "GoTerm",
+          "value": "P:MAPK cascade"
+        },
+        {
+          "key": "GoEvidenceType",
+          "value": "IBA:GO_Central"
+        }
+      ]
+    },
+    {
+      "database": "GO",
+      "id": "GO:0038061",
+      "properties": [
+        {
+          "key": "GoTerm",
+          "value": "P:non-canonical NF-kappaB signal transduction"
+        },
+        {
+          "key": "GoEvidenceType",
+          "value": "IMP:UniProtKB"
+        }
+      ],
+      "evidences": [
+        {
+          "evidenceCode": "ECO:0000315",
+          "source": "PubMed",
+          "id": "10094049"
+        }
+      ]
+    },
+    {
+      "database": "CDD",
+      "id": "cd13991",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "STKc_NIK"
+        },
+        {
+          "key": "MatchStatus",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "database": "FunFam",
+      "id": "1.10.510.10:FF:000383",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "Mitogen-activated protein kinase kinase kinase 14"
+        },
+        {
+          "key": "MatchStatus",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "database": "FunFam",
+      "id": "3.30.200.20:FF:000326",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "Mitogen-activated protein kinase kinase kinase 14"
+        },
+        {
+          "key": "MatchStatus",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "database": "Gene3D",
+      "id": "3.30.200.20",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "Phosphorylase Kinase, domain 1"
+        },
+        {
+          "key": "MatchStatus",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "database": "Gene3D",
+      "id": "1.10.510.10",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "Transferase(Phosphotransferase) domain 1"
+        },
+        {
+          "key": "MatchStatus",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "database": "InterPro",
+      "id": "IPR011009",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "Kinase-like_dom_sf"
+        }
+      ]
+    },
+    {
+      "database": "InterPro",
+      "id": "IPR042787",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "M3K14_STKc"
+        }
+      ]
+    },
+    {
+      "database": "InterPro",
+      "id": "IPR050538",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "MAP_kinase_kinase_kinase"
+        }
+      ]
+    },
+    {
+      "database": "InterPro",
+      "id": "IPR017425",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "MAPKKK14"
+        }
+      ]
+    },
+    {
+      "database": "InterPro",
+      "id": "IPR000719",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "Prot_kinase_dom"
+        }
+      ]
+    },
+    {
+      "database": "InterPro",
+      "id": "IPR017441",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "Protein_kinase_ATP_BS"
+        }
+      ]
+    },
+    {
+      "database": "InterPro",
+      "id": "IPR008271",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "Ser/Thr_kinase_AS"
+        }
+      ]
+    },
+    {
+      "database": "PANTHER",
+      "id": "PTHR48016",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "MAP KINASE KINASE KINASE SSK2-RELATED-RELATED"
+        },
+        {
+          "key": "MatchStatus",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "database": "PANTHER",
+      "id": "PTHR48016:SF9",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "MITOGEN-ACTIVATED PROTEIN KINASE KINASE KINASE 14"
+        },
+        {
+          "key": "MatchStatus",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "database": "Pfam",
+      "id": "PF00069",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "Pkinase"
+        },
+        {
+          "key": "MatchStatus",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "database": "PIRSF",
+      "id": "PIRSF038175",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "MAPKKK14"
+        },
+        {
+          "key": "MatchStatus",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "database": "SMART",
+      "id": "SM00220",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "S_TKc"
+        },
+        {
+          "key": "MatchStatus",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "database": "SUPFAM",
+      "id": "SSF56112",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "Protein kinase-like (PK-like)"
+        },
+        {
+          "key": "MatchStatus",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "database": "PROSITE",
+      "id": "PS00107",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "PROTEIN_KINASE_ATP"
+        },
+        {
+          "key": "MatchStatus",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "database": "PROSITE",
+      "id": "PS50011",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "PROTEIN_KINASE_DOM"
+        },
+        {
+          "key": "MatchStatus",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "database": "PROSITE",
+      "id": "PS00108",
+      "properties": [
+        {
+          "key": "EntryName",
+          "value": "PROTEIN_KINASE_ST"
+        },
+        {
+          "key": "MatchStatus",
+          "value": "1"
+        }
+      ]
+    }
+  ],
+  "sequence": {
+    "value": "MAVMEMACPGAPGSAVGQQKELPKAKEKTPPLGKKQSSVYKLEAVEKSPVFCGKWEILNDVITKGTAKEGSEAGPAAISIIAQAECENSQEFSPTFSERIFIAGSKQYSQSESLDQIPNNVAHATEGKMARVCWKGKRRSKARKKRKKKSSKSLAHAGVALAKPLPRTPEQESCTIPVQEDESPLGAPYVRNTPQFTKPLKEPGLGQLCFKQLGEGLRPALPRSELHKLISPLQCLNHVWKLHHPQDGGPLPLPTHPFPYSRLPHPFPFHPLQPWKPHPLESFLGKLACVDSQKPLPDPHLSKLACVDSPKPLPGPHLEPSCLSRGAHEKFSVEEYLVHALQGSVSSGQAHSLTSLAKTWAARGSRSREPSPKTEDNEGVLLTEKLKPVDYEYREEVHWATHQLRLGRGSFGEVHRMEDKQTGFQCAVKKVRLEVFRAEELMACAGLTSPRIVPLYGAVREGPWVNIFMELLEGGSLGQLVKEQGCLPEDRALYYLGQALEGLEYLHSRRILHGDVKADNVLLSSDGSHAALCDFGHAVCLQPDGLGKSLLTGDYIPGTETHMAPEVVLGRSCDAKVDVWSSCCMMLHMLNGCHPWTQFFRGPLCLKIASEPPPVREIPPSCAPLTAQAIQEGLRKEPIHRVSAAELGGKVNRALQQVGGLKSPWRGEYKEPRHPPPNQANYHQTLHAQPRELSPRAPGPRPAEETTGRAPKLQPPLPPEPPEPNKSPPLTLSKEESGMWEPLPLSSLEPAPARNPSSPERKATVPEQELQQLEIELFLNSLSQPFSLEEQEQILSCLSIDSLSLSDDSEKNPSKASQSSRDTLSSGVHSWSSQAEARSSSWNMVLARGRPTDTPSYFNGVKVQIQSLNGEHLHIREFHRVKVGDIATGISSQIPAAAFSLVTKDGQPVRYDMEVPDSGIDLQCTLAPDGSFAWSWRVKHGQLENRP",
+    "length": 947,
+    "molWeight": 104042,
+    "crc64": "C9D10F67FF7F48AC",
+    "md5": "D9CC6D3AAF9D619C94A2A58C4049686C"
+  },
+  "extraAttributes": {
+    "countByCommentType": {
+      "FUNCTION": 1,
+      "CATALYTIC ACTIVITY": 2,
+      "SUBUNIT": 1,
+      "INTERACTION": 17,
+      "SUBCELLULAR LOCATION": 1,
+      "TISSUE SPECIFICITY": 1,
+      "PTM": 2,
+      "DISEASE": 1,
+      "SIMILARITY": 1
+    },
+    "countByFeatureType": {
+      "Chain": 1,
+      "Domain": 1,
+      "Region": 5,
+      "Compositional bias": 5,
+      "Active site": 1,
+      "Binding site": 2,
+      "Modified residue": 1,
+      "Natural variant": 9,
+      "Mutagenesis": 2,
+      "Sequence conflict": 3,
+      "Helix": 15,
+      "Beta strand": 11,
+      "Turn": 7
+    },
+    "uniParcId": "UPI0000074220"
+  }
+}

--- a/library/iuphar_library.py
+++ b/library/iuphar_library.py
@@ -76,7 +76,10 @@ def load_targets(path: str | Path, *, encoding: str = "utf-8") -> pd.DataFrame:
     The ``target_id`` and ``family_id`` columns in the official files are
     zero-padded strings. Reading them as numeric values would drop the
     padding and break lookups.  To avoid this, all columns are read as
-    strings and missing values are replaced with empty strings.
+    strings and missing values are replaced with empty strings.  The
+    original data uses the column name ``swissprot`` for UniProt accession
+    numbers; this is normalised to ``uniprot_id`` for consistency with the
+    rest of the library.
 
     Parameters
     ----------
@@ -99,6 +102,7 @@ def load_targets(path: str | Path, *, encoding: str = "utf-8") -> pd.DataFrame:
             "HGNC_name": "hgnc_name",
             "HGNC_ID": "hgnc_id",
             "HGNC_id": "hgnc_id",
+            "swissprot": "uniprot_id",
         }
     )
     _validate_columns(df, EXPECTED_TARGET_COLUMNS)

--- a/tests/test_iuphar_mapping.py
+++ b/tests/test_iuphar_mapping.py
@@ -24,12 +24,17 @@ def test_map_uniprot_file(tmp_path: Path) -> None:
         "100,FamilyX,,0001,Enzyme.Lyase\n",
         encoding="utf-8",
     )
-    input_csv.write_text("uniprot_id;hgnc_name\nQ12345;GeneX\n", encoding="utf-8")
+    input_csv.write_text(
+        "uniprot_id;GuidetoPHARMACOLOGY;hgnc_name\n"
+        "Q99999;0001;\n"
+        "Q12345;;\n",
+        encoding="utf-8",
+    )
 
     data = IUPHARData.from_files(target_csv, family_csv)
     df = data.map_uniprot_file(input_csv, output_csv, sep=";")
 
     assert output_csv.exists()
     out_df = pd.read_csv(output_csv, sep=";", dtype=str)
-    assert out_df.loc[0, "target_id"] == "0001"
-    assert df.loc[0, "target_id"] == "0001"
+    assert list(out_df["target_id"]) == ["0001", "0001"]
+    assert list(df["target_id"]) == ["0001", "0001"]

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 import sys
-import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 


### PR DESCRIPTION
## Summary
- normalize IUPHAR target loading to expose `swissprot` column as `uniprot_id`
- include example UniProt JSON in `data/uniprot` for offline lookups

## Testing
- `ruff check .`
- `mypy --explicit-package-bases library get_target_data.py` *(fails: incompatible return types and annotations)*
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aea2903f1083248c62ad0dccbf5f54