### PR TITLE
Add data profiling for saved tables

### DIFF
--- a/library/__init__.py
+++ b/library/__init__.py
@@ -10,4 +10,5 @@ __all__ = [
     "gtop_normalize",
     "protein_classifier",
     "iuphar",
+    "data_profiling",
 ]

--- a/library/chembl2uniprot/mapping.py
+++ b/library/chembl2uniprot/mapping.py
@@ -37,6 +37,11 @@ from tenacity import (
 from .config import Config, RetryConfig, UniprotConfig, load_and_validate_config
 from .logging_utils import configure_logging
 
+try:
+    from data_profiling import analyze_table_quality
+except ModuleNotFoundError:  # pragma: no cover
+    from ..data_profiling import analyze_table_quality
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -386,4 +391,5 @@ def map_chembl_to_uniprot(
     df[out_col] = df[chembl_col].map(_join_ids)
 
     df.to_csv(output_csv_path, sep=sep, encoding=encoding_out, index=False)
+    analyze_table_quality(df, table_name=str(Path(output_csv_path).with_suffix("")))
     return output_csv_path

--- a/library/data_profiling.py
+++ b/library/data_profiling.py
@@ -1,0 +1,357 @@
+"""Tabular data profiling utilities.
+
+This module provides :func:`analyze_table_quality` which profiles each
+column in a :class:`pandas.DataFrame` and computes pairwise correlations
+for numeric columns.  The function writes two CSV reports: a quality report
+and a correlation matrix.  It has no third-party dependencies beyond
+``pandas`` and ``numpy`` and is suitable for offline use.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import warnings
+from collections.abc import Sized
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from pandas.errors import DtypeWarning
+
+LOGGER = logging.getLogger(__name__)
+
+# Precompiled regular expressions for pattern coverage
+_DOI_RE = re.compile(r"^10\.\d{4,9}/\S+$")
+_ISSN_RE = re.compile(r"^\d{4}-\d{3}[\dXx]$")
+_URL_RE = re.compile(r"^(?:https?|ftp)://|^www\.")
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+BOOL_LIKE = {"true", "false", "yes", "no", "y", "n", "1", "0", "t", "f"}
+
+
+def _load_table(table: pd.DataFrame | str | Path) -> pd.DataFrame:
+    """Load a table from ``table``.
+
+    Parameters
+    ----------
+    table:
+        Either an existing :class:`pandas.DataFrame` or path to a CSV file.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Loaded data frame.
+    """
+
+    if isinstance(table, pd.DataFrame):
+        return table.copy()
+
+    path = Path(table)
+    encodings = ["utf-8-sig", "utf-8", "cp1251", "latin-1"]
+    for enc in encodings:
+        try:
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=DtypeWarning)
+                return pd.read_csv(path, encoding=enc, low_memory=False)
+        except UnicodeDecodeError:
+            LOGGER.debug("failed to decode %s with %s", path, enc)
+            continue
+    raise UnicodeDecodeError("utf-8", b"", 0, 1, "Unable to decode CSV")
+
+
+def _is_isbn(value: str) -> bool:
+    """Return ``True`` if ``value`` is a valid ISBN10/13."""
+
+    digits = re.sub(r"[-\s]", "", value)
+    if re.fullmatch(r"\d{9}[\dXx]", digits):
+        total = sum(
+            (10 - i) * (10 if ch.upper() == "X" else int(ch))
+            for i, ch in enumerate(digits)
+        )
+        return total % 11 == 0
+    if re.fullmatch(r"\d{13}", digits):
+        total = sum(
+            (1 if i % 2 == 0 else 3) * int(ch) for i, ch in enumerate(digits[:-1])
+        )
+        check = (10 - total % 10) % 10
+        return check == int(digits[-1])
+    return False
+
+
+def _non_empty_mask(series: pd.Series) -> pd.Series:
+    """Boolean mask of values that are not empty by content."""
+
+    def is_non_empty(val: Any) -> bool:
+        if isinstance(val, str):
+            return bool(val.strip())
+        if isinstance(val, Sized) and not isinstance(val, (bytes, bytearray)):
+            # For sequences and other sized containers, consider length
+            return len(val) > 0
+        try:
+            return not pd.isna(val)
+        except (TypeError, ValueError):
+            # Objects that cannot be evaluated by pandas are treated as non-empty
+            return True
+
+    return series.map(is_non_empty)
+
+
+def _string_values(series: pd.Series, mask: pd.Series) -> pd.Series:
+    """Return non-empty string values from ``series`` according to ``mask``."""
+
+    return (
+        series[mask & series.map(lambda x: isinstance(x, str))].astype(str).str.strip()
+    )
+
+
+def _pattern_cov(strings: pd.Series, pattern: re.Pattern[str]) -> float:
+    """Fraction of ``strings`` matching ``pattern``."""
+
+    if strings.empty:
+        return 0.0
+    return float(strings.str.match(pattern).mean())
+
+
+def _isbn_cov(strings: pd.Series) -> float:
+    if strings.empty:
+        return 0.0
+    return float(strings.map(_is_isbn).mean())
+
+
+def _bool_like_cov(values: pd.Series) -> float:
+    if values.empty:
+        return 0.0
+    return float(values.astype(str).str.strip().str.lower().isin(BOOL_LIKE).mean())
+
+
+def _numeric_stats(series: pd.Series) -> tuple[pd.Series, float, dict[str, float]]:
+    """Convert ``series`` to numeric values and compute summary statistics."""
+
+    numeric = pd.to_numeric(series, errors="coerce").astype(float)
+
+    coverage = float(numeric.notna().mean())
+    stats = {
+        "numeric_min": float(numeric.min()) if coverage else np.nan,
+        "numeric_p50": float(numeric.quantile(0.5)) if coverage else np.nan,
+        "numeric_p95": float(numeric.quantile(0.95)) if coverage else np.nan,
+        "numeric_max": float(numeric.max()) if coverage else np.nan,
+        "numeric_mean": float(numeric.mean()) if coverage else np.nan,
+        "numeric_std": float(numeric.std(ddof=0)) if coverage else np.nan,
+    }
+
+    return numeric, coverage, stats
+
+
+def _parse_dates(series: pd.Series) -> tuple[float, dict[str, pd.Timestamp | float]]:
+    """Attempt to parse ``series`` as dates and compute summary statistics."""
+
+    def normalise(val: object) -> object:
+        if isinstance(val, str) and re.fullmatch(r"\d{4}", val.strip()):
+            return f"{val.strip()}-07-01"
+        return val
+
+    normalised = series.map(normalise)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Parsed string.*included an un-recognized timezone",
+            category=FutureWarning,
+        )
+        dates = pd.to_datetime(normalised, errors="coerce", utc=True, format="mixed")
+
+    coverage = float(dates.notna().mean())
+    if coverage:
+        dt = dates.dropna().dt.tz_convert(None)
+        stats: dict[str, pd.Timestamp | float] = {
+            "date_min": dt.min(),
+            "date_p50": dt.quantile(0.5),
+            "date_max": dt.max(),
+        }
+    else:
+        stats = {"date_min": np.nan, "date_p50": np.nan, "date_max": np.nan}
+    return coverage, stats
+
+
+def _text_length_stats(series: pd.Series) -> dict[str, float]:
+    values = series.dropna().map(lambda x: str(x).strip())
+    if values.empty:
+        return {
+            "text_len_min": np.nan,
+            "text_len_p50": np.nan,
+            "text_len_p95": np.nan,
+            "text_len_max": np.nan,
+        }
+    lengths = values.map(len)
+    return {
+        "text_len_min": float(lengths.min()),
+        "text_len_p50": float(lengths.quantile(0.5)),
+        "text_len_p95": float(lengths.quantile(0.95)),
+        "text_len_max": float(lengths.max()),
+    }
+
+
+def _top_values(series: pd.Series) -> str:
+    counts = series.dropna().map(lambda x: str(x).strip()).value_counts().head(3)
+    parts = [f"{str(val)[:60]} ({cnt})" for val, cnt in counts.items()]
+    return "; ".join(parts)
+
+
+def analyze_table_quality(
+    table: pd.DataFrame | str | Path, table_name: str
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Profile ``table`` and compute correlations for numeric columns.
+
+    Parameters
+    ----------
+    table:
+        :class:`pandas.DataFrame` or path to a CSV file.
+    table_name:
+        Base name used for output files.  The generated reports append
+        ``"_quality_report_table.csv"`` and ``"_data_correlation_report_table.csv"``
+        to this value.
+
+    Returns
+    -------
+    tuple[pandas.DataFrame, pandas.DataFrame]
+        Quality report and correlation matrix.
+    """
+
+    df = _load_table(table)
+    rows: list[dict[str, object]] = []
+    numeric_candidates: dict[str, pd.Series] = {}
+    for column in df.columns:
+        series = df[column]
+        non_null = int(series.notna().sum())
+        mask = _non_empty_mask(series)
+        non_empty = int(mask.sum())
+        empty_pct = float(1 - non_empty / len(series)) if len(series) else 0.0
+        try:
+            unique_cnt = int(series.dropna().nunique())
+        except TypeError:
+            # ``nunique`` requires hashable values; fall back to string representation
+            unique_cnt = int(series.dropna().map(str).nunique())
+        unique_pct = float(unique_cnt / non_empty) if non_empty else np.nan
+
+        strings = _string_values(series, mask)
+        pattern_cov_doi = _pattern_cov(strings, _DOI_RE)
+        pattern_cov_issn = _pattern_cov(strings, _ISSN_RE)
+        pattern_cov_isbn = _isbn_cov(strings)
+        pattern_cov_url = _pattern_cov(strings, _URL_RE)
+        pattern_cov_email = _pattern_cov(strings, _EMAIL_RE)
+
+        bool_like_cov = _bool_like_cov(strings)
+
+        numeric_series, numeric_cov, num_stats = _numeric_stats(series)
+        if numeric_cov >= 0.8:
+            numeric_candidates[column] = numeric_series
+
+        date_cov, date_stats = _parse_dates(series)
+
+        text_stats = _text_length_stats(series)
+
+        roles: list[str] = []
+        if pattern_cov_url > 0:
+            roles.append("url")
+        if pattern_cov_doi > 0:
+            roles.append("doi")
+        if pattern_cov_issn > 0:
+            roles.append("issn")
+        if pattern_cov_isbn > 0:
+            roles.append("isbn")
+        if pattern_cov_email > 0:
+            roles.append("email")
+        if bool_like_cov >= 0.8:
+            roles.append("boolean")
+        if date_cov >= 0.8:
+            roles.append("date")
+        if numeric_cov >= 0.8:
+            roles.append("numeric")
+        if non_empty and unique_cnt / non_empty >= 0.98:
+            roles.append("identifier-like")
+        elif unique_cnt <= min(100, 0.05 * non_empty):
+            roles.append("categorical")
+        else:
+            roles.append("free-text")
+
+        row: dict[str, object] = {
+            "column": column,
+            "non_null": non_null,
+            "non_empty": non_empty,
+            "empty_pct": empty_pct,
+            "unique_cnt": unique_cnt,
+            "unique_pct_of_non_empty": unique_pct,
+            "pattern_cov_doi": pattern_cov_doi,
+            "pattern_cov_issn": pattern_cov_issn,
+            "pattern_cov_isbn": pattern_cov_isbn,
+            "pattern_cov_url": pattern_cov_url,
+            "pattern_cov_email": pattern_cov_email,
+            "bool_like_cov": bool_like_cov,
+            "numeric_cov": numeric_cov,
+            **num_stats,
+            "date_cov": date_cov,
+            **date_stats,
+            **text_stats,
+            "guessed_roles": "|".join(roles),
+            "top_values": _top_values(series),
+        }
+        rows.append(row)
+
+    column_order = [
+        "column",
+        "non_null",
+        "non_empty",
+        "empty_pct",
+        "unique_cnt",
+        "unique_pct_of_non_empty",
+        "pattern_cov_doi",
+        "pattern_cov_issn",
+        "pattern_cov_isbn",
+        "pattern_cov_url",
+        "pattern_cov_email",
+        "bool_like_cov",
+        "numeric_cov",
+        "numeric_min",
+        "numeric_p50",
+        "numeric_p95",
+        "numeric_max",
+        "numeric_mean",
+        "numeric_std",
+        "date_cov",
+        "date_min",
+        "date_p50",
+        "date_max",
+        "text_len_min",
+        "text_len_p50",
+        "text_len_p95",
+        "text_len_max",
+        "guessed_roles",
+        "top_values",
+    ]
+    quality_report = pd.DataFrame(rows, columns=column_order)
+    quality_path = f"{table_name}_quality_report_table.csv"
+    quality_report.to_csv(quality_path, index=False, encoding="utf-8-sig")
+
+    corr_path = f"{table_name}_data_correlation_report_table.csv"
+    if numeric_candidates:
+        corr_report = pd.DataFrame(numeric_candidates).corr(method="pearson")
+        corr_report.reset_index().to_csv(corr_path, index=False, encoding="utf-8-sig")
+    else:
+        corr_report = pd.DataFrame()
+        corr_report.to_csv(corr_path, index=False, encoding="utf-8-sig")
+
+    return quality_report, corr_report
+
+
+if __name__ == "__main__":  # pragma: no cover - illustrative usage
+    demo = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "url": ["https://example.com", "http://test.com", None, ""],
+            "value": [10, "20", "30", "not"],
+            "year": ["2020", "1999", None, "no"],
+        }
+    )
+    analyze_table_quality(demo, table_name="demo")

