### PR TITLE
feat: map ChEMBL targets to UniProt accessions

### DIFF
--- a/library/chembl_library.py
+++ b/library/chembl_library.py
@@ -38,6 +38,8 @@ from __future__ import annotations
 from typing import Any, Iterable
 
 import logging
+import time
+
 import pandas as pd
 import requests
 from requests.adapters import HTTPAdapter
@@ -70,6 +72,7 @@ TARGET_FIELDS = [
     "relationship",
     "gene",
     "uniprot_id",
+    "mapping_uniprot_id",
     "chembl_alternative_name",
     "ec_code",
     "hgnc_name",
@@ -103,21 +106,80 @@ def _parse_alt_names(synonyms: list[dict[str, str]]) -> str:
     return "|".join(sorted(names))
 
 
-def _parse_uniprot_id(xrefs: list[dict[str, str]]) -> str:
-    """Extract a UniProt accession from a list of cross references.
+def _map_chembl_to_uniprot(chembl_id: str) -> str:
+    """Map a ChEMBL target ID to a UniProt accession.
 
-    The ChEMBL API may label UniProt references with slightly different
-    source database names; the check therefore normalises the label to
-    upper case and matches common variants.
+    The UniProt ID mapping service is asynchronous. A job is submitted and
+    polled until completion. Network failures or missing mappings yield an
+    empty string.
     """
 
+    if not chembl_id:
+        return ""
+
+    try:
+        resp = _session.post(
+            "https://rest.uniprot.org/idmapping/run",
+            data={"from": "ChEMBL_ID", "to": "UniProtKB", "ids": chembl_id},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        job_id = resp.json().get("jobId")
+        if not job_id:
+            return ""
+        status_url = f"https://rest.uniprot.org/idmapping/status/{job_id}"
+        result_url = f"https://rest.uniprot.org/idmapping/uniprotkb/results/{job_id}"
+        for _ in range(10):
+            status_resp = _session.get(status_url, timeout=30)
+            status_resp.raise_for_status()
+            status = status_resp.json()
+            if status.get("jobStatus") == "FINISHED":
+                result_resp = _session.get(result_url, timeout=30)
+                result_resp.raise_for_status()
+                data = result_resp.json()
+                items = data.get("results") or []
+                if items:
+                    return items[0].get("to", "")
+                return ""
+            if status.get("jobStatus") == "FAILED":
+                return ""
+            time.sleep(1)
+    except requests.RequestException as exc:  # pragma: no cover - network
+        logger.warning("UniProt mapping request failed for %s: %s", chembl_id, exc)
+    except ValueError as exc:  # pragma: no cover - malformed JSON
+        logger.warning(
+            "Failed to decode UniProt mapping response for %s: %s", chembl_id, exc
+        )
+    return ""
+
+
+def _parse_uniprot_id(xrefs: list[dict[str, str]], chembl_id: str) -> tuple[str, str]:
+    """Return UniProt IDs from cross references and mapping.
+
+    Parameters
+    ----------
+    xrefs:
+        Cross references returned by the ChEMBL API.
+    chembl_id:
+        ChEMBL target identifier used for UniProt mapping.
+
+    Returns
+    -------
+    tuple[str, str]
+        A pair ``(uniprot_id, mapping_uniprot_id)``.
+    """
+
+    uniprot_id = ""
     for x in xrefs:
         src = (x.get("xref_src_db") or "").upper()
         if src in {"UNIPROT", "UNIPROT ACCESSION", "UNIPROT ACC", "UNIPROTKB"}:
             ident = x.get("xref_id", "")
             if ident:
-                return ident
-    return ""
+                uniprot_id = ident
+                break
+    mapping_uniprot_id = _map_chembl_to_uniprot(chembl_id)
+    return uniprot_id, mapping_uniprot_id
+
 
 
 def _parse_hgnc(xrefs: list[dict[str, str]]) -> tuple[str, str]:
@@ -183,7 +245,9 @@ def _parse_target_record(data: dict[str, Any]) -> dict[str, Any]:
     gene = _parse_gene_synonyms(synonyms)
     ec_code = _parse_ec_codes(synonyms)
     alt_name = _parse_alt_names(synonyms)
-    uniprot_id = _parse_uniprot_id(xrefs)
+    uniprot_id, mapping_uniprot_id = _parse_uniprot_id(
+        xrefs, data.get("target_chembl_id", "")
+    )
     hgnc_name, hgnc_id = _parse_hgnc(xrefs)
 
     return {
@@ -194,6 +258,7 @@ def _parse_target_record(data: dict[str, Any]) -> dict[str, Any]:
         "relationship": comp.get("relationship", ""),
         "gene": gene,
         "uniprot_id": uniprot_id,
+        "mapping_uniprot_id": mapping_uniprot_id,
         "chembl_alternative_name": alt_name,
         "ec_code": ec_code,
         "hgnc_name": hgnc_name,
@@ -213,8 +278,10 @@ def get_target(chembl_target_id: str) -> dict[str, Any]:
     -------
     dict
         A dictionary containing information about the target, including
-        a ``uniprot_id`` when a UniProt cross reference is present. If the
-        request fails an empty dictionary with pre-defined keys is returned.
+        both a ``uniprot_id`` parsed from cross references and a
+        ``mapping_uniprot_id`` obtained via the UniProt ID mapping service.
+        If the request fails an empty dictionary with pre-defined keys is
+        returned.
     """
     if chembl_target_id in {"", "#N/A"}:
         return dict(EMPTY_TARGET)

--- a/tests/test_chembl_library.py
+++ b/tests/test_chembl_library.py
@@ -70,6 +70,7 @@ SAMPLE_DF = pd.DataFrame(
         "relationship": ["single"],
         "gene": ["MAP3K14"],
         "uniprot_id": ["Q99558"],
+        "mapping_uniprot_id": ["Q99558"],
         "chembl_alternative_name": ["NIK"],
         "ec_code": ["2.7.11.25"],
         "hgnc_name": ["MAP3K14"],
@@ -89,16 +90,20 @@ def test_chunked_invalid_size() -> None:
 
 def test_get_target(monkeypatch) -> None:
     monkeypatch.setattr(cl._session, "get", lambda url, timeout=30: FakeResponse(SAMPLE_JSON))
+    monkeypatch.setattr(cl, "_map_chembl_to_uniprot", lambda cid: "Q99558")
     data = cl.get_target(SAMPLE_ID)
     assert data["uniprot_id"] == "Q99558"
+    assert data["mapping_uniprot_id"] == "Q99558"
     assert data["gene"] == "MAP3K14|NIK"
 
 
 def test_get_targets(monkeypatch) -> None:
     bulk_json = {"targets": [SAMPLE_JSON]}
     monkeypatch.setattr(cl._session, "get", lambda url, timeout=30: FakeResponse(bulk_json))
+    monkeypatch.setattr(cl, "_map_chembl_to_uniprot", lambda cid: "Q99558")
     df = cl.get_targets([SAMPLE_ID])
     assert df.loc[0, "uniprot_id"] == "Q99558"
+    assert df.loc[0, "mapping_uniprot_id"] == "Q99558"
     assert df.shape[0] == 1
 
 

--- a/tests/test_cli_pipeline.py
+++ b/tests/test_cli_pipeline.py
@@ -25,6 +25,7 @@ def _sample_chembl_df() -> pd.DataFrame:
             "relationship": ["single"],
             "gene": ["MAP3K14"],
             "uniprot_id": ["Q99558"],
+            "mapping_uniprot_id": ["Q99558"],
             "chembl_alternative_name": ["NIK"],
             "ec_code": ["2.7.11.25"],
             "hgnc_name": ["MAP3K14"],
@@ -60,6 +61,7 @@ def test_run_uniprot(tmp_path: Path) -> None:
         data_dir=DATA_DIR / "uniprot",
         sep=",",
         encoding="utf8",
+        column="uniprot_id",
     )
     assert gtd.run_uniprot(args) == 0
     df = pd.read_csv(output_csv, dtype=str)
@@ -99,6 +101,7 @@ def test_run_all(monkeypatch, tmp_path: Path) -> None:
         family_csv=DATA_DIR / "_IUPHAR_family.csv",
         sep=",",
         encoding="utf8",
+        uniprot_column="uniprot_id",
     )
     assert gtd.run_all(args) == 0
     df = pd.read_csv(output_csv, dtype=str)


### PR DESCRIPTION
## Summary
- map ChEMBL target IDs to UniProt using the ID mapping API and expose `mapping_uniprot_id`
- allow choosing the UniProt column (`uniprot_id` or `mapping_uniprot_id`) for downstream processing
- adjust CLI and tests for new UniProt mapping capability

## Testing
- `pytest tests/test_chembl_library.py tests/test_cli_pipeline.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'get_assay_data')*

------
https://chatgpt.com/codex/tasks/task_e_68b1ecb90e8c8324b87a847b03a3e937