### PR TITLE
feat: expand ChEMBL target fields

### DIFF
--- a/library/chembl_targets.py
+++ b/library/chembl_targets.py
@@ -5,6 +5,13 @@ information for a list of ChEMBL identifiers and returns a :class:`pandas.DataFr
 ready for serialisation.  The implementation favours determinism: list-like
 fields are sorted and serialised either as JSON arrays or pipe-delimited strings
 depending on the configuration.
+
+Algorithm Notes
+---------------
+1. Clean and deduplicate the provided identifiers.
+2. Retrieve each target record via HTTP with retry and rate limiting.
+3. Extract relevant attributes and serialise list-like fields according to
+   the configuration.
 """
 
 from __future__ import annotations
@@ -143,6 +150,63 @@ def _extract_protein_synonyms(payload: Dict[str, Any]) -> List[str]:
     return sorted(n for n in names if n)
 
 
+def _extract_ec_numbers(payload: Dict[str, Any]) -> List[str]:
+    """Collect EC numbers from component synonyms."""
+
+    codes: set[str] = set()
+    for comp in payload.get("target_components", []) or []:
+        for syn in comp.get("target_component_synonyms", []) or []:
+            if (syn.get("syn_type") or "").upper() == "EC_NUMBER":
+                codes.add(syn.get("component_synonym", ""))
+    return sorted(c for c in codes if c)
+
+
+def _extract_alt_names(payload: Dict[str, Any]) -> List[str]:
+    """Collect UniProt alternative names from component synonyms."""
+
+    names: set[str] = set()
+    for comp in payload.get("target_components", []) or []:
+        for syn in comp.get("target_component_synonyms", []) or []:
+            if (syn.get("syn_type") or "").upper() == "UNIPROT":
+                names.add(syn.get("component_synonym", ""))
+    return sorted(n for n in names if n)
+
+
+def _extract_uniprot_ids(payload: Dict[str, Any]) -> List[str]:
+    """Extract UniProt identifiers from cross references."""
+
+    ids: set[str] = set()
+    for ref in payload.get("cross_references", []) or []:
+        db = (ref.get("xref_db") or "").upper()
+        if "UNIPROT" in db:
+            ids.add(ref.get("xref_id", ""))
+    for comp in payload.get("target_components", []) or []:
+        for ref in comp.get("target_component_xrefs", []) or []:
+            db = (ref.get("xref_src_db") or "").upper()
+            if "UNIPROT" in db:
+                ids.add(ref.get("xref_id", ""))
+    return sorted(i for i in ids if i)
+
+
+def _extract_hgnc(payload: Dict[str, Any]) -> tuple[str, str]:
+    """Return HGNC name and identifier from cross references."""
+
+    for ref in payload.get("cross_references", []) or []:
+        if (ref.get("xref_db") or "").upper() == "HGNC":
+            name = ref.get("xref_name") or ""
+            ident = ref.get("xref_id") or ""
+            hgnc_id = ident.split(":")[-1] if ident else ""
+            return name, hgnc_id
+    for comp in payload.get("target_components", []) or []:
+        for ref in comp.get("target_component_xrefs", []) or []:
+            if (ref.get("xref_src_db") or "").upper() == "HGNC":
+                name = ref.get("xref_name") or ""
+                ident = ref.get("xref_id") or ""
+                hgnc_id = ident.split(":")[-1] if ident else ""
+                return name, hgnc_id
+    return "", ""
+
+
 def _extract_protein_classifications(payload: Dict[str, Any]) -> List[str]:
     classifications: List[str] = []
     pc = payload.get("protein_classification")
@@ -188,6 +252,12 @@ def fetch_targets(ids: Sequence[str], cfg: TargetConfig) -> pd.DataFrame:
         except Exception as exc:  # noqa: BLE001 - we log and continue
             LOGGER.warning("Failed to fetch %s: %s", chembl_id, exc)
             payload = {}
+        genes = _extract_gene_symbols(payload)
+        prot_names = _extract_protein_synonyms(payload)
+        ec_numbers = _extract_ec_numbers(payload)
+        alt_names = _extract_alt_names(payload)
+        uniprot_ids = _extract_uniprot_ids(payload)
+        hgnc_name, hgnc_id = _extract_hgnc(payload)
         record = {
             "target_chembl_id": chembl_id,
             "pref_name": payload.get("pref_name"),
@@ -205,12 +275,15 @@ def fetch_targets(ids: Sequence[str], cfg: TargetConfig) -> pd.DataFrame:
             "cross_references": _serialize(
                 _extract_cross_refs(payload), list_format=cfg.list_format
             ),
-            "gene_symbol_list": _serialize(
-                _extract_gene_symbols(payload), list_format=cfg.list_format
+            "gene_symbol_list": _serialize(genes, list_format=cfg.list_format),
+            "protein_synonym_list": _serialize(prot_names, list_format=cfg.list_format),
+            "ec_number_list": _serialize(ec_numbers, list_format=cfg.list_format),
+            "chembl_alternative_name_list": _serialize(
+                alt_names, list_format=cfg.list_format
             ),
-            "protein_synonym_list": _serialize(
-                _extract_protein_synonyms(payload), list_format=cfg.list_format
-            ),
+            "uniprot_id_list": _serialize(uniprot_ids, list_format=cfg.list_format),
+            "hgnc_name": hgnc_name,
+            "hgnc_id": hgnc_id,
         }
         records.append(record)
     df = pd.DataFrame(records)

--- a/tests/test_chembl_targets.py
+++ b/tests/test_chembl_targets.py
@@ -31,14 +31,24 @@ def test_fetch_targets_parses_fields(requests_mock: requests_mock.Mocker) -> Non
                 "target_component_synonyms": [
                     {"component_synonym": "ABC1", "syn_type": "GENE_SYMBOL"},
                     {"component_synonym": "ProtAlt", "syn_type": "PROTEIN_NAME"},
+                    {"component_synonym": "1.1.1.1", "syn_type": "EC_NUMBER"},
+                    {"component_synonym": "AltUni", "syn_type": "UNIPROT"},
                 ],
                 "target_component_xrefs": [
                     {"xref_src_db": "Ensembl", "xref_id": "ENSG000001"},
                     {"xref_src_db": "UniProt", "xref_id": "P12345"},
+                    {
+                        "xref_src_db": "HGNC",
+                        "xref_id": "HGNC:5",
+                        "xref_name": "HGNCNAME",
+                    },
                 ],
             }
         ],
-        "cross_references": [{"xref_db": "IUPHAR/BPS", "xref_id": "123"}],
+        "cross_references": [
+            {"xref_db": "IUPHAR/BPS", "xref_id": "123"},
+            {"xref_db": "UniProt", "xref_id": "Q99999"},
+        ],
         "protein_classification": {
             "pref_name": "L5",
             "parent": {"pref_name": "L4"},
@@ -59,15 +69,34 @@ def test_fetch_targets_parses_fields(requests_mock: requests_mock.Mocker) -> Non
         "cross_references",
         "gene_symbol_list",
         "protein_synonym_list",
+        "ec_number_list",
+        "chembl_alternative_name_list",
+        "uniprot_id_list",
+        "hgnc_name",
+        "hgnc_id",
     ]
     record = df.iloc[0]
     comps = json.loads(record["target_components"])
     assert comps[0]["accession"] == "P12345"
     refs = json.loads(record["cross_references"])
-    assert [r["xref_db"] for r in refs] == ["Ensembl", "IUPHAR/BPS", "UniProt"]
+    assert [r["xref_db"] for r in refs] == [
+        "Ensembl",
+        "HGNC",
+        "IUPHAR/BPS",
+        "UniProt",
+        "UniProt",
+    ]
     genes = json.loads(record["gene_symbol_list"])
     assert genes == ["ABC1"]
     names = json.loads(record["protein_synonym_list"])
     assert names == ["ProtAlt"]
+    ec_numbers = json.loads(record["ec_number_list"])
+    assert ec_numbers == ["1.1.1.1"]
+    alt_names = json.loads(record["chembl_alternative_name_list"])
+    assert alt_names == ["AltUni"]
+    uniprot_ids = json.loads(record["uniprot_id_list"])
+    assert uniprot_ids == ["P12345", "Q99999"]
+    assert record["hgnc_name"] == "HGNCNAME"
+    assert record["hgnc_id"] == "5"
     classes = json.loads(record["protein_classifications"])
     assert classes == ["L4", "L5"]


### PR DESCRIPTION
## Summary
- enrich ChEMBL target fetcher with EC numbers, UniProt alt names, IDs and HGNC info
- extend target tests for the new fields

## Testing
- `black library/chembl_targets.py tests/test_chembl_targets.py`
- `ruff check library/chembl_targets.py tests/test_chembl_targets.py`
- `mypy library/chembl_targets.py tests/test_chembl_targets.py`
- `pytest tests/test_chembl_targets.py::test_fetch_targets_parses_fields -q`
- `pytest -q` *(fails: test_uniprot_cli, test_cli_writes_output)*


------
https://chatgpt.com/codex/tasks/task_e_68c7f3cbfec48324945d274540d0c4e3