### PR TITLE
Enforce strict mypy checking and add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev]
+      - name: Black
+        run: black --check .
+      - name: Ruff
+        run: ruff check .
+      - name: Mypy
+        run: mypy --strict chembl2uniprot tests
+      - name: Pytest
+        run: pytest

--- a/chembl2uniprot/config.py
+++ b/chembl2uniprot/config.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, cast
 import json
 import logging
 
@@ -33,13 +33,17 @@ class Config:
 
 
 def _read_yaml(path: Path) -> Dict[str, Any]:
-    with path.open("r", encoding="utf-8") as fh:
-        return yaml.safe_load(fh) or {}
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError("Configuration file must contain a mapping at the root")
+    return cast(Dict[str, Any], data)
 
 
 def _read_json(path: Path) -> Dict[str, Any]:
-    with path.open("r", encoding="utf-8") as fh:
-        return json.load(fh)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Schema file must contain a JSON object at the root")
+    return cast(Dict[str, Any], data)
 
 
 def load_and_validate_config(

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,1 @@
 [mypy]
-ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,8 @@ dev = [
     "black",
     "ruff",
     "mypy",
+    "types-PyYAML",
+    "types-jsonschema",
+    "pandas-stubs",
+    "types-requests",
 ]

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 import pandas as pd
 import pytest
+from requests_mock.mocker import Mocker
 
 from chembl2uniprot import map_chembl_to_uniprot
 
@@ -30,7 +31,7 @@ def read_output(path: Path) -> list[str | None]:
 
 
 def test_success_mapping_single_batch(
-    requests_mock, tmp_path: Path, config_path: Path
+    requests_mock: Mocker, tmp_path: Path, config_path: Path
 ) -> None:
     run_url = "https://rest.uniprot.org/idmapping/run"
     status_url = "https://rest.uniprot.org/idmapping/status/123"
@@ -52,7 +53,7 @@ def test_success_mapping_single_batch(
     assert read_output(out) == ["P1", "P2"]
 
 
-def test_no_mapping(requests_mock, tmp_path: Path, config_path: Path) -> None:
+def test_no_mapping(requests_mock: Mocker, tmp_path: Path, config_path: Path) -> None:
     run_url = "https://rest.uniprot.org/idmapping/run"
     status_url = "https://rest.uniprot.org/idmapping/status/1"
     results_url = "https://rest.uniprot.org/idmapping/results/1"
@@ -64,7 +65,9 @@ def test_no_mapping(requests_mock, tmp_path: Path, config_path: Path) -> None:
     assert read_output(out) == [None, None]
 
 
-def test_multiple_mappings(requests_mock, tmp_path: Path, config_path: Path) -> None:
+def test_multiple_mappings(
+    requests_mock: Mocker, tmp_path: Path, config_path: Path
+) -> None:
     run_url = "https://rest.uniprot.org/idmapping/run"
     status_url = "https://rest.uniprot.org/idmapping/status/1"
     results_url = "https://rest.uniprot.org/idmapping/results/1"
@@ -85,7 +88,7 @@ def test_multiple_mappings(requests_mock, tmp_path: Path, config_path: Path) -> 
 
 
 def test_retry_on_server_error(
-    requests_mock, tmp_path: Path, config_path: Path
+    requests_mock: Mocker, tmp_path: Path, config_path: Path
 ) -> None:
     run_url = "https://rest.uniprot.org/idmapping/run"
     status_url = "https://rest.uniprot.org/idmapping/status/1"


### PR DESCRIPTION
## Summary
- remove ignore_missing_imports setting
- add missing type hints and payload validation
- run mypy --strict in CI

## Testing
- `black .`
- `ruff check .`
- `mypy --strict chembl2uniprot tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7ac0b8ea48324bba4c0688a112648