### PR TITLE
Rate limit applied to each retry attempt

### DIFF
--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -14,7 +14,7 @@ from chembl2uniprot.config import (
     RetryConfig,
     UniprotConfig,
 )
-from chembl2uniprot.mapping import RateLimiter, _poll_job
+from chembl2uniprot.mapping import RateLimiter, _poll_job, _request_with_retry
 
 DATA_DIR = Path(__file__).parent / "data"
 CONFIG_DIR = DATA_DIR / "config"
@@ -168,3 +168,44 @@ def test_deterministic_csv(requests_mock, tmp_path: Path, config_path: Path) -> 
     map_chembl_to_uniprot(INPUT_SINGLE, out2, config_path)
 
     assert out1.read_bytes() == out2.read_bytes()
+
+
+class CountingLimiter(RateLimiter):
+    """Rate limiter that counts how often ``wait`` is invoked."""
+
+    def __init__(self) -> None:
+        super().__init__(rps=0)
+        self.calls = 0
+
+    def wait(self) -> None:  # pragma: no cover - simple counter
+        self.calls += 1
+
+
+def test_rate_limiter_called_on_retries(requests_mock) -> None:
+    url = "https://example.org"
+    limiter = CountingLimiter()
+    requests_mock.get(url, [{"status_code": 500}, {"status_code": 200}])
+    _request_with_retry(
+        "get",
+        url,
+        timeout=1,
+        rate_limiter=limiter,
+        max_attempts=2,
+        backoff=0,
+    )
+    assert limiter.calls == 2
+
+
+def test_rate_limiter_single_request(requests_mock) -> None:
+    url = "https://example.org"
+    limiter = CountingLimiter()
+    requests_mock.get(url, status_code=200)
+    _request_with_retry(
+        "get",
+        url,
+        timeout=1,
+        rate_limiter=limiter,
+        max_attempts=2,
+        backoff=0,
+    )
+    assert limiter.calls == 1


### PR DESCRIPTION
## Summary
- call `RateLimiter.wait` within `_request_with_retry`'s `_do_request` to limit every network attempt
- add regression tests covering rate limiter behaviour for retries and single requests

## Testing
- `black library/chembl2uniprot/mapping.py tests/test_mapping.py`
- `ruff check library/chembl2uniprot/mapping.py tests/test_mapping.py`
- `mypy library/chembl2uniprot/mapping.py tests/test_mapping.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7c6793b2c8324abc899d12753e63b