### PR TITLE
Add optional HTTP caching layer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -190,3 +190,8 @@ orthologs:
   retries: 3
   backoff_base_sec: 1.0
 
+http_cache:
+  enabled: false
+  path: ".cache/http_cache"
+  ttl_sec: 86400
+

--- a/library/chembl_targets.py
+++ b/library/chembl_targets.py
@@ -27,9 +27,9 @@ import pandas as pd
 # as a standalone module during testing. We therefore try a relative import
 # first and fall back to the top-level module.
 try:  # pragma: no cover - fallback for test environments
-    from .http_client import HttpClient
+    from .http_client import CacheConfig, HttpClient
 except ImportError:  # pragma: no cover
-    from http_client import HttpClient  # type: ignore[no-redef]
+    from http_client import CacheConfig, HttpClient  # type: ignore[no-redef]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -52,6 +52,8 @@ class TargetConfig:
         Maximum number of retry attempts for failed requests.
     rps:
         Allowed requests per second against the API.
+    cache:
+        Optional HTTP cache configuration applied to outbound requests.
     output_encoding:
         Encoding used when writing CSV output.
     output_sep:
@@ -67,6 +69,7 @@ class TargetConfig:
     timeout_sec: float = 30.0
     max_retries: int = 3
     rps: float = 2.0
+    cache: CacheConfig | None = None
     output_encoding: str = "utf-8-sig"
     output_sep: str = ","
     list_format: str = "json"  # "json" or "pipe"
