### PR TITLE
Add CLI options for log level and CSV handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,22 +52,37 @@ mypy.ini             # Type checker configuration
 
 ## Usage
 
-1. Prepare a configuration file (see ``tests/data/config.yaml`` for an example).
+1. Prepare a configuration file (see ``tests/data/config/valid.yaml`` for an example).
 2. Run the mapper:
 
 ```bash
-python -m chembl2uniprot --input input.csv --output output.csv --config config.yaml
+python -m chembl2uniprot \
+    --input input.csv \
+    --output output.csv \
+    --config config.yaml \
+    --log-level INFO \
+    --sep , \
+    --encoding utf-8
 ```
 
-When ``--output`` is omitted the result is written next to ``input.csv`` with the
-suffix ``_with_uniprot.csv``.  The mapped UniProt identifiers are stored in a new
-column defined by the configuration file.
+Flags ``--log-level``, ``--sep`` and ``--encoding`` are optional and default to
+``INFO``, ``,``, and ``utf-8`` respectively.  When ``--output`` is omitted the
+result is written next to ``input.csv`` with the suffix ``_with_uniprot.csv``.
+The mapped UniProt identifiers are stored in a new column defined by the
+configuration file.
 
 The mapping function can also be used programmatically:
 
 ```python
 from chembl2uniprot import map_chembl_to_uniprot
-map_chembl_to_uniprot("input.csv", "output.csv", "config.yaml")
+map_chembl_to_uniprot(
+    "input.csv",
+    "output.csv",
+    "config.yaml",
+    log_level="DEBUG",
+    sep=";",
+    encoding="utf-8",
+)
 ```
 
 ## Testing and quality checks

--- a/chembl2uniprot/__main__.py
+++ b/chembl2uniprot/__main__.py
@@ -5,7 +5,13 @@ Example
 Run the mapper on ``input.csv`` using ``config.yaml`` and write the result to
 ``output.csv``::
 
-    python -m chembl2uniprot --input input.csv --output output.csv --config config.yaml
+    python -m chembl2uniprot \
+        --input input.csv \
+        --output output.csv \
+        --config config.yaml \
+        --log-level INFO \
+        --sep , \
+        --encoding utf-8
 """
 
 from __future__ import annotations
@@ -16,6 +22,11 @@ from pathlib import Path
 from .mapping import map_chembl_to_uniprot
 
 
+DEFAULT_LOG_LEVEL = "INFO"
+DEFAULT_SEP = ","
+DEFAULT_ENCODING = "utf-8"
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Map ChEMBL IDs to UniProt IDs")
     parser.add_argument("--input", required=True, help="Path to input CSV file")
@@ -23,12 +34,30 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--config", default="config.yaml", help="Path to YAML configuration file"
     )
+    parser.add_argument(
+        "--log-level",
+        default=DEFAULT_LOG_LEVEL,
+        help="Logging level (e.g. INFO, DEBUG)",
+    )
+    parser.add_argument(
+        "--sep",
+        default=DEFAULT_SEP,
+        help="CSV field separator",
+    )
+    parser.add_argument(
+        "--encoding",
+        default=DEFAULT_ENCODING,
+        help="File encoding for CSV input and output",
+    )
     args = parser.parse_args(argv)
 
     output = map_chembl_to_uniprot(
         input_csv_path=Path(args.input),
         output_csv_path=Path(args.output) if args.output else None,
         config_path=Path(args.config),
+        log_level=args.log_level,
+        sep=args.sep,
+        encoding=args.encoding,
     )
     print(output)
 

--- a/chembl2uniprot/mapping.py
+++ b/chembl2uniprot/mapping.py
@@ -228,6 +228,10 @@ def map_chembl_to_uniprot(
     input_csv_path: str | Path,
     output_csv_path: str | Path | None = None,
     config_path: str | Path = "config.yaml",
+    *,
+    log_level: str | None = None,
+    sep: str | None = None,
+    encoding: str | None = None,
 ) -> Path:
     """Map ChEMBL identifiers in ``input_csv_path`` to UniProt IDs.
 
@@ -241,6 +245,14 @@ def map_chembl_to_uniprot(
     config_path:
         Path to the YAML configuration file which is validated against
         ``config.schema.json``.
+    log_level:
+        Logging verbosity (e.g. ``"INFO"`` or ``"DEBUG"``). When ``None`` the
+        value from the configuration file is used.
+    sep:
+        CSV field separator. Falls back to the configuration when ``None``.
+    encoding:
+        Character encoding for both reading and writing CSV files. Falls back to
+        the configuration when ``None``.
 
     Returns
     -------
@@ -251,7 +263,13 @@ def map_chembl_to_uniprot(
 
     cfg: Config = load_and_validate_config(config_path)
 
-    logging.basicConfig(level=getattr(logging, cfg.logging.level.upper()))
+    # Allow overriding the configuration with function arguments
+    log_level = log_level or cfg.logging.level
+    sep = sep or cfg.io.csv.separator
+    encoding_in = encoding or cfg.io.input.encoding
+    encoding_out = encoding or cfg.io.output.encoding
+
+    logging.basicConfig(level=getattr(logging, log_level.upper()))
 
     input_csv_path = Path(input_csv_path)
     if output_csv_path is None:
@@ -260,9 +278,6 @@ def map_chembl_to_uniprot(
         )
     output_csv_path = Path(output_csv_path)
 
-    sep = cfg.io.csv.separator
-    encoding_in = cfg.io.input.encoding
-    encoding_out = cfg.io.output.encoding
     chembl_col = cfg.columns.chembl_id
     out_col = cfg.columns.uniprot_out
     delimiter = cfg.io.csv.multivalue_delimiter

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,8 +6,9 @@ import pytest
 from chembl2uniprot.config import load_and_validate_config
 
 DATA_DIR = Path(__file__).parent / "data"
-SCHEMA = DATA_DIR / "config.schema.json"
-CONFIG = DATA_DIR / "config.yaml"
+CONFIG_DIR = DATA_DIR / "config"
+SCHEMA = CONFIG_DIR / "config.schema.json"
+CONFIG = CONFIG_DIR / "valid.yaml"
 
 
 def _write_config(tmp_path: Path, text: str) -> Path:


### PR DESCRIPTION
## Summary
- add `--log-level`, `--sep`, and `--encoding` flags to CLI with sensible defaults
- allow `map_chembl_to_uniprot` to override logging level and CSV formatting
- document new options and usage examples in README

## Testing
- `ruff check .`
- `black --check .`
- `python -m mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7af91aea48324a4150379de4fe25f