--- a/library/hgnc_client.py
+++ b/library/hgnc_client.py
@@ -21,6 +21,11 @@ import pandas as pd
 import requests
 import yaml
 
+try:
+    from data_profiling import analyze_table_quality
+except ModuleNotFoundError:  # pragma: no cover
+    from .data_profiling import analyze_table_quality
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -292,4 +297,5 @@ def map_uniprot_to_hgnc(
     if output_csv_path is None:
         output_csv_path = input_csv_path.with_name(f"hgnc_{input_csv_path.stem}.csv")
     out_df.to_csv(output_csv_path, sep=sep, encoding=encoding, index=False)
+    analyze_table_quality(out_df, table_name=str(Path(output_csv_path).with_suffix("")))
     return output_csv_path

--- a/library/iuphar.py
+++ b/library/iuphar.py
@@ -15,6 +15,11 @@ import pandas as pd
 import requests
 from requests import Session
 
+try:
+    from data_profiling import analyze_table_quality
+except ModuleNotFoundError:  # pragma: no cover
+    from .data_profiling import analyze_table_quality
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -545,6 +550,7 @@ class IUPHARData:
         df["full_name_path"] = df["target_id"].apply(self.all_name)
 
         df.to_csv(output_path, index=False, encoding=encoding, sep=sep)
+        analyze_table_quality(df, table_name=str(Path(output_path).with_suffix("")))
         LOGGER.info("file_written", extra={"rows": len(df), "path": str(output_path)})
         return df
 

--- a/library/uniprot_enrich/enrich.py
+++ b/library/uniprot_enrich/enrich.py
@@ -3,9 +3,15 @@ import random
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, Iterable, List, Optional
+from pathlib import Path
 
 import pandas as pd
 import requests
+
+try:
+    from data_profiling import analyze_table_quality
+except ModuleNotFoundError:  # pragma: no cover
+    from ..data_profiling import analyze_table_quality
 
 OUTPUT_COLUMNS = [
     "uniprotkb_Id",
@@ -509,3 +515,4 @@ def enrich_uniprot(input_csv_path: str, list_sep: str = "|") -> None:
     df_original = pd.read_csv(input_csv_path)
     df_original.to_csv(backup_path, index=False, encoding="utf-8", lineterminator="\n")
     df.to_csv(input_csv_path, index=False, encoding="utf-8", lineterminator="\n")
+    analyze_table_quality(df, table_name=str(Path(input_csv_path).with_suffix("")))

--- a/scripts/data_profiling_main.py
+++ b/scripts/data_profiling_main.py
@@ -1,0 +1,41 @@
+"""Command line interface for generating data profiling reports."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Sequence
+
+from library.data_profiling import analyze_table_quality
+
+DEFAULT_LOG_LEVEL = "INFO"
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the profiling utility on a CSV file."""
+
+    parser = argparse.ArgumentParser(
+        description="Generate quality and correlation reports for a table"
+    )
+    parser.add_argument("--input", default="input.csv", help="Path to input CSV file")
+    parser.add_argument(
+        "--output-prefix",
+        help=(
+            "Prefix for output reports. Defaults to the input file stem in the current"
+            " directory"
+        ),
+    )
+    parser.add_argument(
+        "--log-level", default=DEFAULT_LOG_LEVEL, help="Logging verbosity level"
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    table_name = args.output_prefix or str(Path(args.input).with_suffix(""))
+    analyze_table_quality(args.input, table_name=table_name)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/dump_gtop_target.py
+++ b/scripts/dump_gtop_target.py
@@ -14,6 +14,7 @@ from typing import List, cast
 
 import pandas as pd
 import yaml
+from library.data_profiling import analyze_table_quality
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -137,6 +138,9 @@ def main() -> None:
         sep=cfg_dict.get("output", {}).get("sep", ","),
         quoting=csv.QUOTE_MINIMAL,
     )
+    analyze_table_quality(
+        targets_df, table_name=str((out_dir / "targets").with_suffix(""))
+    )
     syn_df = (
         pd.concat(syn_rows, ignore_index=True)
         if syn_rows
@@ -148,6 +152,9 @@ def main() -> None:
         encoding=cfg_dict.get("output", {}).get("encoding", "utf-8-sig"),
         sep=cfg_dict.get("output", {}).get("sep", ","),
         quoting=csv.QUOTE_MINIMAL,
+    )
+    analyze_table_quality(
+        syn_df, table_name=str((out_dir / "targets_synonyms").with_suffix(""))
     )
     int_df = (
         pd.concat(int_rows, ignore_index=True)
@@ -173,6 +180,9 @@ def main() -> None:
         encoding=cfg_dict.get("output", {}).get("encoding", "utf-8-sig"),
         sep=cfg_dict.get("output", {}).get("sep", ","),
         quoting=csv.QUOTE_MINIMAL,
+    )
+    analyze_table_quality(
+        int_df, table_name=str((out_dir / "targets_interactions").with_suffix(""))
     )
 
 

--- a/scripts/get_target_data_main.py
+++ b/scripts/get_target_data_main.py
@@ -14,6 +14,7 @@ if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
 from chembl_targets import TargetConfig, fetch_targets  # noqa: E402
+from data_profiling import analyze_table_quality  # noqa: E402
 
 DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_SEP = ","
@@ -46,6 +47,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     result.to_csv(
         args.output, index=False, sep=cfg.output_sep, encoding=cfg.output_encoding
     )
+    analyze_table_quality(result, table_name=str(Path(args.output).with_suffix("")))
 
     print(args.output)
 

--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -10,7 +10,7 @@ import logging
 import sys
 from pathlib import Path
 
-from typing import Any, Callable, Dict, Iterable, List
+from typing import Any, Callable, Dict, Iterable, List, Sequence
 
 import pandas as pd
 import yaml  # type: ignore[import]
@@ -38,6 +38,7 @@ from library.uniprot_enrich.enrich import (
 
 
 from library.protein_classifier import classify_protein
+from library.data_profiling import analyze_table_quality
 
 
 from library.pipeline_targets import (
@@ -647,6 +648,7 @@ def save_output(
     out_path = Path(output).expanduser().resolve()
     out_path.parent.mkdir(parents=True, exist_ok=True)
     df.to_csv(out_path, index=False, sep=sep, encoding=encoding)
+    analyze_table_quality(df, table_name=str(out_path.with_suffix("")))
     return out_path
 
 
@@ -726,7 +728,7 @@ def main() -> None:
     chembl_df = fetch_targets(ids, chembl_cfg, batch_size=args.batch_size)
 
     def _cached_chembl_fetch(
-        _: List[str], __: TargetConfig
+        _: Sequence[str], __: TargetConfig
     ) -> pd.DataFrame:  # pragma: no cover - simple wrapper
         return chembl_df
 

--- a/scripts/protein_classify_main.py
+++ b/scripts/protein_classify_main.py
@@ -21,6 +21,7 @@ if str(ROOT) not in sys.path:
 
 from library.protein_classifier import classify_protein
 from library.chembl2uniprot.logging_utils import configure_logging
+from library.data_profiling import analyze_table_quality
 
 DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_SEP = ";"
@@ -73,6 +74,7 @@ def main(argv: list[str] | None = None) -> None:
     df["evidence"] = results.apply(lambda r: ";".join(r.get("evidence", [])))
 
     df.to_csv(output_path, index=False, encoding=args.encoding, lineterminator="\n")
+    analyze_table_quality(df, table_name=str(output_path.with_suffix("")))
     print(output_path)
 
 

--- a/tests/test_data_profiling.py
+++ b/tests/test_data_profiling.py
@@ -1,0 +1,22 @@
+"""Tests for the :mod:`library.data_profiling` module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from library.data_profiling import analyze_table_quality
+
+
+def test_analyze_table_quality_creates_reports(tmp_path: Path) -> None:
+    """Profile a small data frame and ensure reports are written."""
+
+    df = pd.DataFrame({"num": [1, 2, 3], "text": ["a", "b", None]})
+    prefix = tmp_path / "sample"
+    quality, corr = analyze_table_quality(df, table_name=str(prefix))
+
+    assert quality["column"].tolist() == ["num", "text"]
+    assert (tmp_path / "sample_quality_report_table.csv").exists()
+    assert (tmp_path / "sample_data_correlation_report_table.csv").exists()
+    assert isinstance(corr, pd.DataFrame)


### PR DESCRIPTION
## Summary
- add reusable table-profiling utility and CLI
- generate quality and correlation reports whenever pipeline tables are written
- cover profiling utility with unit tests

## Testing
- `ruff check library/chembl2uniprot/mapping.py library/iuphar.py library/hgnc_client.py library/uniprot_enrich/enrich.py >/tmp/ruff.log && tail -n 20 /tmp/ruff.log`
- `mypy library scripts >/tmp/mypy.log && tail -n 20 /tmp/mypy.log`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68c837bc4eac832498a8fd740d37f2fd