### PR TITLE
Handle optional IUPHAR classification columns

### DIFF
--- a/tests/test_pipeline_targets_main.py
+++ b/tests/test_pipeline_targets_main.py
@@ -12,6 +12,7 @@ from pipeline_targets_main import (
     add_protein_classification,
     add_uniprot_fields,
     merge_chembl_fields,
+    reorder_iuphar_columns,
 )
 
 
@@ -94,3 +95,22 @@ def test_add_uniprot_fields() -> None:
     assert row["geneName"] == "GENE1"
     assert row["secondaryAccessionNames"] == "Name1|Name2"
     assert row["molecular_function"] == "binding"
+
+
+def test_reorder_iuphar_columns_handles_absent_columns() -> None:
+    df = pd.DataFrame({"a": [1], "b": [2]})
+    out = reorder_iuphar_columns(df)
+    assert list(out.columns) == ["a", "b"]
+
+
+def test_reorder_iuphar_columns_moves_existing() -> None:
+    df = pd.DataFrame(
+        {
+            "col": [1],
+            "iuphar_name": ["n"],
+            "b": [2],
+            "iuphar_type": ["t"],
+        }
+    )
+    out = reorder_iuphar_columns(df)
+    assert list(out.columns) == ["col", "b", "iuphar_type", "iuphar_name"]


### PR DESCRIPTION
## Summary
- add `reorder_iuphar_columns` helper to safely move IUPHAR columns to end
- call helper in pipeline so missing classification columns no longer raise `KeyError`
- test column reordering with and without IUPHAR fields

## Testing
- `black scripts/pipeline_targets_main.py tests/test_pipeline_targets_main.py`
- `ruff check scripts/pipeline_targets_main.py tests/test_pipeline_targets_main.py`
- `mypy --follow-imports=skip scripts/pipeline_targets_main.py tests/test_pipeline_targets_main.py`
- `pytest tests/test_pipeline_targets_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c820c0dda483249f0401ffb2dc66b4