### PR TITLE
Enable strict mypy checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install .[dev]
+      - name: Lint
+        run: |
+          ruff check .
+          black --check .
+      - name: Type check
+        run: mypy --strict chembl2uniprot
+      - name: Test
+        run: pytest

--- a/chembl2uniprot/config.py
+++ b/chembl2uniprot/config.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, cast
 import json
 import logging
 
@@ -163,12 +163,14 @@ def _build_config(data: Dict[str, Any]) -> Config:
 
 def _read_yaml(path: Path) -> Dict[str, Any]:
     with path.open("r", encoding="utf-8") as fh:
-        return yaml.safe_load(fh) or {}
+        data = yaml.safe_load(fh) or {}
+    return cast(Dict[str, Any], data)
 
 
 def _read_json(path: Path) -> Dict[str, Any]:
     with path.open("r", encoding="utf-8") as fh:
-        return json.load(fh)
+        data = json.load(fh)
+    return cast(Dict[str, Any], data)
 
 
 def load_and_validate_config(

--- a/chembl2uniprot/mapping.py
+++ b/chembl2uniprot/mapping.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Sequence
+from typing import Any, Dict, Iterable, List, Sequence, cast
 import hashlib
 import json
 import logging
@@ -93,7 +93,7 @@ def _request_with_retry(
     rate_limiter: RateLimiter,
     max_attempts: int,
     backoff: float,
-    **kwargs,
+    **kwargs: Any,
 ) -> requests.Response:
     """Perform an HTTP request with retry and rate limiting."""
 
@@ -142,7 +142,7 @@ def _start_job(
         data=payload,
     )
     try:
-        return resp.json()
+        return cast(Dict[str, Any], resp.json())
     except json.JSONDecodeError:
         LOGGER.debug("Unparseable response from %s: %s", url, resp.text)
         raise

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,1 @@
 [mypy]
-ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,8 @@ dev = [
     "black",
     "ruff",
     "mypy",
+    "pandas-stubs",
+    "types-PyYAML",
+    "types-jsonschema",
+    "types-requests",
 ]


### PR DESCRIPTION
## Summary
- remove global `ignore_missing_imports`
- add missing type hints and casts for strict mypy
- run `mypy --strict` in CI

## Testing
- `ruff check .`
- `black --check .`
- `mypy --strict chembl2uniprot`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7b2b0070c8324972d64c8ec74d205