### PR TITLE
Raise HTTP errors for invalid UniProt requests

### DIFF
--- a/library/chembl2uniprot/mapping.py
+++ b/library/chembl2uniprot/mapping.py
@@ -112,7 +112,9 @@ def _request_with_retry(
             resp.raise_for_status()
         return resp
 
-    return _do_request()
+    resp = _do_request()
+    resp.raise_for_status()
+    return resp
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -14,7 +14,7 @@ from chembl2uniprot.config import (
     RetryConfig,
     UniprotConfig,
 )
-from chembl2uniprot.mapping import RateLimiter, _poll_job
+from chembl2uniprot.mapping import RateLimiter, _poll_job, _request_with_retry
 
 DATA_DIR = Path(__file__).parent / "data"
 CONFIG_DIR = DATA_DIR / "config"
@@ -144,6 +144,22 @@ def test_poll_job_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
             RateLimiter(0),
             timeout=0.1,
             retry_cfg=RetryConfig(max_attempts=1, backoff_sec=0),
+        )
+
+
+def test_request_with_retry_raises_for_client_error(requests_mock) -> None:
+    """Client errors should raise ``HTTPError`` without retrying."""
+
+    url = "https://rest.uniprot.org/idmapping/run"
+    requests_mock.post(url, status_code=404)
+    with pytest.raises(requests.HTTPError):
+        _request_with_retry(
+            "post",
+            url,
+            timeout=1,
+            rate_limiter=RateLimiter(0),
+            max_attempts=1,
+            backoff=0,
         )
 
 


### PR DESCRIPTION
## Summary
- Surface UniProt client errors immediately by calling `raise_for_status` after each request
- Add regression test expecting `HTTPError` on 4xx responses

## Testing
- `black library/chembl2uniprot/mapping.py tests/test_mapping.py`
- `ruff check library/chembl2uniprot/mapping.py tests/test_mapping.py`
- `mypy library/chembl2uniprot/mapping.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7c67bd27483249bcb02000a840d1c