### PR TITLE
Add target post-processing utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,3 +255,29 @@ Tests
 test_iuphar_mapping.py — verifies map_uniprot_file maps UniProt ID to target ID and writes expected CSV.
 
 test_read_ids.py — validates read_ids: filtering of empty/#N/A, error when column missing.
+
+## Target post-processing
+
+The combined CSV produced by `get_target_data.py all` can be normalised
+with the standalone script ``main.py``:
+
+```bash
+python main.py raw_targets.csv postprocessed_targets.csv
+```
+
+The command accepts ``--sep`` and ``--encoding`` options mirroring the
+main pipeline. Logging verbosity can be controlled with ``--log-level``.
+
+### Development
+
+Recommended quality tools:
+
+```bash
+ruff .
+black --check .
+mypy mylib
+pytest
+```
+
+These commands ensure code style, type correctness and unit-test
+coverage.

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -13,8 +13,10 @@ import pandas as pd
 from library import chembl_library as cl
 from library import iuphar_library as ii
 from library import uniprot_library as uu
+from mylib import postprocess_targets
 
 logger = logging.getLogger(__name__)
+
 
 def _pipe_merge(values: Sequence[str | None]) -> str:
     """Return a ``"|"``-joined string of unique, non-empty tokens.
@@ -45,6 +47,7 @@ def _first_token(value: str | None) -> str:
     if isinstance(value, str) and value:
         return value.split("|")[0]
     return ""
+
 
 def read_ids(
     path: str | Path,
@@ -91,6 +94,7 @@ def read_ids(
         raise FileNotFoundError(f"input file not found: {path}") from exc
     except csv.Error as exc:
         raise ValueError(f"malformed CSV in file: {path}: {exc}") from exc
+
 
 def build_parser() -> argparse.ArgumentParser:
     """Create and return the top-level CLI argument parser.
@@ -270,6 +274,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     return parser
 
