### PR TITLE
Add property-based and determinism tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
     "types-PyYAML",
     "types-jsonschema",
     "types-requests",
+    "hypothesis",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -1,0 +1,80 @@
+"""Utilities for verifying deterministic outputs.
+
+This script writes a small CSV file twice using :func:`write_rows` and
+confirms that the resulting hashes are identical.  It exits with a non-zero
+status if the hashes differ, making it suitable for use in automated tests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from library.io_utils import CsvConfig, write_rows  # noqa: E402
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _hash_file(path: Path) -> str:
+    """Return the SHA-256 hash of ``path``.
+
+    Parameters
+    ----------
+    path:
+        File whose contents will be hashed.
+    """
+
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _sample_rows() -> Sequence[Dict[str, Any]]:
+    """Provide a deterministic set of rows for testing."""
+
+    return [
+        {"id": 1, "names": ["alpha", "beta"]},
+        {"id": 2, "names": ["gamma", "delta"]},
+    ]
+
+
+def main() -> None:
+    """Run the determinism check.
+
+    The function writes the same rows twice to different temporary files and
+    compares their SHA-256 hashes.  A mismatch results in a ``RuntimeError``.
+    """
+
+    logging.basicConfig(level=logging.INFO)
+
+    cfg = CsvConfig(sep=",", encoding="utf-8", list_format="json")
+    rows = _sample_rows()
+    columns = ["id", "names"]
+
+    tmp1 = Path("_det_check_1.csv")
+    tmp2 = Path("_det_check_2.csv")
+
+    write_rows(tmp1, rows, columns, cfg)
+    write_rows(tmp2, rows, columns, cfg)
+
+    hash1 = _hash_file(tmp1)
+    hash2 = _hash_file(tmp2)
+
+    LOGGER.info("hash1=%s hash2=%s", hash1, hash2)
+
+    try:
+        if hash1 != hash2:
+            msg = "Non-deterministic output detected"
+            raise RuntimeError(msg)
+    finally:
+        tmp1.unlink(missing_ok=True)
+        tmp2.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/tests/data/golden_write_rows.csv
+++ b/tests/data/golden_write_rows.csv
@@ -1,0 +1,3 @@
+id,names,meta
+1,"[""alpha"",""beta""]","[{""id"":""x"",""name"":""y""}]"
+2,"[""gamma"",""delta""]","[{""id"":""u"",""name"":""v""},{""id"":""w"",""name"":""z""}]"

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -1,0 +1,122 @@
+"""Tests for :mod:`library.io_utils`."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from hypothesis import given, settings, strategies as st
+
+from library.io_utils import CsvConfig, _serialise_list, write_rows
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis-based tests for _serialise_list
+# ---------------------------------------------------------------------------
+
+
+def _parse_pipe(value: str) -> Iterable[str]:
+    r"""Parse a pipe-delimited string produced by ``_serialise_list``.
+
+    This function splits on unescaped pipes and unescapes ``\|`` sequences.
+    """
+
+    result = []
+    current = []
+    escape = False
+    for ch in value:
+        if escape:
+            if ch not in ("|", "\\"):
+                current.append("\\")
+            current.append(ch)
+            escape = False
+            continue
+        if ch == "\\":
+            escape = True
+            continue
+        if ch == "|":
+            result.append("".join(current))
+            current = []
+            continue
+        current.append(ch)
+    if escape:
+        current.append("\\")
+    result.append("".join(current))
+    return result
+
+
+pipe_strategy = st.lists(
+    st.one_of(
+        st.text(),
+        st.integers(),
+        st.tuples(st.text(), st.text()),
+    )
+)
+
+
+@settings(max_examples=25)
+@given(pipe_strategy)
+def test_serialise_list_pipe_roundtrip(values: list[Any]) -> None:
+    """Serialisation to ``pipe`` is stable under a parse/serialise round-trip."""
+
+    serialised = _serialise_list(values, "pipe")
+    parsed = list(_parse_pipe(serialised))
+    assert _serialise_list(parsed, "pipe") == serialised
+
+
+@settings(max_examples=25)
+@given(pipe_strategy)
+def test_serialise_list_json_roundtrip(values: list[Any]) -> None:
+    """Serialisation to ``json`` round-trips via ``json.loads``."""
+
+    serialised = _serialise_list(values, "json")
+    parsed = json.loads(serialised)
+    expected = [
+        {"id": v[0], "name": v[1]} if isinstance(v, tuple) else v for v in values
+    ]
+    assert parsed == expected
+
+
+# ---------------------------------------------------------------------------
+# Golden file test for write_rows
+# ---------------------------------------------------------------------------
+
+
+def test_write_rows_golden(tmp_path: Path) -> None:
+    """Ensure :func:`write_rows` produces deterministic output."""
+
+    cfg = CsvConfig(sep=",", encoding="utf-8", list_format="json")
+    rows = [
+        {"id": 1, "names": ["alpha", "beta"], "meta": [("x", "y")]},
+        {
+            "id": 2,
+            "names": ["gamma", "delta"],
+            "meta": [("u", "v"), ("w", "z")],
+        },
+    ]
+    columns = ["id", "names", "meta"]
+
+    out = tmp_path / "rows.csv"
+    write_rows(out, rows, columns, cfg)
+
+    golden = Path(__file__).parent / "data" / "golden_write_rows.csv"
+    assert out.read_bytes() == golden.read_bytes()
+
+    digest = hashlib.sha256(out.read_bytes()).hexdigest()
+    assert digest == "f3acc2865cc6a94ad18b62dfac787ba4cb991e95b815a1cb5558bdacd071e285"
+
+
+# ---------------------------------------------------------------------------
+# Integration of determinism script
+# ---------------------------------------------------------------------------
+
+
+def test_check_determinism_script() -> None:
+    """Run the determinism script and ensure it succeeds."""
+
+    import subprocess
+    import sys
+
+    subprocess.run([sys.executable, "scripts/check_determinism.py"], check=True)


### PR DESCRIPTION
## Summary
- add Hypothesis property-based tests for list serialisation
- add golden-file test with hash verification for `write_rows`
- integrate determinism check script into pytest

## Testing
- `ruff check scripts/check_determinism.py tests/test_io_utils.py`
- `mypy scripts/check_determinism.py tests/test_io_utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c82401d4b88324a2a43c88384b536f