### PR TITLE
feat: batch UniProt and ChEMBL retrieval

### DIFF
--- a/tests/test_pipeline_targets_main.py
+++ b/tests/test_pipeline_targets_main.py
@@ -61,8 +61,8 @@ def test_add_iuphar_classification():
 def test_add_protein_classification():
     samples = json.loads((Path("tests/data/protein_samples.json").read_text()))
 
-    def fetcher(_: str) -> dict:
-        return samples["gpcr"]
+    def fetcher(_: Iterable[str]) -> Dict[str, dict]:
+        return {"P00000": samples["gpcr"]}
 
     df = pd.DataFrame({"uniprot_id_primary": ["P00000"]})
     out = add_protein_classification(df, fetcher)

--- a/tests/test_uniprot_client.py
+++ b/tests/test_uniprot_client.py
@@ -1,0 +1,30 @@
+from typing import Dict
+from pathlib import Path
+import sys
+
+import requests_mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from library.uniprot_client import NetworkConfig, RateLimitConfig, UniProtClient
+
+
+def test_fetch_entries_json_batches(requests_mock: requests_mock.Mocker) -> None:
+    client = UniProtClient(
+        base_url="https://rest.uniprot.org/uniprotkb",
+        fields="",
+        network=NetworkConfig(timeout_sec=1, max_retries=1),
+        rate_limit=RateLimitConfig(rps=1000),
+    )
+    url = "https://rest.uniprot.org/uniprotkb/stream"
+    requests_mock.get(
+        url,
+        json={
+            "results": [
+                {"primaryAccession": "P1"},
+                {"primaryAccession": "P2"},
+            ]
+        },
+    )
+    res: Dict[str, Dict[str, str]] = client.fetch_entries_json(["P1", "P2"])
+    assert requests_mock.call_count == 1
+    assert set(res.keys()) == {"P1", "P2"}


### PR DESCRIPTION
## Summary
- support batched UniProt entry downloads via `fetch_entries_json`
- add batch querying to ChEMBL target fetching
- expose `--batch-size` CLI option and apply batched classification in `pipeline_targets_main`

## Testing
- `python -m black library/uniprot_client.py library/chembl_targets.py scripts/pipeline_targets_main.py tests/test_pipeline_targets_main.py tests/test_uniprot_client.py tests/test_chembl_targets.py`
- `ruff check library/uniprot_client.py library/chembl_targets.py scripts/pipeline_targets_main.py tests/test_pipeline_targets_main.py tests/test_uniprot_client.py tests/test_chembl_targets.py`
- `mypy --ignore-missing-imports --follow-imports=skip library/uniprot_client.py library/chembl_targets.py scripts/pipeline_targets_main.py tests/test_pipeline_targets_main.py tests/test_uniprot_client.py tests/test_chembl_targets.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c822a2f3f88324a12d7bc6a599cb21