### PR TITLE
Clean isoform name and synonym extraction

### DIFF
--- a/tests/data/uniprot_entry.json
+++ b/tests/data/uniprot_entry.json
@@ -70,8 +70,24 @@
     {
       "commentType": "ALTERNATIVE_PRODUCTS",
       "isoforms": [
-        {"name": {"value": "Isoform 2"}, "id": "P12345-2"},
-        {"name": {"value": "Isoform 1"}, "id": "P12345-1"}
+        {
+          "name": {"value": "Isoform 2 "},
+          "id": "P12345-2",
+          "synonyms": [
+            {"value": " Beta"},
+            {"value": "Gamma"},
+            {"value": "Beta"}
+          ]
+        },
+        {
+          "name": {"value": " Isoform 1"},
+          "id": "P12345-1",
+          "synonyms": [
+            {"value": " Alpha"},
+            {"value": "Alpha"},
+            {"value": "Zeta"}
+          ]
+        }
       ]
     }
   ],

--- a/tests/test_uniprot_dump.py
+++ b/tests/test_uniprot_dump.py
@@ -28,6 +28,7 @@ def test_normalize_entry_sorts_lists() -> None:
     data = normalize_entry(entry, include_sequence=False, isoforms=isoforms)
     assert data["protein_alternative_names"] == ["Alt A", "Alt B"]
     assert data["isoform_ids"] == ["P12345-1", "P12345-2"]
+    assert data["isoform_names"] == ["Isoform 1", "Isoform 2"]
     assert data["isoform_ids_all"] == ["P12345-1", "P12345-2"]
     assert data["isoforms_count"] == 2
     iso_json = json.loads(data["isoforms_json"])
@@ -36,6 +37,15 @@ def test_normalize_entry_sorts_lists() -> None:
     assert data["features_signal_peptide"] == ["1-10"]
     assert data["features_transmembrane"] == ["20-40"]
     assert data["ptm_modified_residue"] == ["150:Phosphoserine"]
+
+
+def test_extract_isoforms_parses_synonyms() -> None:
+    entry = _load_sample()
+    headers = [">sp|P12345-1|", ">sp|P12345-2|"]
+    isoforms = extract_isoforms(entry, headers)
+    assert [iso["isoform_name"] for iso in isoforms] == ["Isoform 1", "Isoform 2"]
+    assert isoforms[0]["isoform_synonyms"] == ["Alpha", "Zeta"]
+    assert isoforms[1]["isoform_synonyms"] == ["Beta", "Gamma"]
 
 
 def test_output_columns_include_sequence() -> None:


### PR DESCRIPTION
## Summary
- strip whitespace from isoform names and synonyms
- de-duplicate isoform synonyms while preserving order
- derive isoform IDs and names from normalized isoform data
- add regression test for isoform name and synonym parsing

## Testing
- `black library/uniprot_normalize.py tests/test_uniprot_dump.py`
- `ruff check library/uniprot_normalize.py tests/test_uniprot_dump.py`
- `mypy library/uniprot_normalize.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8178c9cbc8324993fe979d1831498