### PR TITLE
Add CLI to retrieve ChEMBL target data

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,12 +42,13 @@ library/
     chembl2uniprot/      # Configuration and mapping utilities
         __init__.py
         config.py
-        mapping.py
+    mapping.py
 schemas/
     default_config.yaml  # Built-in configuration
     config.schema.json   # JSON schema for configuration validation
 scripts/
-    chembl2uniprot_main.py  # CLI entry point
+    chembl2uniprot_main.py  # ChEMBL to UniProt mapper
+    get_target_data_main.py # ChEMBL target downloader
 tests/
     data/            # Sample config and CSV files used in tests
     test_mapping.py  # Unit tests
@@ -93,6 +94,22 @@ map_chembl_to_uniprot(
     encoding="utf-8",
 )
 ```
+
+### Downloading target metadata
+
+Fetch basic information for targets listed in ``targets.csv`` and write the
+result to ``targets_dump.csv``:
+
+```bash
+python scripts/get_target_data_main.py \
+    --input targets.csv \
+    --output targets_dump.csv \
+    --column target_chembl_id \
+    --log-level INFO
+```
+
+Nested fields in the output are encoded as JSON strings to ensure
+deterministic, machine-readable results.
 
 ## Testing and quality checks
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,17 @@
+# Usage
+
+## get_target_data_main.py
+
+Download target metadata from ChEMBL for identifiers listed in a CSV file:
+
+```bash
+python scripts/get_target_data_main.py \
+    --input data/targets.csv \
+    --output out/targets_dump.csv \
+    --column target_chembl_id \
+    --log-level INFO
+```
+
+The input file must contain a column with ChEMBL target identifiers. Duplicate
+and empty values are ignored. The resulting CSV contains one row per unique
+identifier with nested fields serialised as JSON strings.

--- a/library/chembl2uniprot/config.py
+++ b/library/chembl2uniprot/config.py
@@ -165,7 +165,6 @@ def _build_config(data: Dict[str, Any]) -> Config:
     # of ``chembl_id`` and standardise on the modern key.
     columns_cfg = _normalise_column_aliases(dict(data["columns"]), drop_legacy=True)
 
-
     io_cfg = IOConfig(
         input=EncodingConfig(**data["io"]["input"]),
         output=EncodingConfig(**data["io"]["output"]),

--- a/library/chembl_targets.py
+++ b/library/chembl_targets.py
@@ -1,0 +1,191 @@
+"""Utilities for downloading and normalising ChEMBL target records.
+
+The :func:`fetch_targets` function orchestrates the retrieval of target
+information for a list of ChEMBL identifiers and returns a :class:`pandas.DataFrame`
+ready for serialisation.  The implementation favours determinism: list-like
+fields are sorted and serialised either as JSON arrays or pipe-delimited strings
+depending on the configuration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import logging
+from typing import Any, Dict, List, Sequence
+
+import pandas as pd
+
+from http_client import HttpClient
+
+LOGGER = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration dataclass
+
+
+@dataclass
+class TargetConfig:
+    """Configuration controlling data acquisition."""
+
+    base_url: str = "https://www.ebi.ac.uk/chembl/api/data"
+    timeout_sec: float = 30.0
+    max_retries: int = 3
+    rps: float = 2.0
+    output_encoding: str = "utf-8-sig"
+    output_sep: str = ","
+    list_format: str = "json"  # "json" or "pipe"
+
+
+# ---------------------------------------------------------------------------
+# Normalisation helpers
+
+
+def normalise_ids(ids: Sequence[str]) -> List[str]:
+    """Return cleaned and deduplicated ChEMBL identifiers.
+
+    Parameters
+    ----------
+    ids:
+        Raw sequence of identifiers possibly containing duplicates or empty
+        entries.
+    """
+
+    cleaned = []
+    seen = set()
+    for raw in ids:
+        if raw is None:
+            continue
+        cid = raw.strip().upper()
+        if not cid:
+            continue
+        if cid not in seen:
+            seen.add(cid)
+            cleaned.append(cid)
+    return cleaned
+
+
+# ---------------------------------------------------------------------------
+# Data extraction utilities
+
+
+def _serialize(obj: Any, *, list_format: str) -> str:
+    """Serialise ``obj`` deterministically according to ``list_format``."""
+
+    if isinstance(obj, list) and list_format == "pipe":
+        return "|".join(json.dumps(x, ensure_ascii=False, sort_keys=True) for x in obj)
+    return json.dumps(obj, ensure_ascii=False, sort_keys=True)
+
+
+def _extract_components(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    comps = []
+    for comp in payload.get("target_components", []) or []:
+        comps.append(
+            {
+                "component_id": comp.get("component_id"),
+                "accession": comp.get("accession"),
+                "component_type": comp.get("component_type"),
+                "component_description": comp.get("component_description"),
+            }
+        )
+    comps.sort(key=lambda c: (c.get("accession") or ""))
+    return comps
+
+
+def _extract_cross_refs(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    refs: List[Dict[str, Any]] = []
+    for ref in payload.get("cross_references", []) or []:
+        refs.append({"xref_db": ref.get("xref_db"), "xref_id": ref.get("xref_id")})
+    for comp in payload.get("target_components", []) or []:
+        for ref in comp.get("target_component_xrefs", []) or []:
+            refs.append(
+                {"xref_db": ref.get("xref_src_db"), "xref_id": ref.get("xref_id")}
+            )
+    refs.sort(key=lambda r: (r.get("xref_db") or "", r.get("xref_id") or ""))
+    return refs
+
+
+def _extract_gene_symbols(payload: Dict[str, Any]) -> List[str]:
+    genes: set[str] = set()
+    for comp in payload.get("target_components", []) or []:
+        for syn in comp.get("target_component_synonyms", []) or []:
+            stype = (syn.get("syn_type") or "").upper()
+            if "GENE_SYMBOL" in stype:
+                genes.add(syn.get("component_synonym", ""))
+    return sorted(g for g in genes if g)
+
+
+def _extract_protein_classifications(payload: Dict[str, Any]) -> List[str]:
+    classifications: List[str] = []
+    pc = payload.get("protein_classification")
+    while pc:
+        name = pc.get("pref_name") or pc.get("protein_classification")
+        if name:
+            classifications.insert(0, name)
+        pc = pc.get("parent") if isinstance(pc.get("parent"), dict) else None
+    return classifications
+
+
+# ---------------------------------------------------------------------------
+# Public API
+
+
+def fetch_targets(ids: Sequence[str], cfg: TargetConfig) -> pd.DataFrame:
+    """Fetch ChEMBL targets and return a normalised DataFrame.
+
+    Parameters
+    ----------
+    ids:
+        Sequence of target ChEMBL identifiers.
+    cfg:
+        Configuration governing network behaviour and output formatting.
+    """
+
+    norm_ids = normalise_ids(ids)
+    client = HttpClient(
+        timeout=cfg.timeout_sec, max_retries=cfg.max_retries, rps=cfg.rps
+    )
+    records: List[Dict[str, Any]] = []
+    for chembl_id in norm_ids:
+        url = f"{cfg.base_url.rstrip('/')}/target/{chembl_id}?format=json"
+        try:
+            resp = client.request("get", url)
+            if resp.status_code == 200:
+                payload = resp.json()
+            else:
+                LOGGER.warning(
+                    "Non-200 response for %s: %s", chembl_id, resp.status_code
+                )
+                payload = {}
+        except Exception as exc:  # noqa: BLE001 - we log and continue
+            LOGGER.warning("Failed to fetch %s: %s", chembl_id, exc)
+            payload = {}
+        record = {
+            "target_chembl_id": chembl_id,
+            "pref_name": payload.get("pref_name"),
+            "target_type": payload.get("target_type"),
+            "organism": payload.get("organism"),
+            "target_components": _serialize(
+                _extract_components(payload), list_format=cfg.list_format
+            ),
+            "protein_classifications": _serialize(
+                _extract_protein_classifications(payload), list_format=cfg.list_format
+            ),
+            "cross_references": _serialize(
+                _extract_cross_refs(payload), list_format=cfg.list_format
+            ),
+            "gene_symbol_list": _serialize(
+                _extract_gene_symbols(payload), list_format=cfg.list_format
+            ),
+        }
+        records.append(record)
+    df = pd.DataFrame(records)
+    return df
+
+
+__all__ = [
+    "TargetConfig",
+    "fetch_targets",
+    "normalise_ids",
+]

--- a/library/http_client.py
+++ b/library/http_client.py
@@ -1,0 +1,104 @@
+"""Lightweight HTTP client with retry and rate limiting.
+
+This module exposes the :class:`HttpClient` which wraps :mod:`requests` to
+provide a deterministic network layer for the command line utilities in this
+repository.  The client honours a maximum request rate and performs
+exponential backoff retries on transient errors.
+
+Algorithm Notes
+---------------
+1. Before each outgoing request the client checks the configured requests per
+   second limit and sleeps if necessary.
+2. HTTP errors and network issues are retried up to ``max_retries`` times with
+   exponential backoff.
+3. Responses are returned as :class:`requests.Response` objects and are
+   expected to be decoded by the caller.
+
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import time
+from typing import Any
+
+import requests
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class RateLimiter:
+    """Simple token bucket style rate limiter.
+
+    Parameters
+    ----------
+    rps:
+        Maximum number of requests per second. ``0`` disables rate limiting.
+    last_call:
+        Timestamp of the last request, used to enforce the delay.
+    """
+
+    rps: float
+    last_call: float = 0.0
+
+    def wait(self) -> None:
+        """Sleep just enough to satisfy the configured rate limit."""
+
+        if self.rps <= 0:
+            return
+        interval = 1.0 / self.rps
+        now = time.monotonic()
+        delta = now - self.last_call
+        if delta < interval:
+            time.sleep(interval - delta)
+        self.last_call = time.monotonic()
+
+
+class HttpClient:
+    """Wrapper around :mod:`requests` with retry and rate limiting."""
+
+    def __init__(self, *, timeout: float, max_retries: int, rps: float) -> None:
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.rate_limiter = RateLimiter(rps)
+        self.session = requests.Session()
+
+    def request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
+        """Perform an HTTP request honouring retry and rate limits.
+
+        Parameters
+        ----------
+        method:
+            HTTP verb such as ``"get"`` or ``"post"``.
+        url:
+            Absolute URL to request.
+        **kwargs:
+            Additional arguments passed to :func:`requests.request`.
+        """
+
+        @retry(
+            reraise=True,
+            retry=retry_if_exception_type(requests.RequestException),
+            stop=stop_after_attempt(self.max_retries),
+            wait=wait_exponential(multiplier=1),
+        )
+        def _do_request() -> requests.Response:
+            self.rate_limiter.wait()
+            resp = self.session.request(method, url, timeout=self.timeout, **kwargs)
+            if resp.status_code >= 500:
+                resp.raise_for_status()
+            return resp
+
+        resp = _do_request()
+        return resp
+
+
+__all__ = ["HttpClient", "RateLimiter"]

--- a/scripts/get_target_data_main.py
+++ b/scripts/get_target_data_main.py
@@ -1,0 +1,54 @@
+"""Command line interface for downloading ChEMBL target metadata."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB_DIR = ROOT / "library"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from chembl_targets import TargetConfig, fetch_targets  # noqa: E402
+
+DEFAULT_LOG_LEVEL = "INFO"
+DEFAULT_SEP = ","
+DEFAULT_ENCODING = "utf-8-sig"
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Download ChEMBL target data")
+    parser.add_argument("--input", required=True, help="Input CSV file")
+    parser.add_argument("--output", required=True, help="Output CSV file")
+    parser.add_argument(
+        "--column", default="target_chembl_id", help="Column with target IDs"
+    )
+    parser.add_argument("--log-level", default=DEFAULT_LOG_LEVEL)
+    parser.add_argument("--sep", default=DEFAULT_SEP)
+    parser.add_argument("--encoding", default=DEFAULT_ENCODING)
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    import pandas as pd
+
+    df = pd.read_csv(args.input, sep=args.sep, encoding=args.encoding)
+    if args.column not in df.columns:
+        raise ValueError(f"missing column {args.column}")
+    ids = df[args.column].dropna().astype(str).tolist()
+
+    cfg = TargetConfig(output_sep=args.sep, output_encoding=args.encoding)
+    result = fetch_targets(ids, cfg)
+    result.to_csv(
+        args.output, index=False, sep=cfg.output_sep, encoding=cfg.output_encoding
+    )
+
+    print(args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/uniprot_enrich_main.py
+++ b/scripts/uniprot_enrich_main.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 """Command line interface for :mod:`uniprot_enrich`.
 
 This script enriches a CSV file containing UniProt accessions with additional
@@ -35,7 +36,9 @@ LIB_DIR = ROOT / "library"
 if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
-from uniprot_enrich import enrich_uniprot  # noqa: E402  # type: ignore[reportMissingImports]
+from uniprot_enrich import (
+    enrich_uniprot,
+)  # noqa: E402  # type: ignore[reportMissingImports]
 
 
 DEFAULT_LOG_LEVEL = "INFO"

--- a/tests/test_chembl_targets.py
+++ b/tests/test_chembl_targets.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import requests_mock
+
+from typing import Sequence, cast
+
+from chembl_targets import TargetConfig, fetch_targets, normalise_ids
+
+
+def test_normalise_ids() -> None:
+    raw: list[str | None] = [" CHEMBL1 ", "chembl1", "", None, "CHEMBL2"]
+    assert normalise_ids(cast(Sequence[str], raw)) == ["CHEMBL1", "CHEMBL2"]
+
+
+def test_fetch_targets_parses_fields(requests_mock: requests_mock.Mocker) -> None:
+    cfg = TargetConfig(base_url="http://test", list_format="json", rps=0)
+    url = "http://test/target/CHEMBL612?format=json"
+    payload = {
+        "pref_name": "Example",
+        "target_type": "SINGLE PROTEIN",
+        "organism": "Homo sapiens",
+        "target_components": [
+            {
+                "component_id": 1,
+                "accession": "P12345",
+                "component_type": "PROTEIN",
+                "component_description": "desc",
+                "target_component_synonyms": [
+                    {"component_synonym": "ABC1", "syn_type": "GENE_SYMBOL"}
+                ],
+                "target_component_xrefs": [
+                    {"xref_src_db": "Ensembl", "xref_id": "ENSG000001"},
+                    {"xref_src_db": "UniProt", "xref_id": "P12345"},
+                ],
+            }
+        ],
+        "cross_references": [{"xref_db": "IUPHAR/BPS", "xref_id": "123"}],
+        "protein_classification": {
+            "pref_name": "L5",
+            "parent": {"pref_name": "L4"},
+        },
+    }
+    requests_mock.get(url, json=payload)
+    df = fetch_targets(["CHEMBL612"], cfg)
+    assert list(df.columns) == [
+        "target_chembl_id",
+        "pref_name",
+        "target_type",
+        "organism",
+        "target_components",
+        "protein_classifications",
+        "cross_references",
+        "gene_symbol_list",
+    ]
+    record = df.iloc[0]
+    comps = json.loads(record["target_components"])
+    assert comps[0]["accession"] == "P12345"
+    refs = json.loads(record["cross_references"])
+    assert [r["xref_db"] for r in refs] == ["Ensembl", "IUPHAR/BPS", "UniProt"]
+    genes = json.loads(record["gene_symbol_list"])
+    assert genes == ["ABC1"]
+    classes = json.loads(record["protein_classifications"])
+    assert classes == ["L4", "L5"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,7 +41,6 @@ def test_target_chembl_id_alias() -> None:
     assert loaded.columns.chembl_id == "chembl_id"
 
 
-
 def test_chembl_id_with_legacy_schema(tmp_path: Path) -> None:
     """Config using ``chembl_id`` passes against a schema requiring ``target_chembl_id``."""
     cfg_path = tmp_path / "config.yaml"
@@ -55,4 +54,3 @@ def test_chembl_id_with_legacy_schema(tmp_path: Path) -> None:
     schema_path.write_text(json.dumps(legacy_schema))
     loaded = load_and_validate_config(cfg_path, schema_path)
     assert loaded.columns.chembl_id == "target_chembl_id"
-


### PR DESCRIPTION
## Summary
- implement reusable HTTP client with rate limiting and retries
- add utilities to fetch and normalise ChEMBL target metadata
- provide `get_target_data_main.py` command line interface and usage docs

## Testing
- `ruff check .`
- `black --check .`
- `python -m mypy --config-file mypy.ini .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7cd02b9848324927e3c47bdc3f702