### PR TITLE
Add HGNC mapping utilities

### DIFF
--- a/library/hgnc_client.py
+++ b/library/hgnc_client.py
@@ -1,0 +1,272 @@
+"""HGNC lookup utilities.
+
+Algorithm Notes
+---------------
+1. Load YAML configuration specifying HGNC endpoint, network and output options.
+2. Read the input CSV containing UniProt accessions and validate required columns.
+3. Deduplicate the accessions and query the HGNC API for each unique identifier.
+4. For matched genes, request the recommended protein name from UniProt.
+5. Emit a CSV mapping each input accession to gene and protein metadata.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, List
+import logging
+import time
+
+import pandas as pd
+import requests
+import yaml
+
+LOGGER = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration dataclasses
+
+
+@dataclass
+class HGNCServiceConfig:
+    """Endpoint configuration for HGNC REST API."""
+
+    base_url: str
+
+
+@dataclass
+class NetworkConfig:
+    """Network behaviour settings."""
+
+    timeout_sec: float
+    max_retries: int
+
+
+@dataclass
+class RateLimitConfig:
+    """Rate limiting parameters."""
+
+    rps: float
+
+
+@dataclass
+class OutputConfig:
+    """CSV output formatting options."""
+
+    sep: str
+    encoding: str
+
+
+@dataclass
+class Config:
+    """Aggregated application configuration."""
+
+    hgnc: HGNCServiceConfig
+    network: NetworkConfig
+    rate_limit: RateLimitConfig
+    output: OutputConfig
+
+
+def load_config(path: str | Path) -> Config:
+    """Load configuration from ``path``."""
+
+    with Path(path).open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    return Config(
+        hgnc=HGNCServiceConfig(**data["hgnc"]),
+        network=NetworkConfig(**data["network"]),
+        rate_limit=RateLimitConfig(**data["rate_limit"]),
+        output=OutputConfig(**data["output"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting and HTTP helpers
+
+
+@dataclass
+class RateLimiter:
+    """Simple time-based rate limiter."""
+
+    rps: float
+    last_call: float = 0.0
+
+    def wait(self) -> None:
+        """Sleep as necessary to satisfy the configured rate limit."""
+
+        if self.rps <= 0:
+            return
+        interval = 1.0 / self.rps
+        now = time.monotonic()
+        delta = now - self.last_call
+        if delta < interval:
+            time.sleep(interval - delta)
+        self.last_call = time.monotonic()
+
+
+# ---------------------------------------------------------------------------
+# HGNC and UniProt clients
+
+
+@dataclass
+class HGNCRecord:
+    """Mapping information for a single UniProt accession."""
+
+    uniprot_id: str
+    hgnc_id: str
+    gene_symbol: str
+    gene_name: str
+    protein_name: str
+
+
+class HGNCClient:
+    """Minimal client for querying the HGNC API."""
+
+    def __init__(self, cfg: Config) -> None:
+        self.cfg = cfg
+        self.rate_limiter = RateLimiter(cfg.rate_limit.rps)
+
+    def _request(self, url: str) -> requests.Response:
+        """Perform ``GET`` request with retry and rate limiting."""
+
+        last_exc: Exception | None = None
+        for attempt in range(self.cfg.network.max_retries):
+            self.rate_limiter.wait()
+            try:
+                resp = requests.get(
+                    url,
+                    timeout=self.cfg.network.timeout_sec,
+                    headers={"Accept": "application/json"},
+                )
+            except requests.RequestException as exc:  # network error
+                last_exc = exc
+            else:
+                if resp.status_code >= 500:
+                    last_exc = requests.HTTPError(
+                        f"Server error {resp.status_code} for {url}"
+                    )
+                else:
+                    return resp
+            time.sleep(2**attempt)
+        assert last_exc is not None
+        raise last_exc
+
+    def _fetch_protein_name(self, uniprot_id: str) -> str:
+        """Return recommended protein name from UniProt."""
+
+        url = f"https://rest.uniprot.org/uniprotkb/{uniprot_id}.json"
+        try:
+            resp = self._request(url)
+        except Exception:  # pragma: no cover - network errors handled silently
+            return ""
+        if resp.status_code != 200:
+            return ""
+        try:
+            data = resp.json()
+        except ValueError:
+            return ""
+        return (
+            data.get("proteinDescription", {})
+            .get("recommendedName", {})
+            .get("fullName", {})
+            .get("value", "")
+        )
+
+    def fetch(self, uniprot_id: str) -> HGNCRecord:
+        """Lookup ``uniprot_id`` in HGNC and return mapping data."""
+
+        url = f"{self.cfg.hgnc.base_url.rstrip('/')}/{uniprot_id}"
+        resp = self._request(url)
+        if resp.status_code != 200:
+            LOGGER.warning(
+                "HGNC lookup for %s failed with %s", uniprot_id, resp.status_code
+            )
+            return HGNCRecord(uniprot_id, "", "", "", "")
+        try:
+            payload = resp.json()
+        except ValueError:
+            LOGGER.warning("Unparseable HGNC response for %s", uniprot_id)
+            return HGNCRecord(uniprot_id, "", "", "", "")
+        docs = payload.get("response", {}).get("docs", [])
+        if not docs:
+            LOGGER.warning("No HGNC entry for %s", uniprot_id)
+            return HGNCRecord(uniprot_id, "", "", "", "")
+        doc = docs[0]
+        protein = self._fetch_protein_name(uniprot_id)
+        return HGNCRecord(
+            uniprot_id=uniprot_id,
+            hgnc_id=doc.get("hgnc_id", ""),
+            gene_symbol=doc.get("symbol", ""),
+            gene_name=doc.get("name", ""),
+            protein_name=protein,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+
+
+OUTPUT_COLUMNS = ["uniprot_id", "hgnc_id", "gene_symbol", "gene_name", "protein_name"]
+
+
+def map_uniprot_to_hgnc(
+    input_csv_path: Path,
+    output_csv_path: Path | None,
+    config_path: Path,
+    *,
+    column: str = "uniprot_id",
+    sep: str | None = None,
+    encoding: str | None = None,
+    log_level: str = "INFO",
+) -> Path:
+    """Map UniProt accessions to HGNC identifiers.
+
+    Parameters
+    ----------
+    input_csv_path:
+        Path to the CSV file containing UniProt accessions.
+    output_csv_path:
+        Desired path for the output CSV.  When ``None`` a path derived from the
+        input name is used.
+    config_path:
+        Path to the YAML configuration file.
+    column:
+        Name of the column in ``input_csv_path`` holding UniProt accessions.
+    sep, encoding:
+        Optional overrides for CSV formatting.  Defaults come from the
+        configuration file.
+    log_level:
+        Logging verbosity level (e.g. ``INFO`` or ``DEBUG``).
+
+    Returns
+    -------
+    Path
+        Path to the written CSV file.
+    """
+
+    cfg = load_config(config_path)
+    logging.basicConfig(level=getattr(logging, log_level.upper(), logging.INFO))
+    sep = sep or cfg.output.sep
+    encoding = encoding or cfg.output.encoding
+
+    df = pd.read_csv(input_csv_path, sep=sep, encoding=encoding)
+    if column not in df.columns:
+        raise ValueError(f"Missing column '{column}' in input")
+
+    # Preserve order while deduplicating.
+    raw_ids: List[str] = [str(v) for v in df[column]]
+    unique_ids = list(dict.fromkeys(filter(None, raw_ids)))
+
+    client = HGNCClient(cfg)
+    mapping: Dict[str, HGNCRecord] = {uid: client.fetch(uid) for uid in unique_ids}
+
+    rows = [
+        asdict(mapping.get(uid, HGNCRecord(uid, "", "", "", ""))) for uid in raw_ids
+    ]
+    out_df = pd.DataFrame(rows, columns=OUTPUT_COLUMNS)
+
+    if output_csv_path is None:
+        output_csv_path = input_csv_path.with_name(f"hgnc_{input_csv_path.stem}.csv")
+    out_df.to_csv(output_csv_path, sep=sep, encoding=encoding, index=False)
+    return output_csv_path

--- a/schemas/hgnc_config.yaml
+++ b/schemas/hgnc_config.yaml
@@ -1,0 +1,10 @@
+hgnc:
+  base_url: "https://rest.genenames.org/fetch/uniprot_ids"
+network:
+  timeout_sec: 30
+  max_retries: 3
+rate_limit:
+  rps: 3
+output:
+  sep: ","
+  encoding: "utf-8"

--- a/scripts/get_hgnc_by_uniprot.py
+++ b/scripts/get_hgnc_by_uniprot.py
@@ -1,0 +1,57 @@
+"""Command line interface for HGNC lookup by UniProt accession."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB_DIR = ROOT / "library"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from hgnc_client import map_uniprot_to_hgnc  # noqa: E402
+
+DEFAULT_LOG_LEVEL = "INFO"
+DEFAULT_SEP = ","
+DEFAULT_ENCODING = "utf-8"
+DEFAULT_COLUMN = "uniprot_id"
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the HGNC mapping CLI."""
+
+    parser = argparse.ArgumentParser(description="Map UniProt accessions to HGNC IDs")
+    parser.add_argument("--input", default="input.csv", help="Path to input CSV file")
+    parser.add_argument("--output", help="Path to output CSV file", required=False)
+    parser.add_argument(
+        "--column", default=DEFAULT_COLUMN, help="Name of UniProt column"
+    )
+    parser.add_argument(
+        "--config", help="Path to YAML configuration file", required=False
+    )
+    parser.add_argument("--log-level", default=DEFAULT_LOG_LEVEL, help="Logging level")
+    parser.add_argument("--sep", default=DEFAULT_SEP, help="CSV field separator")
+    parser.add_argument("--encoding", default=DEFAULT_ENCODING, help="File encoding")
+    args = parser.parse_args(argv)
+
+    if args.config:
+        config_path = Path(args.config)
+    else:
+        config_path = ROOT / "schemas" / "hgnc_config.yaml"
+
+    out_path = map_uniprot_to_hgnc(
+        input_csv_path=Path(args.input),
+        output_csv_path=Path(args.output) if args.output else None,
+        config_path=config_path,
+        column=args.column,
+        sep=args.sep,
+        encoding=args.encoding,
+        log_level=args.log_level,
+    )
+    print(out_path)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_hgnc_client.py
+++ b/tests/test_hgnc_client.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from hgnc_client import map_uniprot_to_hgnc
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / "schemas" / "hgnc_config.yaml"
+
+
+def _write_csv(path: Path, values: list[str]) -> None:
+    df = pd.DataFrame({"uniprot_id": values})
+    df.to_csv(path, index=False)
+
+
+def _read_output(path: Path) -> list[dict[str, str]]:
+    df = pd.read_csv(path).fillna("")
+    return df.to_dict(orient="records")
+
+
+def test_valid_uniprot_id(requests_mock, tmp_path: Path) -> None:
+    in_csv = tmp_path / "in.csv"
+    _write_csv(in_csv, ["P35348"])
+    out_csv = tmp_path / "out.csv"
+
+    hgnc_url = "https://rest.genenames.org/fetch/uniprot_ids/P35348"
+    requests_mock.get(
+        hgnc_url,
+        json={
+            "response": {
+                "docs": [
+                    {
+                        "symbol": "ADRA1A",
+                        "name": "adrenoceptor alpha 1A",
+                        "hgnc_id": "HGNC:277",
+                    }
+                ]
+            }
+        },
+    )
+    uniprot_url = "https://rest.uniprot.org/uniprotkb/P35348.json"
+    requests_mock.get(
+        uniprot_url,
+        json={
+            "proteinDescription": {
+                "recommendedName": {
+                    "fullName": {"value": "Alpha-1A adrenergic receptor"}
+                }
+            }
+        },
+    )
+
+    map_uniprot_to_hgnc(in_csv, out_csv, CONFIG)
+    assert _read_output(out_csv) == [
+        {
+            "uniprot_id": "P35348",
+            "hgnc_id": "HGNC:277",
+            "gene_symbol": "ADRA1A",
+            "gene_name": "adrenoceptor alpha 1A",
+            "protein_name": "Alpha-1A adrenergic receptor",
+        }
+    ]
+
+
+def test_non_human_uniprot_id(requests_mock, tmp_path: Path) -> None:
+    in_csv = tmp_path / "in.csv"
+    _write_csv(in_csv, ["Q91X72"])
+    out_csv = tmp_path / "out.csv"
+
+    hgnc_url = "https://rest.genenames.org/fetch/uniprot_ids/Q91X72"
+    requests_mock.get(hgnc_url, json={"response": {"docs": []}})
+    uniprot_url = "https://rest.uniprot.org/uniprotkb/Q91X72.json"
+    uniprot_mock = requests_mock.get(uniprot_url, json={})
+
+    map_uniprot_to_hgnc(in_csv, out_csv, CONFIG)
+    assert _read_output(out_csv) == [
+        {
+            "uniprot_id": "Q91X72",
+            "hgnc_id": "",
+            "gene_symbol": "",
+            "gene_name": "",
+            "protein_name": "",
+        }
+    ]
+    assert uniprot_mock.call_count == 0
+
+
+def test_duplicate_input_ids(requests_mock, tmp_path: Path) -> None:
+    in_csv = tmp_path / "in.csv"
+    _write_csv(in_csv, ["P35348", "P35348"])
+    out_csv = tmp_path / "out.csv"
+
+    hgnc_url = "https://rest.genenames.org/fetch/uniprot_ids/P35348"
+    hgnc_mock = requests_mock.get(
+        hgnc_url,
+        json={
+            "response": {
+                "docs": [
+                    {
+                        "symbol": "ADRA1A",
+                        "name": "adrenoceptor alpha 1A",
+                        "hgnc_id": "HGNC:277",
+                    }
+                ]
+            }
+        },
+    )
+    uniprot_url = "https://rest.uniprot.org/uniprotkb/P35348.json"
+    uniprot_mock = requests_mock.get(
+        uniprot_url,
+        json={
+            "proteinDescription": {
+                "recommendedName": {
+                    "fullName": {"value": "Alpha-1A adrenergic receptor"}
+                }
+            }
+        },
+    )
+
+    map_uniprot_to_hgnc(in_csv, out_csv, CONFIG)
+    assert _read_output(out_csv) == [
+        {
+            "uniprot_id": "P35348",
+            "hgnc_id": "HGNC:277",
+            "gene_symbol": "ADRA1A",
+            "gene_name": "adrenoceptor alpha 1A",
+            "protein_name": "Alpha-1A adrenergic receptor",
+        },
+        {
+            "uniprot_id": "P35348",
+            "hgnc_id": "HGNC:277",
+            "gene_symbol": "ADRA1A",
+            "gene_name": "adrenoceptor alpha 1A",
+            "protein_name": "Alpha-1A adrenergic receptor",
+        },
+    ]
+    assert hgnc_mock.call_count == 1
+    assert uniprot_mock.call_count == 1


### PR DESCRIPTION
## Summary
- add HGNC client to fetch gene and protein metadata for UniProt accessions
- expose command-line interface `get_hgnc_by_uniprot.py`
- cover mapping logic and edge cases with unit tests

## Testing
- `black library scripts tests --quiet`
- `ruff check library/hgnc_client.py scripts/get_hgnc_by_uniprot.py tests/test_hgnc_client.py`
- `mypy --ignore-missing-imports --disable-error-code=import-untyped library/hgnc_client.py scripts/get_hgnc_by_uniprot.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7cf42479c8324b9001e76ab4a5015