### PR TITLE
Fix GtoP interaction handling and ortholog imports

### DIFF
--- a/library/orthologs.py
+++ b/library/orthologs.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, Iterable, List, Optional
 
 import requests
 
-from uniprot_client import NetworkConfig, RateLimitConfig
+from .uniprot_client import NetworkConfig, RateLimitConfig
 
 LOGGER = logging.getLogger(__name__)
 

--- a/library/pipeline_targets.py
+++ b/library/pipeline_targets.py
@@ -187,11 +187,9 @@ def run_pipeline(
                     target.get("targetId"), "naturalLigands"
                 )
                 gtop_nat = len(nat or [])
-                params: Dict[str, Any] = {
-                    "affinity": cfg.iuphar.affinity_parameter,
-                }
-                if cfg.iuphar.approved_only is not None:
-                    params["approved"] = str(cfg.iuphar.approved_only).lower()
+                params: Dict[str, Any] = {}
+                if cfg.iuphar.approved_only:
+                    params["approved"] = "true"
                 if cfg.iuphar.primary_target_only:
                     params["primaryTarget"] = "true"
                 inter = gtop_client.fetch_target_endpoint(


### PR DESCRIPTION
## Summary
- avoid unsupported parameters when fetching GtoP target interactions
- handle GtoP API 400 responses gracefully
- fix relative import for internal UniProt client

## Testing
- `ruff check library/orthologs.py library/pipeline_targets.py library/gtop_client.py`
- `mypy library/orthologs.py library/pipeline_targets.py library/gtop_client.py`
- `pytest` *(fails: No mock address for UniProt search and unexpected CLI output)*
- `pytest tests/test_pipeline_targets.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7ebd85ce883248c928f943a61ec5d