### PR TITLE
Integrate UniProt ID mapping and column selection

### DIFF
--- a/library/uniprot_id_mapping.py
+++ b/library/uniprot_id_mapping.py
@@ -1,0 +1,118 @@
+"""Functions to map ChEMBL target IDs to UniProt accessions using the UniProt ID Mapping API."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.parse
+import urllib.request
+from urllib.error import HTTPError
+from typing import Optional, Callable, Any
+
+API_BASE = "https://rest.uniprot.org/idmapping"
+
+logger = logging.getLogger(__name__)
+
+
+def map_chembl_to_uniprot(
+    chembl_target_id: str,
+    poll_interval: float = 0.5,
+    timeout: float = 300.0,
+    opener: Optional[Callable[..., Any]] = None,
+) -> str:
+    """Map a ChEMBL target identifier to a UniProt accession.
+
+    Parameters
+    ----------
+    chembl_target_id:
+        ChEMBL target identifier (e.g., ``"CHEMBL204"``).
+    poll_interval:
+        Seconds to wait between polling the UniProt API for job completion.
+    timeout:
+        Maximum number of seconds to wait for the mapping job to finish.
+    opener:
+        Optional callable with the same signature as :func:`urllib.request.urlopen`
+        used to perform HTTP requests. Primarily intended for testing.
+
+    Returns
+    -------
+    str
+        UniProt accession corresponding to ``chembl_target_id``.
+
+    Raises
+    ------
+    ValueError
+        If the API reports failure, no UniProt ID is found, or a UniProt API
+        request returns an HTTP error.
+    TimeoutError
+        If the mapping job does not complete within ``timeout`` seconds.
+    URLError
+        If a network-related error occurs.
+    """
+
+    if opener is None:
+        opener = urllib.request.urlopen
+
+    def _open_json(url: str, data: bytes | None = None) -> Any:
+        """Open ``url`` and parse the JSON response."""
+        try:
+            with opener(url, data=data) as response:
+                return json.load(response)
+        except HTTPError as exc:  # pragma: no cover - network failure simulation
+            body = ""
+            if exc.fp is not None:
+                try:
+                    body = exc.fp.read().decode()
+                except Exception:  # pragma: no cover - fallback if decode fails
+                    body = ""
+            raise ValueError(
+                f"UniProt API request to {url} failed with status {exc.code}: {body or exc.reason}"
+            ) from exc
+
+    data = urllib.parse.urlencode(
+        {"from": "ChEMBL", "to": "UniProtKB", "ids": chembl_target_id}
+    ).encode()
+    logger.debug("Submitting ID mapping job for %s", chembl_target_id)
+    run_data = _open_json(f"{API_BASE}/run", data=data)
+    job_id = run_data.get("jobId")
+    if not job_id:
+        raise ValueError("UniProt ID Mapping API did not return a job ID")
+
+    status_url = f"{API_BASE}/status/{job_id}"
+    start = time.time()
+    result_data = {}
+    while True:
+        status_data = _open_json(status_url)
+        if "results" in status_data:
+            result_data = status_data
+            status = "FINISHED"
+        else:
+            status = status_data.get("jobStatus") or status_data.get("status")
+        logger.debug("Job %s status: %s", job_id, status)
+        if status == "FINISHED":
+            break
+        if status == "FAILED":
+            raise ValueError("UniProt ID mapping job failed")
+        if time.time() - start > timeout:
+            raise TimeoutError("UniProt ID mapping job timed out")
+        time.sleep(poll_interval)
+
+    if not result_data:
+        result_url = f"{API_BASE}/uniprotkb/results/{job_id}?format=json"
+        result_data = _open_json(result_url)
+
+    results = result_data.get("results", [])
+    if not results:
+        raise ValueError(f"No UniProt ID found for {chembl_target_id}")
+
+    first = results[0]
+    to = first.get("to", {})
+    accession = to.get("primaryAccession")
+    if not accession:
+        raise ValueError("Unexpected response format from UniProt ID mapping API")
+
+    return accession
+
+
+__all__ = ["map_chembl_to_uniprot"]

--- a/tests/test_chembl_library.py
+++ b/tests/test_chembl_library.py
@@ -70,12 +70,20 @@ SAMPLE_DF = pd.DataFrame(
         "relationship": ["single"],
         "gene": ["MAP3K14"],
         "uniprot_id": ["Q99558"],
+        "mapping_uniprot_id": ["P12345"],
         "chembl_alternative_name": ["NIK"],
         "ec_code": ["2.7.11.25"],
         "hgnc_name": ["MAP3K14"],
         "hgnc_id": ["6853"],
     }
 )
+
+
+@pytest.fixture(autouse=True)
+def _mock_mapping(monkeypatch) -> None:
+    """Always return a fixed UniProt ID for mapping in tests."""
+
+    monkeypatch.setattr(cl, "map_chembl_to_uniprot", lambda cid: "P12345")
 
 
 def test_chunked_splits_list() -> None:
@@ -92,6 +100,7 @@ def test_get_target(monkeypatch) -> None:
     data = cl.get_target(SAMPLE_ID)
     assert data["uniprot_id"] == "Q99558"
     assert data["gene"] == "MAP3K14|NIK"
+    assert data["mapping_uniprot_id"] == "P12345"
 
 
 def test_get_targets(monkeypatch) -> None:
@@ -99,6 +108,7 @@ def test_get_targets(monkeypatch) -> None:
     monkeypatch.setattr(cl._session, "get", lambda url, timeout=30: FakeResponse(bulk_json))
     df = cl.get_targets([SAMPLE_ID])
     assert df.loc[0, "uniprot_id"] == "Q99558"
+    assert df.loc[0, "mapping_uniprot_id"] == "P12345"
     assert df.shape[0] == 1
 
 

--- a/tests/test_cli_pipeline.py
+++ b/tests/test_cli_pipeline.py
@@ -25,6 +25,7 @@ def _sample_chembl_df() -> pd.DataFrame:
             "relationship": ["single"],
             "gene": ["MAP3K14"],
             "uniprot_id": ["Q99558"],
+            "mapping_uniprot_id": ["Q99558"],
             "chembl_alternative_name": ["NIK"],
             "ec_code": ["2.7.11.25"],
             "hgnc_name": ["MAP3K14"],
@@ -60,10 +61,28 @@ def test_run_uniprot(tmp_path: Path) -> None:
         data_dir=DATA_DIR / "uniprot",
         sep=",",
         encoding="utf8",
+        column="uniprot_id",
     )
     assert gtd.run_uniprot(args) == 0
     df = pd.read_csv(output_csv, dtype=str)
     assert df.loc[0, "uniprot_id"] == "Q99558"
+
+
+def test_run_uniprot_with_mapping(tmp_path: Path) -> None:
+    input_csv = tmp_path / "uids.csv"
+    input_csv.write_text("mapping_uniprot_id\nQ99558\n", encoding="utf8")
+    output_csv = tmp_path / "uniprot.csv"
+    args = argparse.Namespace(
+        input_csv=input_csv,
+        output_csv=output_csv,
+        data_dir=DATA_DIR / "uniprot",
+        sep=",",
+        encoding="utf8",
+        column="mapping_uniprot_id",
+    )
+    assert gtd.run_uniprot(args) == 0
+    df = pd.read_csv(output_csv, dtype=str)
+    assert df.loc[0, "mapping_uniprot_id"] == "Q99558"
 
 
 def test_run_iuphar(tmp_path: Path) -> None:
@@ -99,6 +118,7 @@ def test_run_all(monkeypatch, tmp_path: Path) -> None:
         family_csv=DATA_DIR / "_IUPHAR_family.csv",
         sep=",",
         encoding="utf8",
+        uniprot_column="uniprot_id",
     )
     assert gtd.run_all(args) == 0
     df = pd.read_csv(output_csv, dtype=str)

--- a/tests/test_get_assay_data.py
+++ b/tests/test_get_assay_data.py
@@ -26,7 +26,9 @@ def test_read_ids(tmp_path: Path) -> None:
 
 
 def test_run_chembl(monkeypatch, tmp_path: Path) -> None:
-    monkeypatch.setattr(cl, "get_assays", lambda ids, chunk_size=5: _sample_assay_df())
+    monkeypatch.setattr(
+        cl, "get_assays_all", lambda ids, chunk_size=5: _sample_assay_df()
+    )
     input_csv = tmp_path / "assays.csv"
     input_csv.write_text("assay_chembl_id\nCHEMBL123\n", encoding="utf8")
     output_csv = tmp_path / "out.csv"

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -25,7 +25,9 @@ def _sample_pub_df() -> pd.DataFrame:
 
 def test_run_all_merges_types(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(cl, "get_documents", lambda ids, chunk_size=5: _sample_doc_df())
-    monkeypatch.setattr(gdd, "fetch_pubmed_records", lambda pmids, sleep: _sample_pub_df())
+    monkeypatch.setattr(
+        gdd, "fetch_pubmed_records", lambda pmids, sleep, workers, batch_size: _sample_pub_df()
+    )
 
     input_csv = tmp_path / "docs.csv"
     input_csv.write_text("chembl_id\nCHEMBL100\n", encoding="utf8")
@@ -39,6 +41,8 @@ def test_run_all_merges_types(monkeypatch, tmp_path: Path) -> None:
         encoding="utf8",
         chunk_size=5,
         sleep=0.0,
+        workers=1,
+        batch_size=100,
     )
     assert gdd.run_all(args) == 0
     df = pd.read_csv(output_csv, dtype=str)

--- a/tests/test_uniprot_id_mapping.py
+++ b/tests/test_uniprot_id_mapping.py
@@ -1,0 +1,37 @@
+import json
+import json
+from pathlib import Path
+
+import pytest
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from library.uniprot_id_mapping import map_chembl_to_uniprot
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return json.dumps(self._payload).encode()
+
+
+def test_map_chembl_to_uniprot_success():
+    responses = [
+        {"jobId": "1"},
+        {"jobStatus": "RUNNING"},
+        {"results": [{"to": {"primaryAccession": "Q99558"}}]},
+    ]
+    def opener(url, data=None):
+        return FakeResponse(responses.pop(0))
+
+    accession = map_chembl_to_uniprot("CHEMBL123", opener=opener)
+    assert accession == "Q99558"

--- a/tests/test_uniprot_library.py
+++ b/tests/test_uniprot_library.py
@@ -28,8 +28,9 @@ def test_collect_info_downloads_missing(tmp_path: Path, monkeypatch) -> None:
     sample = json.loads((DATA_DIR / f"{uid}.json").read_text(encoding="utf8"))
 
     def fake_fetch(uniprot_id: str) -> dict:
-        assert uniprot_id == uid
-        return sample
+        if uniprot_id == uid:
+            return sample
+        return {}
 
     monkeypatch.setattr(uu, "fetch_uniprot", fake_fetch)
     data_dir = tmp_path / "uniprot"


### PR DESCRIPTION
## Summary
- add UniProt ID Mapping client to retrieve accessions for ChEMBL targets
- support choosing between `uniprot_id` and `mapping_uniprot_id` when processing UniProt data
- cover new mapping logic and CLI features with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2fd00ab10832495a1b0ba47ae7747