### PR TITLE
feat: add robust CLI for UniProt enrichment

### DIFF
--- a/scripts/uniprot_enrich_main.py
+++ b/scripts/uniprot_enrich_main.py
@@ -1,22 +1,89 @@
-"""CLI for enriching UniProt annotations in-place."""
+"""Command line interface for :mod:`uniprot_enrich`.
+
+This script enriches a CSV file containing UniProt accessions with additional
+annotations fetched from the UniProt REST API.  By default the input file is
+modified in-place, but an explicit output path can be provided to write the
+enriched data to a new file.
+
+Examples
+--------
+Enrich ``data.csv`` in-place::
+
+    python scripts/uniprot_enrich_main.py --input data.csv
+
+Write the enriched result to ``out.csv`` and use a semicolon as list
+separator::
+
+    python scripts/uniprot_enrich_main.py \
+        --input data.csv \
+        --output out.csv \
+        --sep ';'
+"""
+
+from __future__ import annotations
 
 import argparse
 import logging
+import shutil
+import sys
+from pathlib import Path
 
-from library.uniprot_enrich import enrich_uniprot
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB_DIR = ROOT / "library"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from uniprot_enrich import enrich_uniprot  # noqa: E402
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Enrich UniProt data in CSV")
-    parser.add_argument("--input", required=True, help="Path to input CSV")
-    parser.add_argument("--sep", default="|", help="List separator")
+DEFAULT_LOG_LEVEL = "INFO"
+DEFAULT_SEP = "|"
+DEFAULT_ENCODING = "utf-8"
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the command line interface.
+
+    Parameters
+    ----------
+    argv:
+        Optional list of command line arguments. When ``None`` the arguments
+        are taken from :data:`sys.argv`.
+    """
+
+    parser = argparse.ArgumentParser(description="Enrich UniProt data in a CSV file")
+    parser.add_argument("--input", required=True, help="Path to input CSV file")
     parser.add_argument(
-        "--log-level", default="INFO", help="Logging level (e.g. INFO, DEBUG)"
+        "--output",
+        required=False,
+        help="Optional path to write enriched CSV. Defaults to in-place update.",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--log-level", default=DEFAULT_LOG_LEVEL, help="Logging level (e.g. INFO)"
+    )
+    parser.add_argument("--sep", default=DEFAULT_SEP, help="List separator")
+    parser.add_argument(
+        "--encoding",
+        default=DEFAULT_ENCODING,
+        help="File encoding for CSV input and output",
+    )
+    args = parser.parse_args(argv)
+
     logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
-    enrich_uniprot(args.input, list_sep=args.sep)
+
+    input_path = Path(args.input)
+    if args.output:
+        output_path = Path(args.output)
+        # ``enrich_uniprot`` modifies files in-place; copy the input if the user
+        # requested a separate output file.
+        shutil.copy(input_path, output_path)
+        enrich_uniprot(str(output_path), list_sep=args.sep)
+        print(output_path)
+    else:
+        enrich_uniprot(str(input_path), list_sep=args.sep)
+        print(input_path)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
     main()

--- a/tests/test_uniprot_cli.py
+++ b/tests/test_uniprot_cli.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+from uniprot_enrich import enrich_uniprot
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "uniprot_enrich_main.py"
+DATA_FILE = Path(__file__).parent / "data" / "uniprot_sample.csv"
+
+
+def test_uniprot_cli(tmp_path: Path) -> None:
+    """CLI should enrich input and write to provided output path."""
+
+    inp = tmp_path / "input.csv"
+    inp.write_text(DATA_FILE.read_text())
+    out = tmp_path / "out.csv"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--input",
+            str(inp),
+            "--output",
+            str(out),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.strip() == str(out)
+    assert out.exists()
+    df = pd.read_csv(out, dtype=str).fillna("")
+    expected_cols = ["uniprot_id", "other"] + list(
+        enrich_uniprot.__globals__["OUTPUT_COLUMNS"]
+    )
+    assert list(df.columns) == expected_cols


### PR DESCRIPTION
## Summary
- ensure uniprot enrichment CLI works when run as a script
- support optional output paths and richer CLI flags
- add tests for the uniprot enrichment CLI

## Testing
- `ruff check .`
- `black --check scripts/uniprot_enrich_main.py tests/test_uniprot_cli.py`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7c8d9e4a8832497f19e56af2325f8