### PR TITLE
feat: extend Chembl extraction

### DIFF
--- a/tests/test_pipeline_targets_main.py
+++ b/tests/test_pipeline_targets_main.py
@@ -1,0 +1,24 @@
+import pandas as pd
+
+from scripts.pipeline_targets_main import merge_chembl_fields
+
+
+def test_merge_chembl_fields_adds_columns():
+    pipeline_df = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL1"],
+            "hgnc_id": ["HGNC:1"],
+        }
+    )
+    chembl_df = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL1"],
+            "species_group_flag": [1],
+            "hgnc_name": ["ABC"],
+            "hgnc_id": ["HGNC:1"],
+        }
+    )
+    merged = merge_chembl_fields(pipeline_df, chembl_df)
+    assert "species_group_flag" in merged.columns
+    assert "hgnc_name" in merged.columns
+    assert merged.loc[0, "hgnc_id"] == "HGNC:1"


### PR DESCRIPTION
## Summary
- include full set of ChEMBL target fields in pipeline output
- add helper to merge extra ChEMBL columns without duplication
- cover new merge behaviour with unit test

## Testing
- `black scripts/pipeline_targets_main.py tests/test_pipeline_targets_main.py`
- `ruff check scripts/pipeline_targets_main.py tests/test_pipeline_targets_main.py`
- `mypy --explicit-package-bases scripts/pipeline_targets_main.py tests/test_pipeline_targets_main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c80ac5631c8324bd2dabe838421c64