### PR TITLE
feat: expand ChEMBL field extraction

### DIFF
--- a/library/pipeline_targets.py
+++ b/library/pipeline_targets.py
@@ -292,10 +292,14 @@ def run_pipeline(
             "protein_name_canonical": (
                 primary.get("protein_recommended_name")
                 if primary
-                else row.get("pref_name", "")
+                else row.get("protein_name_canonical", row.get("pref_name", ""))
             ),
             "protein_name_alt": _serialise_list(
-                primary.get("protein_alternative_names", []) if primary else [],
+                (
+                    primary.get("protein_alternative_names", [])
+                    if primary
+                    else json.loads(row.get("protein_synonym_list") or "[]")
+                ),
                 cfg.list_format,
             ),
             "organism": (
@@ -303,7 +307,11 @@ def run_pipeline(
                 if primary
                 else row.get("organism", "")
             ),
-            "taxon_id": primary.get("taxon_id", "") if primary else "",
+            "taxon_id": (
+                primary.get("taxon_id", row.get("tax_id", ""))
+                if primary
+                else row.get("tax_id", "")
+            ),
             "lineage_superkingdom": (
                 primary.get("lineage_superkingdom", "") if primary else ""
             ),

--- a/tests/test_chembl_targets.py
+++ b/tests/test_chembl_targets.py
@@ -20,6 +20,8 @@ def test_fetch_targets_parses_fields(requests_mock: requests_mock.Mocker) -> Non
         "pref_name": "Example",
         "target_type": "SINGLE PROTEIN",
         "organism": "Homo sapiens",
+        "tax_id": 9606,
+        "species_group_flag": 0,
         "target_components": [
             {
                 "component_id": 1,
@@ -27,7 +29,8 @@ def test_fetch_targets_parses_fields(requests_mock: requests_mock.Mocker) -> Non
                 "component_type": "PROTEIN",
                 "component_description": "desc",
                 "target_component_synonyms": [
-                    {"component_synonym": "ABC1", "syn_type": "GENE_SYMBOL"}
+                    {"component_synonym": "ABC1", "syn_type": "GENE_SYMBOL"},
+                    {"component_synonym": "ProtAlt", "syn_type": "PROTEIN_NAME"},
                 ],
                 "target_component_xrefs": [
                     {"xref_src_db": "Ensembl", "xref_id": "ENSG000001"},
@@ -46,12 +49,16 @@ def test_fetch_targets_parses_fields(requests_mock: requests_mock.Mocker) -> Non
     assert list(df.columns) == [
         "target_chembl_id",
         "pref_name",
+        "protein_name_canonical",
         "target_type",
         "organism",
+        "tax_id",
+        "species_group_flag",
         "target_components",
         "protein_classifications",
         "cross_references",
         "gene_symbol_list",
+        "protein_synonym_list",
     ]
     record = df.iloc[0]
     comps = json.loads(record["target_components"])
@@ -60,5 +67,7 @@ def test_fetch_targets_parses_fields(requests_mock: requests_mock.Mocker) -> Non
     assert [r["xref_db"] for r in refs] == ["Ensembl", "IUPHAR/BPS", "UniProt"]
     genes = json.loads(record["gene_symbol_list"])
     assert genes == ["ABC1"]
+    names = json.loads(record["protein_synonym_list"])
+    assert names == ["ProtAlt"]
     classes = json.loads(record["protein_classifications"])
     assert classes == ["L4", "L5"]


### PR DESCRIPTION
## Summary
- capture additional ChEMBL fields including canonical protein name, synonyms and taxonomy info
- use ChEMBL-derived names and taxonomy as fallback in pipeline when UniProt data is missing

## Testing
- `black library/chembl_targets.py library/pipeline_targets.py tests/test_chembl_targets.py`
- `ruff check library/chembl_targets.py library/pipeline_targets.py tests/test_chembl_targets.py`
- `mypy library/chembl_targets.py library/pipeline_targets.py tests/test_chembl_targets.py`
- `pytest tests/test_chembl_targets.py tests/test_pipeline_targets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7ef5268bc8324b74d7656baf7005e