### PR TITLE
Remove PubMed column prefixing

### DIFF
--- a/get_document_data.py
+++ b/get_document_data.py
@@ -164,9 +164,8 @@ def run_all(args: argparse.Namespace) -> int:
 
     pmids = [str(p) for p in doc_df["pubmed_id"].dropna().astype(int).tolist()]
     pub_df = fetch_pubmed_records(pmids, args.sleep)
-    pub_df = pub_df.add_prefix("pubmed.")
     merged = doc_df.merge(
-        pub_df, how="left", left_on="pubmed_id", right_on="pubmed.PubMed.PMID"
+        pub_df, how="left", left_on="pubmed_id", right_on="PubMed.PMID"
     )
     try:
         merged.to_csv(args.output_csv, index=False)


### PR DESCRIPTION
## Summary
- drop `add_prefix("pubmed.")` from PubMed record merging
- join document and PubMed data on `PubMed.PMID` column directly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aee08da8648324aa6f2e44eaf0d96c