### PR TITLE
Expose timeout for assay retrieval

### DIFF
--- a/library/chembl_library.py
+++ b/library/chembl_library.py
@@ -359,7 +359,11 @@ def get_assay(chembl_assay_id: str) -> pd.DataFrame:
     return df
 
 
-def get_assays_all(ids: Iterable[str], chunk_size: int = 5) -> pd.DataFrame:
+def get_assays_all(
+    ids: Iterable[str],
+    chunk_size: int = 5,
+    timeout: float = 30.0,
+) -> pd.DataFrame:
     """Fetch assay records for ``ids``.
 
     Parameters
@@ -368,6 +372,8 @@ def get_assays_all(ids: Iterable[str], chunk_size: int = 5) -> pd.DataFrame:
         Assay identifiers to retrieve.
     chunk_size:
         Maximum number of IDs per HTTP request.
+    timeout:
+        Timeout in seconds for each HTTP request.
 
     Returns
     -------
@@ -385,7 +391,7 @@ def get_assays_all(ids: Iterable[str], chunk_size: int = 5) -> pd.DataFrame:
             + ",".join(chunk)
         )
         try:
-            response = _session.get(url, timeout=1000)
+            response = _session.get(url, timeout=timeout)
             response.raise_for_status()
         except requests.RequestException as exc:  # pragma: no cover - network
             logger.warning("Bulk assay request failed for %s: %s", chunk, exc)
@@ -412,7 +418,11 @@ def get_assays_all(ids: Iterable[str], chunk_size: int = 5) -> pd.DataFrame:
     df = pd.concat(records, ignore_index=True)
     return df.reindex(columns=ASSAY_COLUMNS)
 
-def get_assays_notNull(ids: Iterable[str], chunk_size: int = 5) -> pd.DataFrame:
+def get_assays_notNull(
+    ids: Iterable[str],
+    chunk_size: int = 5,
+    timeout: float = 30.0,
+) -> pd.DataFrame:
     """Fetch assay records for ``ids``.
 
     Parameters
@@ -421,6 +431,8 @@ def get_assays_notNull(ids: Iterable[str], chunk_size: int = 5) -> pd.DataFrame:
         Assay identifiers to retrieve.
     chunk_size:
         Maximum number of IDs per HTTP request.
+    timeout:
+        Timeout in seconds for each HTTP request.
 
     Returns
     -------
@@ -438,7 +450,7 @@ def get_assays_notNull(ids: Iterable[str], chunk_size: int = 5) -> pd.DataFrame:
             + ",".join(chunk)
         )
         try:
-            response = _session.get(url, timeout=1000)
+            response = _session.get(url, timeout=timeout)
             response.raise_for_status()
         except requests.RequestException as exc:  # pragma: no cover - network
             logger.warning("Bulk assay request failed for %s: %s", chunk, exc)

--- a/tests/test_chembl_library.py
+++ b/tests/test_chembl_library.py
@@ -108,3 +108,23 @@ def test_extend_target(monkeypatch) -> None:
     out_df = cl.extend_target(input_df)
     assert out_df.loc[0, "chembl_pref_name"] == "MAP3K14"
     assert out_df.loc[0, "chembl_gene"] == "MAP3K14"
+
+
+def test_get_assays_all_timeout(monkeypatch) -> None:
+    def fake_get(url: str, timeout: float):
+        assert timeout == 10
+        return FakeResponse({"assays": [{"assay_chembl_id": "A1"}]})
+
+    monkeypatch.setattr(cl._session, "get", fake_get)
+    df = cl.get_assays_all(["A1"], chunk_size=1, timeout=10)
+    assert df.loc[0, "assay_chembl_id"] == "A1"
+
+
+def test_get_assays_notNull_timeout(monkeypatch) -> None:
+    def fake_get(url: str, timeout: float):
+        assert timeout == 5
+        return FakeResponse({"assays": [{"assay_chembl_id": "A1"}]})
+
+    monkeypatch.setattr(cl._session, "get", fake_get)
+    df = cl.get_assays_notNull(["A1"], chunk_size=1, timeout=5)
+    assert df.loc[0, "assay_chembl_id"] == "A1"


### PR DESCRIPTION
## Summary
- allow specifying request timeout for `get_assays_all` and `get_assays_notNull`
- cover new timeout argument with unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'get_assay_data')*
- `pytest tests/test_chembl_library.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1720c4f908324b1d5c9fae749766c