### PR TITLE
Add catalytic activity extraction

### DIFF
--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -33,6 +33,7 @@ from library.uniprot_client import (
 from library.orthologs import EnsemblHomologyClient, OmaClient
 from library.uniprot_enrich.enrich import (
     UniProtClient as UniProtEnrichClient,
+    _collect_ec_numbers,
 )
 
 
@@ -277,8 +278,6 @@ def add_uniprot_fields(
         "ubiquitination": "ubiquitination",
         "signal_peptide": "signal_peptide",
         "propeptide": "propeptide",
-        "reactions": "reactions",
-        "reaction_ec_numbers": "reaction_ec_numbers",
         "GuidetoPHARMACOLOGY": "GuidetoPHARMACOLOGY",
         "family": "family",
         "SUPFAM": "SUPFAM",
@@ -297,6 +296,99 @@ def add_uniprot_fields(
             # Respect existing columns to avoid overwriting prior values.
             continue
         pipeline_df[out_col] = [mapping.get(i, {}).get(src_col, "") for i in ids]
+    return pipeline_df
+
+
+def extract_activity(data: Any) -> dict[str, str]:
+    """Return catalytic reaction names and EC numbers found in ``data``.
+
+    The UniProt record may list one or more "CATALYTIC ACTIVITY" comments,
+    each describing a reaction and an associated EC number. This helper
+    aggregates those reactions and numbers as pipe-separated strings.
+
+    Parameters
+    ----------
+    data:
+        A UniProt JSON structure, list of entries, or search results
+        containing UniProt entries.
+
+    Returns
+    -------
+    dict[str, str]
+        A dictionary with keys ``reactions`` and ``reaction_ec_numbers``.
+        Missing information yields empty strings.
+    """
+
+    reactions: list[str] = []
+    numbers: list[str] = []
+    if isinstance(data, dict) and "results" in data:
+        entries = data["results"]
+    elif isinstance(data, list):
+        entries = data
+    else:
+        entries = [data]
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        comments = entry.get("comments", [])
+        if not isinstance(comments, list):
+            continue
+        for comment in comments:
+            if not isinstance(comment, dict):
+                continue
+            if comment.get("commentType") != "CATALYTIC ACTIVITY":
+                continue
+            reaction = comment.get("reaction")
+            if not isinstance(reaction, dict):
+                continue
+            name = reaction.get("name")
+            if isinstance(name, dict):
+                name = name.get("value")
+            if isinstance(name, str):
+                reactions.append(name)
+            numbers.extend(list(_collect_ec_numbers(reaction)))
+    return {
+        "reactions": "|".join(reactions),
+        "reaction_ec_numbers": "|".join(numbers),
+    }
+
+
+def add_activity_fields(
+    pipeline_df: pd.DataFrame, fetch_entry: Callable[[str], Any]
+) -> pd.DataFrame:
+    """Append catalytic activity and EC numbers parsed from UniProt entries.
+
+    Parameters
+    ----------
+    pipeline_df:
+        Data frame produced by :func:`run_pipeline` containing a
+        ``uniprot_id_primary`` column.
+    fetch_entry:
+        Callable returning a UniProt JSON entry for a given accession.
+
+    Returns
+    -------
+    pandas.DataFrame
+        ``pipeline_df`` with ``reactions`` and ``reaction_ec_numbers``
+        columns populated. Existing columns are preserved.
+    """
+
+    ids = pipeline_df.get("uniprot_id_primary", pd.Series(dtype=str)).astype(str)
+    cache: Dict[str, dict[str, str]] = {}
+    for acc in ids:
+        if not acc or acc in cache:
+            continue
+        entry = fetch_entry(acc)
+        cache[acc] = (
+            extract_activity(entry)
+            if entry
+            else {"reactions": "", "reaction_ec_numbers": ""}
+        )
+    pipeline_df = pipeline_df.copy()
+    pipeline_df["reactions"] = [cache.get(i, {}).get("reactions", "") for i in ids]
+    pipeline_df["reaction_ec_numbers"] = [
+        cache.get(i, {}).get("reaction_ec_numbers", "") for i in ids
+    ]
     return pipeline_df
 
 
@@ -657,8 +749,16 @@ def main() -> None:
     enrich_client = UniProtEnrichClient()
     out_df = add_uniprot_fields(out_df, enrich_client.fetch_all)
     out_df = merge_chembl_fields(out_df, chembl_df)
+    entry_cache: Dict[str, Any] = {}
+
+    def cached_fetch(acc: str) -> Any:
+        if acc not in entry_cache:
+            entry_cache[acc] = uni_client.fetch_entry_json(acc)
+        return entry_cache[acc]
+
+    out_df = add_activity_fields(out_df, cached_fetch)
     if use_isoforms:
-        out_df = add_isoform_fields(out_df, uni_client.fetch_entry_json)
+        out_df = add_isoform_fields(out_df, cached_fetch)
 
     # Append optional IUPHAR classification data when both CSV files are provided.
     if args.iuphar_target and args.iuphar_family:

--- a/tests/test_pipeline_targets_main.py
+++ b/tests/test_pipeline_targets_main.py
@@ -10,8 +10,10 @@ sys.path.insert(0, str(Path("scripts")))
 from pipeline_targets_main import (
     add_iuphar_classification,
     add_protein_classification,
+    add_activity_fields,
     add_isoform_fields,
     add_uniprot_fields,
+    extract_activity,
     extract_isoform,
     merge_chembl_fields,
     save_output,
@@ -97,6 +99,52 @@ def test_add_uniprot_fields() -> None:
     assert row["geneName"] == "GENE1"
     assert row["secondaryAccessionNames"] == "Name1|Name2"
     assert row["molecular_function"] == "binding"
+
+
+def test_extract_activity() -> None:
+    entry = {
+        "comments": [
+            {
+                "commentType": "CATALYTIC ACTIVITY",
+                "reaction": {
+                    "name": {"value": "A + B = C"},
+                    "ecNumber": [{"value": "1.1.1.1"}],
+                },
+            },
+            {
+                "commentType": "CATALYTIC ACTIVITY",
+                "reaction": {
+                    "name": {"value": "D = E"},
+                    "ecNumbers": [{"value": "2.2.2.2"}, {"value": "3.3.3.3"}],
+                },
+            },
+        ]
+    }
+    result = extract_activity(entry)
+    assert result["reactions"] == "A + B = C|D = E"
+    assert result["reaction_ec_numbers"] == "1.1.1.1|2.2.2.2|3.3.3.3"
+
+
+def test_add_activity_fields() -> None:
+    df = pd.DataFrame({"uniprot_id_primary": ["P00001"]})
+
+    def fetch_entry(_: str) -> dict:
+        return {
+            "comments": [
+                {
+                    "commentType": "CATALYTIC ACTIVITY",
+                    "reaction": {
+                        "name": {"value": "X = Y"},
+                        "ecNumber": [{"value": "4.4.4.4"}],
+                    },
+                }
+            ]
+        }
+
+    out = add_activity_fields(df, fetch_entry)
+    row = out.iloc[0]
+    assert row["reactions"] == "X = Y"
+    assert row["reaction_ec_numbers"] == "4.4.4.4"
 
 
 def test_extract_isoform() -> None:


### PR DESCRIPTION
## Summary
- parse catalytic activity and EC numbers from UniProt entries
- expose reactions and EC codes through new `add_activity_fields`
- unit tests for activity extraction and field augmentation

## Testing
- `ruff check scripts/pipeline_targets_main.py tests/test_pipeline_targets_main.py`
- `mypy --config-file mypy.ini --follow-imports=skip scripts/pipeline_targets_main.py tests/test_pipeline_targets_main.py`
- `pytest tests/test_pipeline_targets_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c82fd27058832481e27578154a7964