### PR TITLE
Refactor config to typed dataclasses

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+import pytest
+
+from chembl2uniprot.config import load_and_validate_config
+
+DATA_DIR = Path(__file__).parent / "data"
+SCHEMA = DATA_DIR / "config.schema.json"
+CONFIG = DATA_DIR / "config.yaml"
+
+
+def _write_config(tmp_path: Path, text: str) -> Path:
+    cfg = tmp_path / "config.yaml"
+    schema = tmp_path / "config.schema.json"
+    cfg.write_text(text)
+    schema.write_text(SCHEMA.read_text())
+    return cfg
+
+
+def test_invalid_type(tmp_path: Path) -> None:
+    cfg_text = CONFIG.read_text().replace("rps: 1000", 'rps: "fast"')
+    cfg = _write_config(tmp_path, cfg_text)
+    with pytest.raises(ValueError):
+        load_and_validate_config(cfg)
+
+
+def test_invalid_value(tmp_path: Path) -> None:
+    cfg_text = CONFIG.read_text().replace("timeout_sec: 30", "timeout_sec: 0")
+    cfg = _write_config(tmp_path, cfg_text)
+    with pytest.raises(ValueError):
+        load_and_validate_config(cfg)


### PR DESCRIPTION
## Summary
- replace untyped config wrapper with nested dataclasses and builder
- use typed config attributes throughout mapping logic
- add tests for invalid config types and values

## Testing
- `black chembl2uniprot tests`
- `ruff check chembl2uniprot tests`
- `mypy chembl2uniprot tests`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7abcc52f48324b2996b036967c9b9