### PR TITLE
feat: add UniProt target dump utility

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,50 @@
+uniprot:
+  base_url: https://rest.uniprot.org/uniprotkb
+  fields:
+    - accession
+    - reviewed
+    - protein_name
+    - gene_primary
+    - gene_names
+    - organism_name
+    - organism_id
+    - lineage
+    - protein_existence
+    - sequence
+    - length
+    - mass
+    - sequence_md5
+    - cc_subcellular_location
+    - cc_function
+    - cc_catalytic_activity
+    - cc_cofactor
+    - cc_pathway
+    - cc_tissue_specificity
+    - cc_expression
+    - ft_signal
+    - ft_transmem
+    - ft_topo_dom
+    - ft_glycosylation
+    - ft_lipidation
+    - ft_disulfid
+    - ft_mod_res
+    - cc_alternative_products
+    - xref_pfam
+    - xref_interpro
+    - xref_pdb
+    - xref_alphafold
+    - xref_chembl
+    - xref_hgnc
+    - xref_ensembl
+    - last_annotation_update
+    - version
+network:
+  timeout_sec: 30
+  max_retries: 3
+rate_limit:
+  rps: 3
+output:
+  sep: ","
+  encoding: utf-8-sig
+  list_format: json
+  include_sequence: false

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,6 +94,23 @@ map_chembl_to_uniprot(
 )
 ```
 
+## UniProt dump
+
+The ``get_uniprot_target_data.py`` script retrieves detailed information about
+UniProt targets.  Provide a CSV file with a column containing UniProt accession
+IDs and obtain a normalised dump with deterministic column ordering.
+
+```bash
+python scripts/get_uniprot_target_data.py \
+    --input ids.csv \
+    --output targets.csv \
+    --column uniprot_id \
+    --include-sequence
+```
+
+The behaviour is configured via ``config.yaml``.  Lists are serialised either as
+JSON (default) or as ``|``-delimited strings depending on the configuration.
+
 ## Testing and quality checks
 
 After making changes, run the following tools:

--- a/library/io_utils.py
+++ b/library/io_utils.py
@@ -1,0 +1,79 @@
+"""Deterministic CSV input/output helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import csv
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Sequence
+
+import pandas as pd
+
+
+@dataclass
+class CsvConfig:
+    sep: str
+    encoding: str
+    list_format: str = "json"
+
+
+def read_ids(path: Path, column: str, cfg: CsvConfig) -> List[str]:
+    """Read a CSV file and return normalised, deduplicated accession IDs."""
+
+    df = pd.read_csv(path, sep=cfg.sep, encoding=cfg.encoding, dtype=str)
+    if column not in df.columns:
+        msg = f"Missing required column '{column}'"
+        raise KeyError(msg)
+    ids = [str(v).strip().upper() for v in df[column].fillna("")]  # type: ignore[arg-type]
+    seen = set()
+    unique: List[str] = []
+    for v in ids:
+        if v and v not in seen:
+            unique.append(v)
+            seen.add(v)
+    return unique
+
+
+def _escape_pipe(value: str) -> str:
+    return value.replace("|", "\\|")
+
+
+def _serialise_list(values: Iterable[Any], list_format: str) -> str:
+    def _normalise(v: Any) -> Any:
+        if isinstance(v, tuple):
+            # Represent domain tuples as id|name or JSON object
+            if list_format == "json":
+                return {"id": v[0], "name": v[1]}
+            return f"{_escape_pipe(str(v[0]))}|{_escape_pipe(str(v[1]))}"
+        return _escape_pipe(str(v)) if list_format == "pipe" else v
+
+    norm = [_normalise(v) for v in values]
+    if list_format == "pipe":
+        return "|".join(str(v) for v in norm)
+    if list_format == "json":
+        return json.dumps(norm, separators=(",", ":"))
+    raise ValueError(f"Unknown list_format: {list_format}")
+
+
+def _serialise_value(value: Any, list_format: str) -> str:
+    if isinstance(value, list):
+        return _serialise_list(value, list_format)
+    return str(value)
+
+
+def write_rows(
+    path: Path,
+    rows: Sequence[Dict[str, Any]],
+    columns: Sequence[str],
+    cfg: CsvConfig,
+) -> None:
+    """Write ``rows`` to ``path`` using deterministic ordering."""
+
+    with path.open("w", encoding=cfg.encoding, newline="") as fh:
+        writer = csv.writer(fh, delimiter=cfg.sep)
+        writer.writerow(columns)
+        for row in rows:
+            writer.writerow(
+                [_serialise_value(row.get(col, ""), cfg.list_format) for col in columns]
+            )

--- a/library/uniprot_client.py
+++ b/library/uniprot_client.py
@@ -1,0 +1,147 @@
+"""HTTP client for retrieving UniProtKB entries.
+
+The client implements rate limiting and retry logic as configured via
+``config.yaml``.  Only a subset of the UniProt REST API is exposed, namely
+fetching individual records by accession using the ``/search`` endpoint with an
+explicit list of return fields.
+
+Algorithm Notes
+---------------
+1. Build the request URL for a given accession with the required fields.
+2. Honour the configured rate limit before each HTTP request.
+3. Retry transient HTTP errors with exponential backoff.
+4. Return the parsed JSON document or ``None`` when no result is found.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import logging
+import time
+from typing import Any, Dict, Optional
+
+import requests
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class NetworkConfig:
+    """Network related settings.
+
+    Parameters
+    ----------
+    timeout_sec:
+        Request timeout in seconds.
+    max_retries:
+        Maximum number of retry attempts for transient failures.
+    backoff_sec:
+        Exponential backoff multiplier in seconds.
+    """
+
+    timeout_sec: float
+    max_retries: int
+    backoff_sec: float = 1.0
+
+
+@dataclass
+class RateLimitConfig:
+    """Rate limiting configuration."""
+
+    rps: float
+
+
+@dataclass
+class UniProtClient:
+    """Thin wrapper around the UniProtKB REST API."""
+
+    base_url: str
+    fields: str
+    network: NetworkConfig
+    rate_limit: RateLimitConfig
+    session: requests.Session = field(default_factory=requests.Session)
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple initialisation
+        self.base_url = self.base_url.rstrip("/")
+        self._last_call = 0.0
+
+    # ------------------------------------------------------------------
+    def _wait_rate_limit(self) -> None:
+        if self.rate_limit.rps <= 0:
+            return
+        interval = 1.0 / self.rate_limit.rps
+        now = time.monotonic()
+        delta = now - self._last_call
+        if delta < interval:
+            time.sleep(interval - delta)
+        self._last_call = time.monotonic()
+
+    def _request(self, url: str, params: Dict[str, str]) -> Optional[requests.Response]:
+        @retry(
+            reraise=True,
+            retry=retry_if_exception_type(requests.RequestException),
+            stop=stop_after_attempt(self.network.max_retries),
+            wait=wait_exponential(multiplier=self.network.backoff_sec),
+        )
+        def _do_request() -> requests.Response:
+            self._wait_rate_limit()
+            LOGGER.debug("GET %s params=%s", url, params)
+            resp = self.session.get(
+                url, params=params, timeout=self.network.timeout_sec
+            )
+            if resp.status_code >= 500:
+                resp.raise_for_status()
+            return resp
+
+        try:
+            resp = _do_request()
+        except requests.RequestException as exc:  # pragma: no cover - network failure
+            LOGGER.warning("Request failed for %s: %s", url, exc)
+            return None
+        if resp.status_code == 404:
+            return None
+        if resp.status_code != 200:  # pragma: no cover - unexpected codes
+            LOGGER.warning("Unexpected response %s for %s", resp.status_code, url)
+            return None
+        return resp
+
+    def fetch(self, accession: str) -> Optional[Dict[str, Any]]:
+        """Fetch a UniProt entry for ``accession``.
+
+        Parameters
+        ----------
+        accession:
+            UniProt accession to retrieve.
+
+        Returns
+        -------
+        Optional[Dict[str, Any]]
+            Parsed JSON document or ``None`` when not found.
+        """
+
+        params = {
+            "query": f"accession:{accession}",
+            "format": "json",
+            "fields": self.fields,
+            "size": "1",
+        }
+        url = f"{self.base_url}/search"
+        resp = self._request(url, params)
+        if not resp:
+            return None
+        try:
+            data = resp.json()
+        except json.JSONDecodeError:  # pragma: no cover - API guarantees JSON
+            LOGGER.warning("Invalid JSON for %s", accession)
+            return None
+        results = data.get("results", [])
+        if not results:
+            return None
+        return results[0]

--- a/library/uniprot_normalize.py
+++ b/library/uniprot_normalize.py
@@ -1,0 +1,316 @@
+"""Utilities to normalise UniProtKB JSON records into tabular form."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Dict, List, Tuple
+
+ORDERED_COLUMNS_BASE = [
+    "uniprot_id",
+    "entry_type",
+    "protein_recommended_name",
+    "protein_alternative_names",
+    "gene_primary",
+    "gene_synonyms",
+    "organism_name",
+    "taxon_id",
+    "lineage_superkingdom",
+    "lineage_phylum",
+    "lineage_class",
+    "lineage_order",
+    "lineage_family",
+    "protein_existence",
+    "sequence_length",
+    "sequence_mass",
+    "sequence_md5",
+    # "sequence" optionally inserted here
+    "subcellular_location",
+    "function",
+    "catalytic_activity",
+    "cofactor",
+    "pathway",
+    "tissue_specificity",
+    "expression",
+    "features_signal_peptide",
+    "features_transmembrane",
+    "features_topology",
+    "ptm_glycosylation",
+    "ptm_lipidation",
+    "ptm_disulfide_bond",
+    "ptm_modified_residue",
+    "isoform_ids",
+    "isoform_names",
+    "domains_pfam",
+    "domains_interpro",
+    "3d_pdb_ids",
+    "alphafold_id",
+    "xref_chembl_target",
+    "xref_hgnc",
+    "xref_ensembl",
+    "last_annotation_update",
+    "entry_version",
+]
+
+
+def output_columns(include_sequence: bool) -> List[str]:
+    cols = ORDERED_COLUMNS_BASE.copy()
+    if include_sequence:
+        cols.insert(17, "sequence")
+    return cols
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+
+
+def _get(entry: Dict[str, Any], *path: str) -> Any:
+    cur: Any = entry
+    for p in path:
+        if isinstance(cur, dict) and p in cur:
+            cur = cur[p]
+        else:
+            return None
+    return cur
+
+
+def _loc_to_range(feature: Dict[str, Any]) -> str:
+    loc = feature.get("location", {})
+    start = _get(loc, "start", "value")
+    end = _get(loc, "end", "value")
+    if start is None and end is None:
+        return ""
+    if start == end:
+        return str(start)
+    return f"{start}-{end}"
+
+
+def _collect_comment(entry: Dict[str, Any], ctype: str) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    for c in entry.get("comments", []):
+        if c.get("commentType") == ctype:
+            items.append(c)
+    return items
+
+
+def _collect_cross_refs(entry: Dict[str, Any], db: str) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for xref in entry.get("uniProtKBCrossReferences", []):
+        if xref.get("database") == db:
+            out.append(xref)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Normalisation
+
+
+def normalize_entry(
+    entry: Dict[str, Any], include_sequence: bool = False
+) -> Dict[str, Any]:
+    """Normalise a raw UniProt record into a flat dictionary.
+
+    Parameters
+    ----------
+    entry:
+        Parsed JSON document as returned by the UniProt API.
+    include_sequence:
+        Whether to include the full amino acid sequence.
+    """
+
+    result: Dict[str, Any] = {c: "" for c in output_columns(include_sequence)}
+
+    result["uniprot_id"] = entry.get("primaryAccession", "")
+    result["entry_type"] = entry.get("entryType", "").lower()
+
+    # Protein names -----------------------------------------------------
+    prot = entry.get("proteinDescription", {})
+    rec = prot.get("recommendedName", {})
+    result["protein_recommended_name"] = _get(rec, "fullName", "value") or ""
+    alt_names: List[str] = []
+    for sn in rec.get("shortNames", []):
+        val = sn.get("value")
+        if val:
+            alt_names.append(val)
+    for alt in prot.get("alternativeNames", []):
+        val = _get(alt, "fullName", "value")
+        if val:
+            alt_names.append(val)
+        for sn in alt.get("shortNames", []):
+            val = sn.get("value")
+            if val:
+                alt_names.append(val)
+    result["protein_alternative_names"] = sorted(set(alt_names))
+
+    # Gene names --------------------------------------------------------
+    genes = entry.get("genes", [])
+    if genes:
+        g0 = genes[0]
+        result["gene_primary"] = _get(g0, "geneName", "value") or ""
+        syns = [s.get("value") for s in g0.get("synonyms", []) if s.get("value")]
+        result["gene_synonyms"] = sorted(set(syns))
+
+    # Organism ----------------------------------------------------------
+    org = entry.get("organism", {})
+    result["organism_name"] = org.get("scientificName", "")
+    result["taxon_id"] = str(org.get("taxonId", ""))
+    lineage = org.get("lineage", [])
+    levels = [
+        "lineage_superkingdom",
+        "lineage_phylum",
+        "lineage_class",
+        "lineage_order",
+        "lineage_family",
+    ]
+    for lvl, name in zip(levels, lineage):
+        result[lvl] = name
+
+    # Protein existence -------------------------------------------------
+    result["protein_existence"] = entry.get("proteinExistence", "")
+
+    seq = entry.get("sequence", {})
+    result["sequence_length"] = seq.get("length", "")
+    result["sequence_mass"] = seq.get("molWeight", "")
+    md5 = seq.get("sequenceChecksum")
+    if not md5 and seq.get("value"):
+        md5 = hashlib.md5(seq["value"].encode()).hexdigest()
+    result["sequence_md5"] = md5 or ""
+    if include_sequence:
+        result["sequence"] = seq.get("value", "")
+
+    # Comments ----------------------------------------------------------
+    sub_loc = []
+    for c in _collect_comment(entry, "SUBCELLULAR_LOCATION"):
+        for loc in c.get("subcellularLocations", []):
+            val = _get(loc, "location", "value")
+            if val:
+                sub_loc.append(val)
+    result["subcellular_location"] = sorted(set(sub_loc))
+
+    funcs = []
+    for c in _collect_comment(entry, "FUNCTION"):
+        for txt in c.get("texts", []):
+            val = txt.get("value")
+            if val:
+                funcs.append(val)
+    result["function"] = " ".join(funcs)
+
+    catal = []
+    for c in _collect_comment(entry, "CATALYTIC_ACTIVITY"):
+        name = _get(c, "reaction", "name")
+        if name:
+            catal.append(name)
+    result["catalytic_activity"] = sorted(set(catal))
+
+    cof = []
+    for c in _collect_comment(entry, "COFACTOR"):
+        for cf in c.get("cofactors", []):
+            val = _get(cf, "name", "value")
+            if val:
+                cof.append(val)
+    result["cofactor"] = sorted(set(cof))
+
+    path = []
+    for c in _collect_comment(entry, "PATHWAY"):
+        for p in c.get("pathways", []):
+            val = p.get("value")
+            if val:
+                path.append(val)
+    result["pathway"] = sorted(set(path))
+
+    ts = []
+    for c in _collect_comment(entry, "TISSUE_SPECIFICITY"):
+        for txt in c.get("texts", []):
+            val = txt.get("value")
+            if val:
+                ts.append(val)
+    result["tissue_specificity"] = " ".join(ts)
+
+    expr = []
+    for c in _collect_comment(entry, "EXPRESSION"):
+        for txt in c.get("texts", []):
+            val = txt.get("value")
+            if val:
+                expr.append(val)
+    result["expression"] = " ".join(expr)
+
+    # Features ----------------------------------------------------------
+    feat_sig: List[Tuple[int, str]] = []
+    feat_tm: List[Tuple[int, str]] = []
+    feat_topo: List[Tuple[int, str]] = []
+    glyco: List[Tuple[int, str]] = []
+    lipid: List[Tuple[int, str]] = []
+    disul: List[Tuple[int, str]] = []
+    modres: List[Tuple[int, str]] = []
+    for feat in entry.get("features", []):
+        ftype = feat.get("type", "")
+        rng = _loc_to_range(feat)
+        start = _get(feat, "location", "start", "value") or 0
+        desc = feat.get("description", "")
+        item = (int(start), f"{rng}:{desc}" if desc else rng)
+        if ftype == "Signal peptide":
+            feat_sig.append(item)
+        elif ftype == "Transmembrane":
+            feat_tm.append(item)
+        elif ftype == "Topological domain":
+            feat_topo.append(item)
+        elif ftype == "Glycosylation":
+            glyco.append(item)
+        elif ftype == "Lipidation":
+            lipid.append(item)
+        elif ftype == "Disulfide bond":
+            disul.append(item)
+        elif ftype == "Modified residue":
+            modres.append(item)
+    result["features_signal_peptide"] = [v for _, v in sorted(feat_sig)]
+    result["features_transmembrane"] = [v for _, v in sorted(feat_tm)]
+    result["features_topology"] = [v for _, v in sorted(feat_topo)]
+    result["ptm_glycosylation"] = [v for _, v in sorted(glyco)]
+    result["ptm_lipidation"] = [v for _, v in sorted(lipid)]
+    result["ptm_disulfide_bond"] = [v for _, v in sorted(disul)]
+    result["ptm_modified_residue"] = [v for _, v in sorted(modres)]
+
+    # Isoforms ---------------------------------------------------------
+    iso_ids: List[str] = []
+    iso_names: List[str] = []
+    for c in _collect_comment(entry, "ALTERNATIVE_PRODUCTS"):
+        for iso in c.get("isoforms", []):
+            iso_id = iso.get("id")
+            iso_name = _get(iso, "name", "value")
+            if iso_id:
+                iso_ids.append(iso_id)
+            if iso_name:
+                iso_names.append(iso_name)
+    result["isoform_ids"] = sorted(set(iso_ids))
+    result["isoform_names"] = sorted(set(iso_names))
+
+    # Cross references -------------------------------------------------
+    def _domains(db: str) -> List[Tuple[str, str]]:
+        pairs: List[Tuple[str, str]] = []
+        for ref in _collect_cross_refs(entry, db):
+            acc = ref.get("id", "")
+            name = ""
+            for prop in ref.get("properties", []):
+                if prop.get("key") in {"Entry name", "entry name"}:
+                    name = prop.get("value", "")
+            pairs.append((acc, name))
+        return sorted(pairs, key=lambda x: x[0])
+
+    result["domains_pfam"] = _domains("Pfam")
+    result["domains_interpro"] = _domains("InterPro")
+    pdb_ids = [ref.get("id", "") for ref in _collect_cross_refs(entry, "PDB")]
+    result["3d_pdb_ids"] = sorted(set(pdb_ids))
+    af = _collect_cross_refs(entry, "AlphaFoldDB")
+    result["alphafold_id"] = af[0].get("id", "") if af else ""
+    chembl = _collect_cross_refs(entry, "ChEMBL")
+    result["xref_chembl_target"] = chembl[0].get("id", "") if chembl else ""
+    hgnc = _collect_cross_refs(entry, "HGNC")
+    result["xref_hgnc"] = hgnc[0].get("id", "") if hgnc else ""
+    ensembl_ids = [ref.get("id", "") for ref in _collect_cross_refs(entry, "Ensembl")]
+    result["xref_ensembl"] = sorted(set(ensembl_ids))
+
+    # Entry audit ------------------------------------------------------
+    audit = entry.get("entryAudit", {})
+    result["last_annotation_update"] = audit.get("lastAnnotationUpdateDate", "")
+    result["entry_version"] = audit.get("entryVersion", "")
+
+    return result

--- a/scripts/get_uniprot_target_data.py
+++ b/scripts/get_uniprot_target_data.py
@@ -1,0 +1,106 @@
+"""Retrieve and normalise UniProtKB target information.
+
+Example
+-------
+>>> python scripts/get_uniprot_target_data.py --input data.csv --output out.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB_DIR = ROOT / "library"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from io_utils import CsvConfig, read_ids, write_rows  # noqa: E402
+from uniprot_client import NetworkConfig, RateLimitConfig, UniProtClient  # noqa: E402
+from uniprot_normalize import normalize_entry, output_columns  # noqa: E402
+
+DEFAULT_INPUT = "input.csv"
+DEFAULT_OUTPUT = "output_input_{date}.csv"
+DEFAULT_COLUMN = "uniprot_id"
+DEFAULT_LOG_LEVEL = "INFO"
+DEFAULT_SEP = ","
+DEFAULT_ENCODING = "utf-8"
+
+
+def _default_output(input_path: Path) -> Path:
+    date = datetime.now().strftime("%Y%m%d")
+    return input_path.with_name(DEFAULT_OUTPUT.format(date=date))
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Fetch UniProt target data")
+    parser.add_argument("--input", default=DEFAULT_INPUT, help="Input CSV path")
+    parser.add_argument("--output", help="Output CSV path")
+    parser.add_argument(
+        "--column", default=DEFAULT_COLUMN, help="Column with UniProt IDs"
+    )
+    parser.add_argument("--sep", default=DEFAULT_SEP, help="CSV separator")
+    parser.add_argument("--encoding", default=DEFAULT_ENCODING, help="File encoding")
+    parser.add_argument(
+        "--include-sequence", action="store_true", help="Include full protein sequence"
+    )
+    parser.add_argument(
+        "--log-level",
+        default=DEFAULT_LOG_LEVEL,
+        help="Logging level (INFO, DEBUG, ... )",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    config = yaml.safe_load((ROOT / "config.yaml").read_text())
+    uniprot_cfg = config.get("uniprot", {})
+    network_cfg = config.get("network", {})
+    rate_cfg = config.get("rate_limit", {})
+    output_cfg = config.get("output", {})
+
+    list_format = output_cfg.get("list_format", "json")
+    include_seq = args.include_sequence or output_cfg.get("include_sequence", False)
+
+    csv_cfg = CsvConfig(sep=args.sep, encoding=args.encoding, list_format=list_format)
+
+    client = UniProtClient(
+        base_url=uniprot_cfg.get("base_url", "https://rest.uniprot.org/uniprotkb"),
+        fields=",".join(uniprot_cfg.get("fields", [])),
+        network=NetworkConfig(
+            timeout_sec=network_cfg.get("timeout_sec", 30),
+            max_retries=network_cfg.get("max_retries", 3),
+            backoff_sec=1.0,
+        ),
+        rate_limit=RateLimitConfig(rps=rate_cfg.get("rps", 3)),
+    )
+
+    input_path = Path(args.input)
+    output_path = Path(args.output) if args.output else _default_output(input_path)
+
+    accessions = read_ids(input_path, args.column, csv_cfg)
+    rows: List[Dict[str, str]] = []
+    cols = output_columns(include_seq)
+
+    for acc in accessions:
+        data = client.fetch(acc)
+        if data is None:
+            logging.warning("No entry for %s", acc)
+            row = {c: "" for c in cols}
+            row["uniprot_id"] = acc
+        else:
+            row = normalize_entry(data, include_seq)
+        rows.append(row)
+
+    write_rows(output_path, rows, cols, csv_cfg)
+    print(output_path)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/uniprot_enrich_main.py
+++ b/scripts/uniprot_enrich_main.py
@@ -35,7 +35,9 @@ LIB_DIR = ROOT / "library"
 if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
-from uniprot_enrich import enrich_uniprot  # noqa: E402  # type: ignore[reportMissingImports]
+from uniprot_enrich import (  # noqa: E402
+    enrich_uniprot,
+)  # type: ignore[reportMissingImports]
 
 
 DEFAULT_LOG_LEVEL = "INFO"

--- a/tests/data/uniprot_entry.json
+++ b/tests/data/uniprot_entry.json
@@ -1,0 +1,102 @@
+{
+  "primaryAccession": "P12345",
+  "entryType": "Reviewed",
+  "proteinDescription": {
+    "recommendedName": {
+      "fullName": {"value": "Sample protein"}
+    },
+    "alternativeNames": [
+      {"fullName": {"value": "Alt B"}},
+      {"fullName": {"value": "Alt A"}}
+    ]
+  },
+  "genes": [
+    {
+      "geneName": {"value": "GENE1"},
+      "synonyms": [{"value": "G1"}, {"value": "GENEONE"}]
+    }
+  ],
+  "organism": {
+    "scientificName": "Homo sapiens",
+    "taxonId": 9606,
+    "lineage": [
+      "Eukaryota",
+      "Metazoa",
+      "Chordata",
+      "Mammalia",
+      "Primates",
+      "Hominidae"
+    ]
+  },
+  "proteinExistence": "Evidence at protein level",
+  "sequence": {
+    "value": "MSTNPKPQR",
+    "length": 9,
+    "molWeight": 999,
+    "sequenceChecksum": "abcd"
+  },
+  "comments": [
+    {
+      "commentType": "SUBCELLULAR_LOCATION",
+      "subcellularLocations": [
+        {"location": {"value": "Cytoplasm"}},
+        {"location": {"value": "Membrane"}}
+      ]
+    },
+    {
+      "commentType": "FUNCTION",
+      "texts": [{"value": "Does something."}]
+    },
+    {
+      "commentType": "CATALYTIC_ACTIVITY",
+      "reaction": {"name": "A = B"}
+    },
+    {
+      "commentType": "COFACTOR",
+      "cofactors": [{"name": {"value": "Zn2+"}}, {"name": {"value": "Mg2+"}}]
+    },
+    {
+      "commentType": "PATHWAY",
+      "pathways": [{"value": "Glycolysis"}]
+    },
+    {
+      "commentType": "TISSUE_SPECIFICITY",
+      "texts": [{"value": "Expressed in liver"}]
+    },
+    {
+      "commentType": "EXPRESSION",
+      "texts": [{"value": "Up-regulated"}]
+    },
+    {
+      "commentType": "ALTERNATIVE_PRODUCTS",
+      "isoforms": [
+        {"name": {"value": "Isoform 2"}, "id": "P12345-2"},
+        {"name": {"value": "Isoform 1"}, "id": "P12345-1"}
+      ]
+    }
+  ],
+  "features": [
+    {"type": "Transmembrane", "location": {"start": {"value": 20}, "end": {"value": 40}}},
+    {"type": "Signal peptide", "location": {"start": {"value": 1}, "end": {"value": 10}}},
+    {"type": "Topological domain", "location": {"start": {"value": 41}, "end": {"value": 60}}},
+    {"type": "Glycosylation", "location": {"start": {"value": 5}, "end": {"value": 5}}, "description": "N-linked"},
+    {"type": "Lipidation", "location": {"start": {"value": 80}, "end": {"value": 80}}},
+    {"type": "Disulfide bond", "location": {"start": {"value": 100}, "end": {"value": 200}}},
+    {"type": "Modified residue", "location": {"start": {"value": 150}, "end": {"value": 150}}, "description": "Phosphoserine"}
+  ],
+  "uniProtKBCrossReferences": [
+    {"database": "Pfam", "id": "PF00002", "properties": [{"key": "Entry name", "value": "DomainB"}]},
+    {"database": "Pfam", "id": "PF00001", "properties": [{"key": "Entry name", "value": "DomainA"}]},
+    {"database": "InterPro", "id": "IPR0001", "properties": [{"key": "Entry name", "value": "InterProA"}]},
+    {"database": "PDB", "id": "2DEF"},
+    {"database": "PDB", "id": "1ABC"},
+    {"database": "AlphaFoldDB", "id": "P12345"},
+    {"database": "ChEMBL", "id": "CHEMBL123"},
+    {"database": "HGNC", "id": "HGNC:123"},
+    {"database": "Ensembl", "id": "ENSP000001"}
+  ],
+  "entryAudit": {
+    "lastAnnotationUpdateDate": "2020-01-01",
+    "entryVersion": 3
+  }
+}

--- a/tests/test_uniprot_dump.py
+++ b/tests/test_uniprot_dump.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import requests_mock
+
+from uniprot_normalize import normalize_entry, output_columns
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "get_uniprot_target_data.py"
+
+
+def _load_sample() -> dict:
+    return json.loads((ROOT / "tests/data/uniprot_entry.json").read_text())
+
+
+def test_normalize_entry_sorts_lists() -> None:
+    entry = _load_sample()
+    data = normalize_entry(entry, include_sequence=False)
+    assert data["protein_alternative_names"] == ["Alt A", "Alt B"]
+    assert data["isoform_ids"] == ["P12345-1", "P12345-2"]
+    assert data["domains_pfam"] == [("PF00001", "DomainA"), ("PF00002", "DomainB")]
+    assert data["features_signal_peptide"] == ["1-10"]
+    assert data["features_transmembrane"] == ["20-40"]
+    assert data["ptm_modified_residue"] == ["150:Phosphoserine"]
+
+
+def test_output_columns_include_sequence() -> None:
+    cols = output_columns(True)
+    assert "sequence" in cols
+    assert cols.index("sequence") == 17
+
+
+def test_cli_writes_output(tmp_path: Path) -> None:
+    from importlib.machinery import SourceFileLoader
+
+    module = SourceFileLoader("get_uniprot_target_data", str(SCRIPT_PATH)).load_module()
+
+    inp = tmp_path / "inp.csv"
+    inp.write_text("uniprot_id\nP12345\np12345\nP00000\n")
+    out = tmp_path / "out.csv"
+
+    sample = _load_sample()
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://rest.uniprot.org/uniprotkb/search",
+            [
+                {"json": {"results": [sample]}},
+                {"json": {"results": []}},
+            ],
+        )
+        module.main(
+            [
+                "--input",
+                str(inp),
+                "--output",
+                str(out),
+                "--sep",
+                ",",
+                "--encoding",
+                "utf-8",
+            ]
+        )
+    df = pd.read_csv(out, dtype=str).fillna("")
+    cols = output_columns(False)
+    assert list(df.columns) == cols
+    assert len(df) == 2
+    assert df.loc[0, "uniprot_id"] == "P12345"
+    assert df.loc[1, "uniprot_id"] == "P00000"


### PR DESCRIPTION
## Summary
- add reusable HTTP client with rate limiting and retries
- normalise UniProt JSON into a stable tabular schema
- provide CLI to fetch UniProt target metadata from accession lists

## Testing
- `ruff check .`
- `python -m mypy --config-file mypy.ini .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7ce1242a08324b9db72b8313ddc50