### PR TITLE
feat: support legacy target chembl column

### DIFF
--- a/library/chembl2uniprot/config.py
+++ b/library/chembl2uniprot/config.py
@@ -138,6 +138,13 @@ def _build_config(data: Dict[str, Any]) -> Config:
         Raw dictionary read from the YAML configuration file.  Assumes the
         structure matches the JSON schema.
     """
+    # Accept legacy configuration where ``target_chembl_id`` was used instead
+    # of the generic ``chembl_id`` key.  This keeps backwards compatibility
+    # with older configuration files while standardising on ``chembl_id``
+    # internally.
+    columns_cfg = dict(data["columns"])
+    if "chembl_id" not in columns_cfg and "target_chembl_id" in columns_cfg:
+        columns_cfg["chembl_id"] = columns_cfg.pop("target_chembl_id")
 
     io_cfg = IOConfig(
         input=EncodingConfig(**data["io"]["input"]),
@@ -153,7 +160,7 @@ def _build_config(data: Dict[str, Any]) -> Config:
     )
     return Config(
         io=io_cfg,
-        columns=ColumnsConfig(**data["columns"]),
+        columns=ColumnsConfig(**columns_cfg),
         uniprot=uniprot_cfg,
         network=NetworkConfig(**data["network"]),
         batch=BatchConfig(**data["batch"]),

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -29,11 +29,16 @@
     },
     "columns": {
       "type": "object",
-      "required": ["chembl_id", "uniprot_out"],
       "properties": {
         "chembl_id": { "type": "string", "minLength": 1 },
+        "target_chembl_id": { "type": "string", "minLength": 1 },
         "uniprot_out": { "type": "string", "minLength": 1 }
-      }
+      },
+      "required": ["uniprot_out"],
+      "anyOf": [
+        {"required": ["chembl_id"]},
+        {"required": ["target_chembl_id"]}
+      ]
     },
     "uniprot": {
       "type": "object",

--- a/tests/data/config/alias.yaml
+++ b/tests/data/config/alias.yaml
@@ -7,7 +7,7 @@ io:
     separator: ","
     multivalue_delimiter: "|"
 columns:
-  chembl_id: "target_chembl_id"
+  target_chembl_id: "chembl_id"
   uniprot_out: "mapped_uniprot_id"
 uniprot:
   base_url: "https://rest.uniprot.org"

--- a/tests/data/config/config.schema.json
+++ b/tests/data/config/config.schema.json
@@ -29,11 +29,16 @@
     },
     "columns": {
       "type": "object",
-      "required": ["chembl_id", "uniprot_out"],
       "properties": {
         "chembl_id": { "type": "string", "minLength": 1 },
+        "target_chembl_id": { "type": "string", "minLength": 1 },
         "uniprot_out": { "type": "string", "minLength": 1 }
-      }
+      },
+      "required": ["uniprot_out"],
+      "anyOf": [
+        {"required": ["chembl_id"]},
+        {"required": ["target_chembl_id"]}
+      ]
     },
     "uniprot": {
       "type": "object",

--- a/tests/data/csv/empty.csv
+++ b/tests/data/csv/empty.csv
@@ -1,1 +1,1 @@
-chembl_id
+target_chembl_id

--- a/tests/data/csv/input.csv
+++ b/tests/data/csv/input.csv
@@ -1,3 +1,3 @@
-chembl_id
+target_chembl_id
 CHEMBL1
 CHEMBL2

--- a/tests/data/csv/input_single.csv
+++ b/tests/data/csv/input_single.csv
@@ -1,2 +1,2 @@
-chembl_id
+target_chembl_id
 CHEMBL1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ def test_cli_uses_default_config(tmp_path: Path) -> None:
     )
     assert out.exists()
     # Output should contain CSV header only
-    assert out.read_text().strip() == "chembl_id,mapped_uniprot_id"
+    assert out.read_text().strip() == "target_chembl_id,mapped_uniprot_id"
     # CLI prints output path
     assert result.stdout.strip() == str(out)
 
@@ -60,7 +60,7 @@ def test_cli_runs(tmp_path: Path) -> None:
     )
     assert out.exists()
     # Output should contain CSV header only
-    assert out.read_text().strip() == "chembl_id,mapped_uniprot_id"
+    assert out.read_text().strip() == "target_chembl_id,mapped_uniprot_id"
     # CLI prints output path
     assert result.stdout.strip() == str(out)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,3 +31,10 @@ def test_invalid_value(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path, cfg_text)
     with pytest.raises(ValueError):
         load_and_validate_config(cfg)
+
+
+def test_target_chembl_id_alias() -> None:
+    """Configuration accepts ``target_chembl_id`` as an alias."""
+    cfg = CONFIG_DIR / "alias.yaml"
+    loaded = load_and_validate_config(cfg)
+    assert loaded.columns.chembl_id == "chembl_id"


### PR DESCRIPTION
## Summary
- allow `target_chembl_id` as legacy alias for `chembl_id` in configuration
- relax JSON schema to accept either `chembl_id` or `target_chembl_id`
- update CSV fixtures and tests for new column name and add dedicated alias test

## Testing
- `python -m black tests/test_cli.py tests/test_config.py library/chembl2uniprot/config.py`
- `ruff check library/chembl2uniprot/config.py tests/test_config.py tests/test_cli.py`
- `mypy library/chembl2uniprot/config.py tests/test_config.py tests/test_cli.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7ba97e44c8324889d4312a4cc5d47