### PR TITLE
Extend IUPHAR UniProt mapping with extra name and EC columns

### DIFF
--- a/tests/test_iuphar_mapping.py
+++ b/tests/test_iuphar_mapping.py
@@ -38,3 +38,37 @@ def test_map_uniprot_file(tmp_path: Path) -> None:
     out_df = pd.read_csv(output_csv, sep=";", dtype=str)
     assert list(out_df["target_id"]) == ["0001", "0001"]
     assert list(df["target_id"]) == ["0001", "0001"]
+
+
+def test_map_uniprot_file_additional(tmp_path: Path) -> None:
+    target_csv = tmp_path / "target.csv"
+    family_csv = tmp_path / "family.csv"
+    input_csv = tmp_path / "input.csv"
+    output_csv = tmp_path / "output.csv"
+
+    target_csv.write_text(
+        "target_id,swissprot,hgnc_name,hgnc_id,gene_name,synonyms,family_id,target_name,type\n"
+        "0001,Q12345,GeneX,1,GENE1,Syn1|Syn2,100,TargetX,Enzyme.Lyase\n",
+        encoding="utf-8",
+    )
+    family_csv.write_text(
+        "family_id,family_name,parent_family_id,target_id,type\n"
+        "100,FamilyX,,0001,Enzyme.Lyase\n",
+        encoding="utf-8",
+    )
+    input_csv.write_text(
+        "uniprot_id;pref_name;component_description;reaction_ec_numbers_x;reaction_ec_numbers_y\n"
+        "Q11111;TargetX;;;\n"
+        "Q22222;;TargetX;;\n"
+        "Q33333;;;1.1.1.1;\n"
+        "Q44444;;;;2.7.7.7\n",
+        encoding="utf-8",
+    )
+
+    data = IUPHARData.from_files(target_csv, family_csv)
+    df = data.map_uniprot_file(input_csv, output_csv, sep=";")
+
+    out_df = pd.read_csv(output_csv, sep=";", dtype=str)
+    assert list(df["target_id"]) == ["0001", "0001", "", ""]
+    assert out_df.loc[2, "IUPHAR_type"] == "Enzyme.Oxidoreductase"
+    assert out_df.loc[3, "IUPHAR_type"] == "Enzyme.Transferase"


### PR DESCRIPTION
## Summary
- Support pref_name and component_description columns when resolving IUPHAR targets by name
- Use reaction_ec_numbers_x/y as fallbacks for EC-number based classification
- Expand name matching helper to consider target_name field
- Test new mappings

## Testing
- `pytest` (fails: AttributeError: 'Namespace' object has no attribute 'workers')
- `pytest tests/test_iuphar_mapping.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b051ac857c8324af3af57a5477c56c