@@ -357,7 +360,10 @@ def fetch_targets(
 
     norm_ids = normalise_ids(ids)
     client = HttpClient(
-        timeout=cfg.timeout_sec, max_retries=cfg.max_retries, rps=cfg.rps
+        timeout=cfg.timeout_sec,
+        max_retries=cfg.max_retries,
+        rps=cfg.rps,
+        cache_config=cfg.cache,
     )
     records: List[Dict[str, Any]] = []
     base = cfg.base_url.rstrip("/")

--- a/library/gtop_client.py
+++ b/library/gtop_client.py
@@ -26,9 +26,9 @@ import requests
 # ``gtop_client`` is imported both as a module within the package and directly in
 # tests. The conditional import below supports both patterns.
 try:  # pragma: no cover - support test environments
-    from .http_client import HttpClient
+    from .http_client import CacheConfig, HttpClient
 except ImportError:  # pragma: no cover
-    from http_client import HttpClient  # type: ignore[no-redef]
+    from http_client import CacheConfig, HttpClient  # type: ignore[no-redef]
 
 
 LOGGER = logging.getLogger(__name__)
@@ -48,12 +48,15 @@ class GtoPConfig:
         Number of retry attempts for transient failures.
     rps:
         Maximum requests per second enforced via a token bucket.
+    cache:
+        Optional HTTP cache configuration shared by all requests.
     """
 
     base_url: str
     timeout_sec: float = 30.0
     max_retries: int = 3
     rps: float = 2.0
+    cache: CacheConfig | None = None
 
 
 class GtoPClient:
@@ -62,7 +65,10 @@ class GtoPClient:
     def __init__(self, cfg: GtoPConfig) -> None:
         self.cfg = cfg
         self.http = HttpClient(
-            timeout=cfg.timeout_sec, max_retries=cfg.max_retries, rps=cfg.rps
+            timeout=cfg.timeout_sec,
+            max_retries=cfg.max_retries,
+            rps=cfg.rps,
+            cache_config=cfg.cache,
         )
         self.base_url = cfg.base_url.rstrip("/")
 

--- a/library/hgnc_client.py
+++ b/library/hgnc_client.py
@@ -26,6 +26,11 @@ try:
 except ModuleNotFoundError:  # pragma: no cover
     from .data_profiling import analyze_table_quality
 
+try:  # pragma: no cover - support package and script imports
+    from .http_client import CacheConfig, create_http_session
+except ImportError:  # pragma: no cover
+    from http_client import CacheConfig, create_http_session  # type: ignore[no-redef]
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -65,12 +70,27 @@ class OutputConfig:
 
 @dataclass
 class Config:
-    """Aggregated application configuration."""
+    """Aggregated application configuration.
+
+    Attributes
+    ----------
+    hgnc:
+        Endpoint configuration for the HGNC REST API.
+    network:
+        Network behaviour settings (timeout and retries).
+    rate_limit:
+        Rate limiting parameters applied to outbound requests.
+    output:
+        CSV output options controlling encoding and separator.
+    cache:
+        Optional HTTP cache configuration shared by network requests.
+    """
 
     hgnc: HGNCServiceConfig
     network: NetworkConfig
     rate_limit: RateLimitConfig
     output: OutputConfig
+    cache: CacheConfig | None = None
 
 
 def load_config(path: str | Path, *, section: str | None = None) -> Config:
@@ -96,6 +116,7 @@ def load_config(path: str | Path, *, section: str | None = None) -> Config:
         network=NetworkConfig(**data["network"]),
         rate_limit=RateLimitConfig(**data["rate_limit"]),
         output=OutputConfig(**data["output"]),
+        cache=CacheConfig.from_dict(data.get("cache")),
     )
 
 
@@ -144,6 +165,7 @@ class HGNCClient:
     def __init__(self, cfg: Config) -> None:
         self.cfg = cfg
         self.rate_limiter = RateLimiter(cfg.rate_limit.rps)
+        self.session = create_http_session(cfg.cache)
 
     def _request(self, url: str) -> requests.Response:
         """Perform a GET request with retry and rate limiting.
@@ -168,7 +190,7 @@ class HGNCClient:
         for attempt in range(self.cfg.network.max_retries):
             self.rate_limiter.wait()
             try:
-                resp = requests.get(
+                resp = self.session.get(
                     url,
                     timeout=self.cfg.network.timeout_sec,
                     headers={"Accept": "application/json"},

--- a/library/http_client.py
+++ b/library/http_client.py
@@ -21,9 +21,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 import time
-from typing import Any
+from pathlib import Path
+from typing import Any, Mapping, Optional
 
 import requests
+import requests_cache
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -32,6 +34,97 @@ from tenacity import (
 )
 
 LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class CacheConfig:
+    """Configuration for persistent HTTP caching.
+
+    Parameters
+    ----------
+    enabled:
+        Whether the cache layer should be activated.  When ``False`` a regular
+        :class:`requests.Session` instance is created.
+    path:
+        Filesystem path passed to :class:`requests_cache.CachedSession`.  The
+        parent directory is created automatically when caching is enabled.
+    ttl_seconds:
+        Time-to-live for cached responses in seconds.  ``0`` disables
+        persistence.
+    """
+
+    enabled: bool = False
+    path: str | None = None
+    ttl_seconds: float = 0.0
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any] | None) -> "CacheConfig" | None:
+        """Build a :class:`CacheConfig` from a configuration mapping.
+
+        Parameters
+        ----------
+        data:
+            Mapping holding configuration keys such as ``enabled``, ``path`` and
+            ``ttl``/``ttl_sec``/``ttl_seconds``.
+
+        Returns
+        -------
+        CacheConfig | None
+            Parsed configuration or ``None`` when the mapping is empty.
+        """
+
+        if not data:
+            return None
+        ttl = (
+            data.get("ttl")
+            or data.get("ttl_sec")
+            or data.get("ttl_seconds")
+            or data.get("expire_after")
+        )
+        ttl_value = float(ttl) if ttl is not None else 0.0
+        path = data.get("path")
+        return cls(
+            enabled=bool(data.get("enabled", False)),
+            path=str(path) if path is not None else None,
+            ttl_seconds=ttl_value,
+        )
+
+    def is_active(self) -> bool:
+        """Return ``True`` when caching should be enabled."""
+
+        return (
+            self.enabled
+            and self.path is not None
+            and isinstance(self.ttl_seconds, (int, float))
+            and self.ttl_seconds > 0
+        )
+
+
+def create_http_session(cache_config: CacheConfig | None = None) -> requests.Session:
+    """Return a :class:`requests.Session` honouring ``cache_config``.
+
+    When caching is disabled or misconfigured, a plain session is returned.
+    Otherwise, :class:`requests_cache.CachedSession` is instantiated with the
+    provided settings.
+    """
+
+    if cache_config is None or not cache_config.is_active():
+        return requests.Session()
+    assert cache_config.path is not None
+    cache_path = Path(cache_config.path).expanduser()
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    LOGGER.debug(
+        "HTTP cache enabled at %s with TTL %.0f s",
+        cache_path,
+        cache_config.ttl_seconds,
+    )
+    session = requests_cache.CachedSession(
+        cache_name=str(cache_path),
+        backend="sqlite",
+        expire_after=int(cache_config.ttl_seconds),
+        allowable_methods=("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"),
+    )
+    return session
 
 
 @dataclass
@@ -63,13 +156,21 @@ class RateLimiter:
 
 
 class HttpClient:
-    """Wrapper around :mod:`requests` with retry and rate limiting."""
+    """Wrapper around :mod:`requests` with retry, caching and rate limiting."""
 
-    def __init__(self, *, timeout: float, max_retries: int, rps: float) -> None:
+    def __init__(
+        self,
+        *,
+        timeout: float,
+        max_retries: int,
+        rps: float,
+        cache_config: CacheConfig | None = None,
+        session: Optional[requests.Session] = None,
+    ) -> None:
         self.timeout = timeout
         self.max_retries = max_retries
         self.rate_limiter = RateLimiter(rps)
-        self.session = requests.Session()
+        self.session = session or create_http_session(cache_config)
 
     def request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
         """Perform an HTTP request honouring retry and rate limits.
@@ -101,4 +202,4 @@ class HttpClient:
         return resp
 
 
-__all__ = ["HttpClient", "RateLimiter"]
+__all__ = ["CacheConfig", "HttpClient", "RateLimiter", "create_http_session"]

--- a/library/io_utils.py
+++ b/library/io_utils.py
@@ -68,6 +68,7 @@ def _serialise_list(values: Iterable[Any], list_format: str) -> str:
     str
         The serialized string.
     """
+
     def _normalise(v: Any) -> Any:
         if isinstance(v, tuple):
             # Represent domain tuples as id|name or JSON object

--- a/library/uniprot_enrich/enrich.py
+++ b/library/uniprot_enrich/enrich.py
@@ -2,7 +2,7 @@ import logging
 import random
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional
 from pathlib import Path
 
 import pandas as pd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pandas",
     "pydantic>=2.0",
     "requests",
+    "requests-cache",
     "tenacity",
     "tqdm",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ jsonschema>=4.17
 tqdm>=4.66
 tenacity>=8.2
 pydantic>=2.0
+requests-cache>=1.1
 
 # Development
 pytest>=7.4

--- a/scripts/dump_gtop_target.py
+++ b/scripts/dump_gtop_target.py
@@ -22,6 +22,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from library.gtop_client import GtoPClient, GtoPConfig, resolve_target  # noqa: E402
+from library.http_client import CacheConfig  # noqa: E402
 from library.gtop_normalize import (  # noqa: E402
     normalise_interactions,
     normalise_synonyms,
@@ -97,6 +98,7 @@ def main() -> None:
     logging.basicConfig(level=getattr(logging, args.log_level.upper()))
     cfg_dict = _load_config(Path(args.config))
     gcfg = cfg_dict.get("gtop", {})
+    global_cache = CacheConfig.from_dict(cfg_dict.get("http_cache"))
     client = GtoPClient(
         GtoPConfig(
             base_url=gcfg.get(
@@ -105,6 +107,7 @@ def main() -> None:
             timeout_sec=cfg_dict.get("network", {}).get("timeout_sec", 30),
             max_retries=cfg_dict.get("network", {}).get("max_retries", 3),
             rps=cfg_dict.get("rate_limit", {}).get("rps", 2),
+            cache=CacheConfig.from_dict(gcfg.get("cache")) or global_cache,
         )
     )
 

--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -31,6 +31,7 @@ from library.uniprot_client import (
     UniProtClient,
 )
 from library.orthologs import EnsemblHomologyClient, OmaClient
+from library.http_client import CacheConfig
 from library.uniprot_enrich.enrich import (
     UniProtClient as UniProtEnrichClient,
     _collect_ec_numbers,
@@ -546,7 +547,11 @@ def parse_args() -> argparse.Namespace:
 
 
 def build_clients(
-    cfg_path: str, pipeline_cfg: PipelineConfig, *, with_orthologs: bool = False
+    cfg_path: str,
+    pipeline_cfg: PipelineConfig,
+    *,
+    with_orthologs: bool = False,
+    default_cache: CacheConfig | None = None,
 ) -> tuple[
     UniProtClient,
     HGNCClient,
@@ -555,12 +560,27 @@ def build_clients(
     OmaClient | None,
     list[str],
 ]:
-    """Initialise service clients used by the pipeline."""
+    """Initialise service clients used by the pipeline.
+
+    Parameters
+    ----------
+    cfg_path:
+        Path to the YAML configuration file.
+    pipeline_cfg:
+        High-level pipeline configuration controlling retries and rate limits.
+    with_orthologs:
+        When ``True`` return ortholog clients in addition to the core clients.
+    default_cache:
+        Optional fallback cache configuration applied when a section does not
+        specify its own cache settings.
+    """
 
     with open(cfg_path, "r", encoding="utf-8") as fh:
         data = yaml.safe_load(fh) or {}
+    global_cache = default_cache or CacheConfig.from_dict(data.get("http_cache"))
     uni_cfg = data["uniprot"]
     fields = ",".join(uni_cfg.get("fields", []))
+    uni_cache = CacheConfig.from_dict(uni_cfg.get("cache")) or global_cache
     uni = UniProtClient(
         base_url=uni_cfg["base_url"],
         fields=fields,
@@ -569,6 +589,7 @@ def build_clients(
             max_retries=pipeline_cfg.retries,
         ),
         rate_limit=UniRateConfig(rps=pipeline_cfg.rate_limit_rps),
+        cache=uni_cache,
     )
 
     # The HGNC configuration is nested under the top-level "hgnc" section
@@ -579,6 +600,11 @@ def build_clients(
     hcfg.network.timeout_sec = pipeline_cfg.timeout_sec
     hcfg.network.max_retries = pipeline_cfg.retries
     hcfg.rate_limit.rps = pipeline_cfg.rate_limit_rps
+    hcfg.cache = (
+        hcfg.cache
+        or CacheConfig.from_dict(data.get("hgnc", {}).get("cache"))
+        or global_cache
+    )
     hgnc = HGNCClient(hcfg)
 
     gcfg = GtoPConfig(
@@ -586,6 +612,7 @@ def build_clients(
         timeout_sec=pipeline_cfg.timeout_sec,
         max_retries=pipeline_cfg.retries,
         rps=pipeline_cfg.rate_limit_rps,
+        cache=CacheConfig.from_dict(data.get("gtop", {}).get("cache")) or global_cache,
     )
     gtop = GtoPClient(gcfg)
 
@@ -594,6 +621,7 @@ def build_clients(
     target_species: list[str] = []
     if with_orthologs:
         orth_cfg = data.get("orthologs", {})
+        orth_cache = CacheConfig.from_dict(orth_cfg.get("cache")) or global_cache
         ens_client = EnsemblHomologyClient(
             base_url="https://rest.ensembl.org",
             network=UniNetworkConfig(
@@ -601,6 +629,7 @@ def build_clients(
                 max_retries=pipeline_cfg.retries,
             ),
             rate_limit=UniRateConfig(rps=pipeline_cfg.rate_limit_rps),
+            cache=orth_cache,
         )
         oma_client = OmaClient(
             base_url="https://omabrowser.org/api",
@@ -609,6 +638,7 @@ def build_clients(
                 max_retries=pipeline_cfg.retries,
             ),
             rate_limit=UniRateConfig(rps=pipeline_cfg.rate_limit_rps),
+            cache=orth_cache,
         )
         target_species = list(orth_cfg.get("target_species", []))
     return uni, hgnc, gtop, ens_client, oma_client, target_species
@@ -673,6 +703,7 @@ def main() -> None:
     # Load optional ChEMBL column configuration and ensure required fields
     with open(args.config, "r", encoding="utf-8") as fh:
         data = yaml.safe_load(fh) or {}
+    global_cache = CacheConfig.from_dict(data.get("http_cache"))
     chembl_cols = list(data.get("chembl", {}).get("columns", []))
     required_cols = [
         "target_chembl_id",
@@ -694,8 +725,11 @@ def main() -> None:
     for col in required_cols:
         if col not in columns:
             columns.append(col)
+    chembl_cache = CacheConfig.from_dict(data.get("chembl", {}).get("cache"))
     chembl_cfg: TargetConfig = TargetConfig(
-        list_format=pipeline_cfg.list_format, columns=columns
+        list_format=pipeline_cfg.list_format,
+        columns=columns,
+        cache=chembl_cache or global_cache,
     )
 
     # Merge additional column requirements from other data sources so that the
@@ -715,7 +749,12 @@ def main() -> None:
         ens_client,
         oma_client,
         target_species,
-    ) = build_clients(args.config, pipeline_cfg, with_orthologs=args.with_orthologs)
+    ) = build_clients(
+        args.config,
+        pipeline_cfg,
+        with_orthologs=args.with_orthologs,
+        default_cache=global_cache,
+    )
 
     df = pd.read_csv(args.input, sep=args.sep, encoding=args.encoding)
     if args.id_column not in df.columns:

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from library.http_client import CacheConfig, HttpClient
+
+
+def test_http_client_uses_cache(tmp_path: Path, requests_mock) -> None:
+    """Responses are served from cache on repeated calls."""
+
+    url = "https://example.org/resource"
+    requests_mock.get(url, json={"status": "ok"})
+    cache_path = tmp_path / "http_cache"
+    client = HttpClient(
+        timeout=1,
+        max_retries=1,
+        rps=0,
+        cache_config=CacheConfig(enabled=True, path=str(cache_path), ttl_seconds=60),
+    )
+
+    first = client.request("get", url)
+    assert first.json() == {"status": "ok"}
+    assert not getattr(first, "from_cache", False)
+
+    second = client.request("get", url)
+    assert second.json() == {"status": "ok"}
+    assert getattr(second, "from_cache", False)
+
+    assert requests_mock.call_count == 1


### PR DESCRIPTION
## Summary
- add a CacheConfig helper to provide optional requests-cache support and plumb it through HttpClient and service clients
- load cache configuration from config.yaml and CLI scripts so the new http_cache section controls shared caching behaviour
- depend on requests-cache and add a unit test covering cached response reuse

## Testing
- black .
- ruff check .
- pytest
- mypy . *(fails: repo already contains missing stub and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c85e5a926483248762066036603b97