### PR TITLE
Add PubChem CID lookup utilities

### DIFF
--- a/get_pubchem_cid.py
+++ b/get_pubchem_cid.py
@@ -1,0 +1,58 @@
+"""Command line utility to look up PubChem CIDs from structural identifiers."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import Optional
+
+from library import pubchem_library as pl
+
+
+logger = logging.getLogger(__name__)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create and return the CLI argument parser."""
+
+    parser = argparse.ArgumentParser(
+        description="Lookup PubChem CIDs from SMILES, InChI or InChIKey"
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (DEBUG, INFO, WARNING)",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--smiles", help="SMILES string to query")
+    group.add_argument("--inchi", help="InChI string to query")
+    group.add_argument("--inchikey", help="InChIKey to query")
+    return parser
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the lookup based on parsed ``args``."""
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    cid: Optional[str]
+    if args.smiles:
+        cid = pl.get_cid_from_smiles(args.smiles)
+    elif args.inchi:
+        cid = pl.get_cid_from_inchi(args.inchi)
+    else:
+        cid = pl.get_cid_from_inchikey(args.inchikey)
+    if cid:
+        print(cid)
+        return 0
+    logger.error("CID not found")
+    return 1
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    raise SystemExit(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -167,6 +167,72 @@ def get_all_cid(compound_name: str) -> Optional[str]:
     return "|".join(unique_cids) if unique_cids else None
 
 
+def _cids_from_identifier_list(data: Dict[str, Any]) -> List[str]:
+    """Extract CIDs from a JSON ``IdentifierList`` structure."""
+
+    return [str(cid) for cid in data.get("IdentifierList", {}).get("CID", [])]
+
+
+def get_cid_from_smiles(smiles: str) -> Optional[str]:
+    """Retrieve PubChem CID(s) for a SMILES string.
+
+    Parameters
+    ----------
+    smiles: str
+        SMILES representation of a compound.
+
+    Returns
+    -------
+    str or None
+        Pipe-separated list of CIDs or ``None`` if the structure is
+        unknown to PubChem.
+    """
+
+    safe_smiles = url_encode(smiles)
+    url = (
+        "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/smiles/"
+        f"{safe_smiles}/cids/JSON"
+    )
+    response = make_request(url)
+    if not response:
+        return None
+    cids = _cids_from_identifier_list(response)
+    unique_cids = sorted(set(cids))
+    return "|".join(unique_cids) if unique_cids else None
+
+
+def get_cid_from_inchi(inchi: str) -> Optional[str]:
+    """Retrieve PubChem CID(s) for an InChI string."""
+
+    safe_inchi = url_encode(inchi)
+    url = (
+        "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/inchi/"
+        f"{safe_inchi}/cids/JSON"
+    )
+    response = make_request(url)
+    if not response:
+        return None
+    cids = _cids_from_identifier_list(response)
+    unique_cids = sorted(set(cids))
+    return "|".join(unique_cids) if unique_cids else None
+
+
+def get_cid_from_inchikey(inchikey: str) -> Optional[str]:
+    """Retrieve PubChem CID(s) for an InChIKey."""
+
+    safe_inchikey = url_encode(inchikey)
+    url = (
+        "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/inchikey/"
+        f"{safe_inchikey}/cids/JSON"
+    )
+    response = make_request(url)
+    if not response:
+        return None
+    cids = _cids_from_identifier_list(response)
+    unique_cids = sorted(set(cids))
+    return "|".join(unique_cids) if unique_cids else None
+
+
 def get_standard_name(cid: str) -> Optional[str]:
     """Retrieve the standard compound name for a given CID."""
     validated = validate_cid(cid)
@@ -267,6 +333,9 @@ __all__ = [
     "validate_cid",
     "get_cid",
     "get_all_cid",
+    "get_cid_from_smiles",
+    "get_cid_from_inchi",
+    "get_cid_from_inchikey",
     "get_standard_name",
     "get_properties",
     "process_compound",

--- a/tests/test_get_pubchem_cid_cli.py
+++ b/tests/test_get_pubchem_cid_cli.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import sys
+import argparse
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import get_pubchem_cid as gpc
+from library import pubchem_library as pl
+
+
+def test_run_smiles(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(pl, "get_cid_from_smiles", lambda s: "123")
+    args = argparse.Namespace(smiles="O", inchi=None, inchikey=None, log_level="INFO")
+    assert gpc.run(args) == 0
+    assert capsys.readouterr().out.strip() == "123"
+
+

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import get_testitem_data as gtd
+from library import pubchem_library as pl
+
+
+def test_add_pubchem_data(monkeypatch) -> None:
+    df = pd.DataFrame({"molecule_structures.canonical_smiles": ["O", ""]})
+
+    monkeypatch.setattr(pl, "get_cid_from_smiles", lambda s: "123" if s else None)
+    monkeypatch.setattr(
+        pl,
+        "get_properties",
+        lambda cid: pl.Properties(
+            "Oxidane", "H2O", "O", "O", "InChI=1S/H2O/h1H2", "XLYOFNOQVPJJNP-UHFFFAOYSA-N"
+        ),
+    )
+
+    result = gtd.add_pubchem_data(df)
+    assert list(result["pubchem_cid"]) == ["123", ""]
+    assert list(result["pubchem_iupac_name"]) == ["Oxidane", ""]
+

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -31,6 +31,24 @@ def test_get_cid(monkeypatch) -> None:
     assert pl.get_cid("water") == "123|456"
 
 
+def test_get_cid_from_smiles(monkeypatch) -> None:
+    sample = {"IdentifierList": {"CID": [123, 123, 456]}}
+    monkeypatch.setattr(pl, "make_request", lambda url, delay=3.0: sample)
+    assert pl.get_cid_from_smiles("O") == "123|456"
+
+
+def test_get_cid_from_inchi(monkeypatch) -> None:
+    sample = {"IdentifierList": {"CID": [789]}}
+    monkeypatch.setattr(pl, "make_request", lambda url, delay=3.0: sample)
+    assert pl.get_cid_from_inchi("InChI=1S/H2O/h1H2") == "789"
+
+
+def test_get_cid_from_inchikey(monkeypatch) -> None:
+    sample = {"IdentifierList": {"CID": [321]}}
+    monkeypatch.setattr(pl, "make_request", lambda url, delay=3.0: sample)
+    assert pl.get_cid_from_inchikey("XLYOFNOQVPJJNP-UHFFFAOYSA-N") == "321"
+
+
 def test_get_standard_name(monkeypatch) -> None:
     sample = {"InformationList": {"Information": [{"Title": "Water"}]}}
     monkeypatch.setattr(pl, "validate_cid", lambda cid: cid)


### PR DESCRIPTION
## Summary
- extend PubChem library with CID lookup from SMILES, InChI, or InChIKey
- add command line interface for CID queries
- augment ChEMBL test item retrieval with PubChem CIDs and properties
- cover new features with unit tests

## Testing
- `pytest tests/test_pubchem_library.py tests/test_get_pubchem_cid_cli.py tests/test_get_testitem_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68b14a25dccc83248278e6ca62a8ab07