### PR TITLE
Add ChEMBL assay retrieval CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Utilities for downloading and integrating target information from
 It also provides helpers for collecting publication metadata from
 PubMed, Semantic Scholar, OpenAlex and CrossRef.
 
-Two command line tools are available:
+Three command line tools are available:
 
 `get_target_data.py`
     Query biological data sources individually or run the combined
@@ -15,6 +15,9 @@ Two command line tools are available:
 
 `get_document_data.py`
     Retrieve document information from the services listed above.
+
+`get_assay_data.py`
+    Fetch assay information from the ChEMBL API for a list of assay IDs.
 
 ## Installation
 
@@ -55,6 +58,15 @@ Map UniProt IDs to IUPHAR classifications:
 python get_target_data.py iuphar uniprot_results.csv iuphar_results.csv \
     --target-csv data/_IUPHAR_target.csv \
     --family-csv data/_IUPHAR_family.csv
+```
+
+### Assay metadata
+
+Retrieve assay information from the ChEMBL API for identifiers listed in
+`assays.csv`:
+
+```bash
+python get_assay_data.py assays.csv assay_results.csv
 ```
 
 ### Document metadata

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -1,0 +1,137 @@
+"""Command line interface for retrieving ChEMBL assay data."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+
+from library import chembl_library as cl
+
+logger = logging.getLogger(__name__)
+
+
+def read_ids(
+    path: str | Path,
+    column: str = "assay_chembl_id",
+    sep: str = ",",
+    encoding: str = "utf8",
+) -> list[str]:
+    """Read ChEMBL assay identifiers from a CSV file.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to the CSV file.
+    column : str, optional
+        Name of the column containing assay identifiers. Defaults to
+        ``"assay_chembl_id"``.
+    sep : str, optional
+        Field delimiter, by default a comma.
+    encoding : str, optional
+        File encoding, by default ``"utf8"``.
+
+    Returns
+    -------
+    list[str]
+        Identifier values in the order they appear. Empty strings and
+        ``"#N/A"`` markers are discarded.
+
+    Raises
+    ------
+    ValueError
+        If ``column`` is not present in the input file.
+    """
+    try:
+        with Path(path).open("r", encoding=encoding, newline="") as fh:
+            reader = csv.DictReader(fh, delimiter=sep)
+            if reader.fieldnames is None or column not in reader.fieldnames:
+                raise ValueError(f"column '{column}' not found in {path}")
+            ids: list[str] = []
+            for row in reader:
+                value = (row.get(column) or "").strip()
+                if value and value != "#N/A":
+                    ids.append(value)
+            return ids
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"input file not found: {path}") from exc
+    except csv.Error as exc:
+        raise ValueError(f"malformed CSV in file: {path}: {exc}") from exc
+
+
+def run_chembl(args: argparse.Namespace) -> int:
+    """Execute assay retrieval from the ChEMBL API.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed command-line arguments.
+
+    Returns
+    -------
+    int
+        Zero on success, non-zero on failure.
+    """
+    try:
+        ids = read_ids(
+            args.input_csv,
+            column=args.column,
+            sep=args.sep,
+            encoding=args.encoding,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        logger.error("%s", exc)
+        return 1
+
+    df = cl.get_assays(ids, chunk_size=args.chunk_size)
+    try:
+        df.to_csv(args.output_csv, index=False, sep=args.sep, encoding=args.encoding)
+        logger.info("Wrote %d rows to %s", len(df), args.output_csv)
+        return 0
+    except OSError as exc:
+        logger.error("failed to write output CSV: %s", exc)
+        return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command-line argument parser."""
+    parser = argparse.ArgumentParser(description="ChEMBL assay data utilities")
+    parser.add_argument("--log-level", default="INFO", help="Logging level")
+    parser.add_argument(
+        "input_csv", type=Path, help="CSV file containing assay identifiers"
+    )
+    parser.add_argument("output_csv", type=Path, help="Destination CSV file")
+    parser.add_argument(
+        "--column",
+        default="assay_chembl_id",
+        help="Column name in the input CSV containing identifiers",
+    )
+    parser.add_argument("--sep", default=",", help="CSV delimiter")
+    parser.add_argument("--encoding", default="utf8", help="File encoding")
+    parser.add_argument(
+        "--chunk-size", type=int, default=5, help="Maximum number of IDs per request"
+    )
+    parser.set_defaults(func=run_chembl)
+    return parser
+
+
+def configure_logging(level: str) -> None:
+    """Configure basic logging."""
+    numeric_level = getattr(logging, level.upper(), logging.INFO)
+    logging.basicConfig(level=numeric_level)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Command line entry point."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    configure_logging(args.log_level)
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_get_assay_data.py
+++ b/tests/test_get_assay_data.py
@@ -1,0 +1,43 @@
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import get_assay_data as gad
+from library import chembl_library as cl
+
+
+def _sample_assay_df() -> pd.DataFrame:
+    data = {col: [""] for col in cl.ASSAY_COLUMNS}
+    data["assay_chembl_id"] = ["CHEMBL123"]
+    return pd.DataFrame(data)
+
+
+def test_read_ids(tmp_path: Path) -> None:
+    csv_file = tmp_path / "assays.csv"
+    csv_file.write_text(
+        "assay_chembl_id\nCHEMBL123\n#N/A\n\nCHEMBL456\n", encoding="utf8"
+    )
+    assert gad.read_ids(csv_file) == ["CHEMBL123", "CHEMBL456"]
+
+
+def test_run_chembl(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(cl, "get_assays", lambda ids, chunk_size=5: _sample_assay_df())
+    input_csv = tmp_path / "assays.csv"
+    input_csv.write_text("assay_chembl_id\nCHEMBL123\n", encoding="utf8")
+    output_csv = tmp_path / "out.csv"
+    args = argparse.Namespace(
+        input_csv=input_csv,
+        output_csv=output_csv,
+        column="assay_chembl_id",
+        sep=",",
+        encoding="utf8",
+        chunk_size=5,
+    )
+    assert gad.run_chembl(args) == 0
+    df = pd.read_csv(output_csv, dtype=str)
+    assert df.loc[0, "assay_chembl_id"] == "CHEMBL123"


### PR DESCRIPTION
## Summary
- add `get_assay_data.py` script to pull assay details from ChEMBL based on IDs in a CSV
- document new assay utility in README
- cover script with unit tests for CSV reading and API invocation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aee506219c8324a77b41331eed3219