+
 def configure_logging(level: str) -> None:
     """Configure basic logging.
 
@@ -400,7 +405,9 @@ def run_all(args: argparse.Namespace) -> int:
         uids = [u for u in chembl_df.get("uniprot_id", []) if isinstance(u, str) and u]
         from tempfile import NamedTemporaryFile
 
-        with NamedTemporaryFile("w", delete=False, encoding=args.encoding, newline="") as tmp:
+        with NamedTemporaryFile(
+            "w", delete=False, encoding=args.encoding, newline=""
+        ) as tmp:
             writer = csv.DictWriter(tmp, fieldnames=["uniprot_id"], delimiter=args.sep)
             writer.writeheader()
             for uid in uids:
@@ -428,7 +435,7 @@ def run_all(args: argparse.Namespace) -> int:
 
         # Prepare combined input for IUPHAR containing ChEMBL and UniProt data
         combined_df = chembl_df.merge(uniprot_df, on="uniprot_id", how="left")
-        
+
         # Consolidate synonym and EC number information for classification
         combined_df["synonyms"] = combined_df.apply(
             lambda r: _pipe_merge(
@@ -448,7 +455,9 @@ def run_all(args: argparse.Namespace) -> int:
             axis=1,
         )
         combined_df["gene_name"] = combined_df["gene"].apply(_first_token)
-        combined_df = combined_df.drop(columns=["ec_numbers", "reaction_ec_numbers"], errors="ignore")
+        combined_df = combined_df.drop(
+            columns=["ec_numbers", "reaction_ec_numbers"], errors="ignore"
+        )
 
         with NamedTemporaryFile(
             "w", delete=False, encoding=args.encoding, newline=""
@@ -482,6 +491,8 @@ def run_all(args: argparse.Namespace) -> int:
         iuphar_df = iuphar_df[["uniprot_id", *classification_cols]]
 
         merged = combined_df.merge(iuphar_df, on="uniprot_id", how="left")
+
+        merged = postprocess_targets(merged)
 
         merged.to_csv(
             args.output_csv, index=False, sep=args.sep, encoding=args.encoding

--- a/main.py
+++ b/main.py
@@ -1,0 +1,49 @@
+"""CLI entry point for target table post-processing."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Sequence
+
+from mylib import postprocess_file
+
+logger = logging.getLogger(__name__)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Target table post-processing")
+    parser.add_argument("input_csv", type=Path, help="Raw merged CSV file")
+    parser.add_argument("output_csv", type=Path, help="Destination for cleaned CSV")
+    parser.add_argument("--sep", default=",", help="CSV delimiter")
+    parser.add_argument("--encoding", default="utf8", help="CSV encoding")
+    parser.add_argument("--log-level", default="INFO", help="Logging level")
+    return parser
+
+
+def configure_logging(level: str) -> None:
+    logging.basicConfig(
+        level=level.upper(), format="%(levelname)s:%(name)s:%(message)s"
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    configure_logging(args.log_level)
+    try:
+        postprocess_file(
+            args.input_csv, args.output_csv, sep=args.sep, encoding=args.encoding
+        )
+        return 0
+    except FileNotFoundError as exc:
+        logger.error("%s", exc)
+        return 1
+    except OSError as exc:
+        logger.error("failed to write output: %s", exc)
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/mylib/__init__.py
+++ b/mylib/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for target data processing."""
+
+from .transforms import postprocess_targets, postprocess_file
+
+__all__ = ["postprocess_targets", "postprocess_file"]

--- a/mylib/transforms.py
+++ b/mylib/transforms.py
@@ -1,0 +1,228 @@
+"""Data transformation utilities for target tables.
+
+This module implements post-processing helpers that reshape and clean the
+merged target information produced by :mod:`get_target_data`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+import logging
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def _pipe_merge(values: Iterable[str | float | None]) -> str:
+    """Return a ``"|"``-separated string of unique tokens.
+
+    Parameters
+    ----------
+    values:
+        Iterable of pipe-delimited strings. ``None`` and empty strings are
+        ignored.
+
+    Returns
+    -------
+    str
+        Unique tokens joined by ``"|"`` in their first appearance order.
+    """
+
+    tokens: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if isinstance(value, str) and value:
+            for part in (p.strip() for p in value.split("|") if p.strip()):
+                if part not in seen:
+                    seen.add(part)
+                    tokens.append(part)
+    return "|".join(tokens)
+
+
+def _first_token(value: str | float | None) -> str:
+    """Return the first token from a pipe-delimited string."""
+
+    if isinstance(value, str) and value:
+        return value.split("|")[0]
+    return ""
+
+
+def postprocess_targets(df: pd.DataFrame) -> pd.DataFrame:
+    """Clean and reshape merged target information.
+
+    Parameters
+    ----------
+    df:
+        DataFrame produced by the ``all`` pipeline in
+        :mod:`get_target_data`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Normalised table ready for export.
+    """
+
+    df = df.copy()
+
+    # --- normalise identifiers -------------------------------------------------
+    df["uniprotkb_Id"] = (
+        df.get("uniProtkbId", pd.Series(dtype=str))
+        .astype(str)
+        .str.split("_")
+        .str[0]
+        .str.split("-")
+        .str[0]
+    )
+    df["secondary_uniprot_id"] = df.get(
+        "secondaryAccessions", pd.Series(dtype=str)
+    ).fillna(df.get("uniprot_id"))
+
+    # Rename "pref_name" to the exported "recommended_name" column
+    if "pref_name" in df.columns:
+        df = df.rename(columns={"pref_name": "recommended_name"})
+
+    # --- gene name handling -----------------------------------------------------
+    df["gene_name_x"] = df.get("gene_name_x", pd.Series(dtype=str)).replace(
+        {"51.1rMVA_034": "N1L"}
+    )
+    df["gene_name"] = df.get("geneName", pd.Series(dtype=str))
+    mask = df["gene_name"].isna() | (df["gene_name"] == "")
+    df.loc[mask, "gene_name"] = df.loc[mask, "gene_name_x"].fillna("")
+    mask = df["gene_name"] == ""
+    df.loc[mask, "gene_name"] = df.loc[mask, "gene"].apply(_first_token)
+    df["gene_name"] = df["gene_name"].replace("", "-").str.upper()
+
+    df["gene"] = df.apply(
+        lambda r: _pipe_merge([r.get("gene"), r.get("gene_name")]), axis=1
+    )
+    df["gene"] = df["gene"].replace("", "-").str.upper()
+
+    # --- synonyms --------------------------------------------------------------
+    synonym_fields = [
+        "gene",
+        "secondaryAccessionNames",
+        "component_description",
+        "chembl_alternative_name",
+        "recommendedName",
+        "names",
+        "gene_name_x",
+        "synonyms_x",
+        "synonyms",
+    ]
+    df["synonyms"] = df.apply(
+        lambda r: _pipe_merge([r.get(f) for f in synonym_fields]), axis=1
+    )
+    df["synonyms"] = (
+        df["synonyms"]
+        .str.replace("||", "|", regex=False)
+        .str.replace("| ", "|", regex=False)
+        .str.replace(" |", "|", regex=False)
+        .str.lower()
+    )
+
+    # --- EC numbers ------------------------------------------------------------
+    df["ec_number"] = df.apply(
+        lambda r: _pipe_merge([r.get("ec_number"), r.get("ec_code")]), axis=1
+    )
+    df["ec_number"] = df["ec_number"].replace("", "-")
+
+    # --- fill optional columns --------------------------------------------------
+    for col in [
+        "isoform_names",
+        "isoform_ids",
+        "isoform_synonyms",
+        "reactions",
+        "full_id_path",
+        "full_name_path",
+    ]:
+        if col in df.columns:
+            df[col] = df[col].fillna("-")
+        else:
+            df[col] = "-"
+
+    # --- deduplicate gene field -------------------------------------------------
+    df["gene"] = df["gene"].apply(lambda v: _pipe_merge([v]))
+
+    # --- final column ordering --------------------------------------------------
+    columns = [
+        "chembl_id",
+        "uniprotkb_Id",
+        "uniprot_id",
+        "secondary_uniprot_id",
+        "gene_name",
+        "recommended_name",
+        "synonyms",
+        "genus",
+        "superkingdom",
+        "phylum",
+        "taxon_id",
+        "ec_number",
+        "hgnc_name",
+        "hgnc_id",
+        "molecular_function",
+        "cellular_component",
+        "subcellular_location",
+        "topology",
+        "transmembrane",
+        "intramembrane",
+        "glycosylation",
+        "lipidation",
+        "disulfide_bond",
+        "modified_residue",
+        "phosphorylation",
+        "acetylation",
+        "ubiquitination",
+        "signal_peptide",
+        "propeptide",
+        "isoform_names",
+        "isoform_ids",
+        "isoform_synonyms",
+        "reactions",
+        "target_id",
+        "IUPHAR_family_id",
+        "IUPHAR_type",
+        "IUPHAR_class",
+        "IUPHAR_subclass",
+        "IUPHAR_chain",
+        "full_id_path",
+        "full_name_path",
+        "GuidetoPHARMACOLOGY",
+        "SUPFAM",
+        "PROSITE",
+        "InterPro",
+        "Pfam",
+        "PRINTS",
+        "TCDB",
+    ]
+    for col in columns:
+        if col not in df.columns:
+            df[col] = "-"
+    return df[columns]
+
+
+def postprocess_file(
+    input_path: Path | str,
+    output_path: Path | str,
+    *,
+    sep: str = ",",
+    encoding: str = "utf8",
+) -> None:
+    """Read a CSV, post-process and write the result.
+
+    Parameters
+    ----------
+    input_path:
+        Path to the CSV file produced by ``get_target_data.py all``.
+    output_path:
+        Destination path for the cleaned CSV file.
+    sep:
+        Field delimiter of the CSV files.
+    encoding:
+        Text encoding of the CSV files.
+    """
+
+    df = pd.read_csv(input_path, sep=sep, encoding=encoding, dtype=str)
+    processed = postprocess_targets(df)
+    processed.to_csv(output_path, index=False, sep=sep, encoding=encoding)

--- a/tests/data/targets_raw.csv
+++ b/tests/data/targets_raw.csv
@@ -1,0 +1,3 @@
+chembl_id,uniprot_id,uniProtkbId,secondaryAccessions,pref_name,gene,geneName,gene_name_x,component_description,chembl_alternative_name,names,secondaryAccessionNames,synonyms_x,ec_code,ec_number,target_id
+CHEMBL1,P12345,P12345-1,,Protein A,GNA1,GNA1,Gene1A,desc a,alt a,name1|name2,secAcc,synA|synB,1.1.1.1,2.2.2.2,TID1
+CHEMBL2,Q54321,Q54321-2,SEC1|SEC2,Protein B,GNB1|gnb1,,51.1rMVA_034,desc b,alt b,nameB,,synB,3.3.3.3,,TID2

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,40 @@
+"""Unit tests for the target post-processing helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from mylib.transforms import postprocess_targets
+
+
+def load_raw() -> pd.DataFrame:
+    path = Path(__file__).parent / "data" / "targets_raw.csv"
+    return pd.read_csv(path, dtype=str)
+
+
+def test_gene_name_and_synonyms() -> None:
+    raw = load_raw()
+    processed = postprocess_targets(raw)
+    row1 = processed[processed["chembl_id"] == "CHEMBL1"].iloc[0]
+    row2 = processed[processed["chembl_id"] == "CHEMBL2"].iloc[0]
+
+    assert row1["gene_name"] == "GNA1"
+    assert row2["gene_name"] == "N1L"
+
+    assert "desc a" in row1["synonyms"].split("|")
+    assert "desc b" in row2["synonyms"].split("|")
+
+    assert set(row1["ec_number"].split("|")) == {"1.1.1.1", "2.2.2.2"}
+    assert row2["ec_number"] == "3.3.3.3"
+
+
+def test_identifier_columns() -> None:
+    raw = load_raw()
+    processed = postprocess_targets(raw)
+    row = processed.iloc[0]
+    assert row["uniprotkb_Id"] == "P12345"
+    assert row["secondary_uniprot_id"] == "P12345"


### PR DESCRIPTION
## Summary
- implement pandas-based post-processing for target tables
- expose standalone CLI and integrate into combined data pipeline
- document workflow and add unit tests for transformation logic

## Testing
- `ruff check mylib main.py get_target_data.py tests/test_transforms.py`
- `black --check mylib/transforms.py main.py get_target_data.py tests/test_transforms.py`
- `mypy mylib main.py tests/test_transforms.py`
- `pytest tests/test_transforms.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1c41d821c832495b980056ff154cc