### PR TITLE
Add per-database column configuration for target pipeline

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,12 @@
 
 gtop:
   base_url: "https://www.guidetopharmacology.org/services"
+  columns:
+    - gtop_target_id
+    - gtop_synonyms
+    - gtop_natural_ligands_n
+    - gtop_interactions_n
+    - gtop_function_text_short
 
 uniprot:
   base_url: "https://rest.uniprot.org/uniprotkb"
@@ -9,6 +15,28 @@ uniprot:
   timeout_sec: 30
   retries: 3
   rps: 3
+  columns:
+    - uniprot_id_primary
+    - uniprot_ids_all
+    - isoform_ids
+    - isoform_names
+    - isoform_synonyms
+    - sequence_length
+    - features_signal_peptide
+    - features_transmembrane
+    - features_topology
+    - ptm_glycosylation
+    - ptm_lipidation
+    - ptm_disulfide_bond
+    - ptm_modified_residue
+    - pfam
+    - interpro
+    - xref_uniprot
+    - xref_ensembl
+    - xref_pdb
+    - xref_alphafold
+    - uniprot_last_update
+    - uniprot_version
 
 chembl:
   columns:
@@ -116,6 +144,10 @@ chembl2uniprot:
     level: "DEBUG"
 
 hgnc:
+  columns:
+    - hgnc_id
+    - gene_symbol
+    - hgnc_name
   hgnc:
     base_url: "https://rest.genenames.org/fetch/uniprot_ids"
   network:

--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -201,6 +201,16 @@ def main() -> None:
         list_format=pipeline_cfg.list_format, columns=columns
     )
 
+    # Merge additional column requirements from other data sources so that the
+    # final output includes every requested field. This allows individual
+    # sections in the YAML configuration (``uniprot``, ``gtop``, ``hgnc``) to
+    # declare their own column lists without having to manually duplicate them
+    # under ``pipeline.columns``.
+    for section in ("uniprot", "gtop", "hgnc"):
+        for col in data.get(section, {}).get("columns", []):
+            if col not in pipeline_cfg.columns:
+                pipeline_cfg.columns.append(col)
+
     (
         uni_client,
         hgnc_client,


### PR DESCRIPTION
## Summary
- list columns to extract from UniProt, GtoP and HGNC in pipeline configuration
- ensure `pipeline_targets_main` merges database column lists into output

## Testing
- `python -m black scripts/pipeline_targets_main.py`
- `ruff check scripts/pipeline_targets_main.py`
- `mypy scripts/pipeline_targets_main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c80d870bd4832499401eec6197d290