### PR TITLE
Add algorithm notes and detailed docstrings

### DIFF
--- a/chembl2uniprot/__main__.py
+++ b/chembl2uniprot/__main__.py
@@ -17,6 +17,15 @@ from .mapping import map_chembl_to_uniprot
 
 
 def main(argv: list[str] | None = None) -> None:
+    """Entry point for the command line interface.
+
+    Parameters
+    ----------
+    argv:
+        Optional list of command line arguments.  When ``None`` the arguments
+        are taken from :data:`sys.argv`.
+    """
+
     parser = argparse.ArgumentParser(description="Map ChEMBL IDs to UniProt IDs")
     parser.add_argument("--input", required=True, help="Path to input CSV file")
     parser.add_argument("--output", required=False, help="Path to output CSV file")


### PR DESCRIPTION
## Summary
- document CLI entry point and add Algorithm Notes for mapping logic
- clarify rate limiting utility and mapping workflow with detailed docstrings

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Argument 2 to "_poll_job" has incompatible type "dict[str, Collection[str]]"; expected "UniprotConfig")*
- `mypy chembl2uniprot`
- `pytest` *(fails: FileNotFoundError: No such file or directory: '/workspace/ChEMBL_dataAcquisition/tests/data/config.yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68c7af48cab88324a1fe84ea5b9364d3