### PR TITLE
Consolidate output configuration and document settings

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -52,12 +52,6 @@ chembl:
     - cross_references
     - gene_symbol_list
     - protein_synonym_list
-
-output:
-  list_format: json
-  encoding: "utf-8-sig"
- 
-
 pipeline:
   rate_limit_rps: 2
   retries: 3
@@ -161,15 +155,11 @@ hgnc:
 
 
 output:
-  # Separator used for CSV output, e.g. "," or "\t"
-  sep: ","
-  # File encoding for generated CSV files
-  encoding: "utf-8-sig"
-  # Serialisation format for list-like fields: "json" or "pipe"
-  list_format: pipe
-  # Include protein sequence column by default
-
-  include_sequence: false
+  # Global settings applied to all generated CSV files
+  sep: ","            # Column separator, e.g. "," or "\t"
+  encoding: "utf-8-sig"  # File encoding for output files
+  list_format: pipe       # Serialisation format for list-like fields ("json" or "pipe")
+  include_sequence: false # Include protein sequence column by default
 
 orthologs:
   enabled: true


### PR DESCRIPTION
## Summary
- remove redundant output block from root config
- document global output settings with inline comments

## Testing
- `pre-commit run --files config.yaml`
- `pytest`
- `mypy .` *(fails: missing type stubs and incompatible types)*

------
https://chatgpt.com/codex/tasks/task_e_68c82b9523148324bdbbd15ca492e955