### PR TITLE
Add shared logging utilities with JSON formatter

### DIFF
--- a/library/chembl2uniprot/logging_utils.py
+++ b/library/chembl2uniprot/logging_utils.py
@@ -1,87 +1,16 @@
-"""Structured logging helpers with redaction support."""
+"""Compatibility wrapper around :mod:`library.logging_utils`.
+
+The project's historical entry points import :func:`configure_logging` from
+``library.chembl2uniprot.logging_utils``.  This module now simply re-exports the
+centralised utilities located in :mod:`library.logging_utils`.
+"""
 
 from __future__ import annotations
 
-import json
-import logging
-import logging.config
-import re
-from typing import Any
+from library.logging_utils import (
+    JsonFormatter,
+    SecretRedactingFilter,
+    configure_logging,
+)
 
-__all__ = ["configure_logging"]
-
-
-class RedactFilter(logging.Filter):
-    """Filter that redacts obvious secret values.
-
-    Any log message containing substrings like ``token=`` or ``key=`` will have
-    the value replaced with ``***`` before being emitted.  The implementation is
-    intentionally simple and meant only as a safeguard against accidental leaks.
-    """
-
-    _pattern = re.compile(r"(?i)(token|key)=([^\s]+)")
-
-    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401
-        message = record.getMessage()
-        message = self._pattern.sub(lambda m: f"{m.group(1)}=***", message)
-        record.msg = message
-        record.args = {}
-        return True
-
-
-class JsonFormatter(logging.Formatter):
-    """Formats log records as JSON strings.
-
-    This formatter converts a log record into a JSON object, making it suitable
-    for structured logging. The resulting JSON includes the log level, logger
-    name, and the log message.
-
-    Example
-    -------
-    A log record with level "INFO", name "my_logger", and message "Hello" will
-    be formatted as:
-    `{"level": "INFO", "name": "my_logger", "message": "Hello"}`
-    """
-
-    def format(self, record: logging.LogRecord) -> str:  # noqa: D401
-        data: dict[str, Any] = {
-            "level": record.levelname,
-            "name": record.name,
-            "message": record.getMessage(),
-        }
-        return json.dumps(data, ensure_ascii=False)
-
-
-def configure_logging(level: str, json_logs: bool = False) -> None:
-    """Configure application logging.
-
-    Parameters
-    ----------
-    level:
-        Logging level (e.g. ``"INFO"`` or ``"DEBUG"``).
-    json_logs:
-        When ``True`` emit JSON-formatted logs instead of human-readable ones.
-    """
-
-    formatter = "json" if json_logs else "human"
-    logging.config.dictConfig(
-        {
-            "version": 1,
-            "disable_existing_loggers": False,
-            "filters": {"redact": {"()": RedactFilter}},
-            "formatters": {
-                "human": {"format": "%(levelname)s %(name)s %(message)s"},
-                "json": {"()": JsonFormatter},
-            },
-            "handlers": {
-                "default": {
-                    "class": "logging.StreamHandler",
-                    "level": level.upper(),
-                    "filters": ["redact"],
-                    "formatter": formatter,
-                    "stream": "ext://sys.stderr",
-                }
-            },
-            "root": {"level": level.upper(), "handlers": ["default"]},
-        }
-    )
+__all__ = ["JsonFormatter", "SecretRedactingFilter", "configure_logging"]

--- a/library/chembl2uniprot/mapping.py
+++ b/library/chembl2uniprot/mapping.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Sequence, cast
+from typing import Any, Dict, Iterable, List, Sequence, cast, Literal
 import hashlib
 import json
 import logging
@@ -391,7 +391,7 @@ def map_chembl_to_uniprot(
     *,
     config_section: str | None = None,
     log_level: str | None = None,
-    log_format: str | None = None,
+    log_format: Literal["human", "json"] | None = None,
     sep: str | None = None,
     encoding: str | None = None,
 ) -> Path:
@@ -443,12 +443,15 @@ def map_chembl_to_uniprot(
 
     # Allow overriding the configuration with function arguments
     log_level = log_level or cfg.logging.level
-    log_format = log_format or cfg.logging.format
+    resolved_format = log_format or cfg.logging.format
     sep = sep or cfg.io.csv.separator
     encoding_in = encoding or cfg.io.input.encoding
     encoding_out = encoding or cfg.io.output.encoding
 
-    configure_logging(log_level, json_logs=log_format == "json")
+    configure_logging(
+        log_level,
+        log_format=cast(Literal["human", "json"], resolved_format),
+    )
     logging.getLogger("urllib3").setLevel(logging.INFO)  # Reduce HTTP verbosity
 
     input_csv_path = Path(input_csv_path)

--- a/library/logging_utils.py
+++ b/library/logging_utils.py
@@ -1,0 +1,221 @@
+"""Project-wide logging helpers with JSON output and secret redaction.
+
+The module provides a configurable logging setup that can emit either
+human-readable or JSON-formatted records.  A :class:`SecretRedactingFilter`
+scans messages and extra context for common secret patterns and replaces the
+corresponding values with ``"***"`` to reduce the risk of leaking credentials.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import logging.config
+import re
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+__all__ = [
+    "JsonFormatter",
+    "SecretRedactingFilter",
+    "configure_logging",
+]
+
+LogFormat = Literal["human", "json"]
+
+_SECRET_KEY_PATTERN = (
+    r"(?:token|secret|password|api[_-]?key|access[_-]?token|auth[_-]?token)"
+)
+_SECRET_REGEX = re.compile(
+    rf"(?i)(?P<prefix>\b{_SECRET_KEY_PATTERN}\b(?:\"|')?\s*[:=]\s*(?:\"|')?)(?P<secret>[^\"',;\s]+)"
+)
+_SECRET_NAME_REGEX = re.compile(rf"(?i)^{_SECRET_KEY_PATTERN}$")
+
+_LOG_RECORD_SKIP_SANITISE = {"msg", "args", "exc_info", "stack_info"}
+_LOG_RECORD_RESERVED_KEYS = {
+    "args",
+    "asctime",
+    "created",
+    "exc_info",
+    "exc_text",
+    "filename",
+    "funcName",
+    "levelname",
+    "levelno",
+    "lineno",
+    "message",
+    "module",
+    "msecs",
+    "msg",
+    "name",
+    "pathname",
+    "process",
+    "processName",
+    "relativeCreated",
+    "stack_info",
+    "thread",
+    "threadName",
+}
+
+
+class SecretRedactingFilter(logging.Filter):
+    """Filter log records to mask common secret tokens.
+
+    The filter replaces obvious secrets (``token=``, ``password=``, etc.) with
+    the placeholder ``"***"``.  Redaction is applied to the formatted log
+    message as well as to values supplied through ``extra`` keyword arguments.
+    The implementation intentionally favours simplicity over completeness and is
+    meant to prevent accidental leaks in command line tools.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401
+        record.msg = self._sanitize(record.getMessage())
+        # ``logging.Filter`` runs before the formatter.  By emptying ``args`` we
+        # prevent the logging framework from attempting to perform %-formatting
+        # again after the message has been sanitised.
+        record.args = ()
+
+        for attr, value in list(record.__dict__.items()):
+            if attr in _LOG_RECORD_SKIP_SANITISE:
+                continue
+            new_value = self._sanitize(value)
+            if _SECRET_NAME_REGEX.search(attr):
+                new_value = "***"
+            record.__dict__[attr] = new_value
+        return True
+
+    @classmethod
+    def _sanitize(cls, value: Any) -> Any:
+        """Recursively redact secrets from ``value``."""
+
+        if isinstance(value, str):
+            return _SECRET_REGEX.sub(lambda match: f"{match.group('prefix')}***", value)
+        if isinstance(value, Mapping):
+            sanitized: dict[Any, Any] = {}
+            for key, val in value.items():
+                new_val = cls._sanitize(val)
+                if isinstance(key, str) and _SECRET_NAME_REGEX.search(key):
+                    new_val = "***"
+                sanitized[key] = new_val
+            return sanitized
+        if isinstance(value, list):
+            return [cls._sanitize(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(cls._sanitize(item) for item in value)
+        if isinstance(value, set):
+            return {cls._sanitize(item) for item in value}
+        return value
+
+
+class JsonFormatter(logging.Formatter):
+    """Format :class:`logging.LogRecord` instances as JSON strings.
+
+    The formatter emits ISO-8601 timestamps, log levels, logger names and the
+    message.  Extra context attached to the log record via ``extra`` is emitted
+    under the ``"extra"`` key once converted into JSON-compatible data
+    structures.
+    """
+
+    def __init__(self, *, ensure_ascii: bool = False) -> None:
+        super().__init__()
+        self.ensure_ascii = ensure_ascii
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401
+        timestamp = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        payload: dict[str, Any] = {
+            "timestamp": timestamp.isoformat().replace("+00:00", "Z"),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack_info"] = self.formatStack(record.stack_info)
+
+        extras = {
+            key: value
+            for key, value in record.__dict__.items()
+            if key not in _LOG_RECORD_RESERVED_KEYS and not key.startswith("_")
+        }
+        if extras:
+            payload["extra"] = self._json_compatible(extras)
+
+        return json.dumps(payload, ensure_ascii=self.ensure_ascii)
+
+    def _json_compatible(self, value: Any) -> Any:
+        """Convert ``value`` into JSON-serialisable data."""
+
+        if isinstance(value, Mapping):
+            return {str(key): self._json_compatible(val) for key, val in value.items()}
+        if isinstance(value, list):
+            return [self._json_compatible(item) for item in value]
+        if isinstance(value, tuple):
+            return [self._json_compatible(item) for item in value]
+        if isinstance(value, set):
+            return [self._json_compatible(item) for item in value]
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            return [self._json_compatible(item) for item in value]
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            return value
+        return repr(value)
+
+
+def _resolve_level(log_level: str) -> int:
+    """Resolve ``log_level`` to a numeric logging level."""
+
+    level = logging.getLevelName(log_level.upper())
+    if isinstance(level, str):
+        msg = f"Unknown log level: {log_level!r}"
+        raise ValueError(msg)
+    return int(level)
+
+
+def configure_logging(
+    log_level: str = "INFO", *, log_format: LogFormat = "human"
+) -> None:
+    """Configure application logging for CLI entry points.
+
+    Args:
+        log_level: Verbosity level name, for example ``"INFO"`` or ``"DEBUG"``.
+        log_format: Output format for log records.  ``"human"`` emits formatted
+            text while ``"json"`` writes structured JSON lines.
+
+    Raises:
+        ValueError: If ``log_format`` or ``log_level`` is not recognised.
+    """
+
+    if log_format not in ("human", "json"):
+        msg = f"Unsupported log format: {log_format!r}"
+        raise ValueError(msg)
+
+    level_value = _resolve_level(log_level)
+
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "filters": {"redact": {"()": SecretRedactingFilter}},
+            "formatters": {
+                "human": {
+                    "format": "%(asctime)s %(levelname)s [%(name)s] %(message)s",
+                    "datefmt": "%Y-%m-%dT%H:%M:%S%z",
+                },
+                "json": {"()": JsonFormatter},
+            },
+            "handlers": {
+                "default": {
+                    "class": "logging.StreamHandler",
+                    "level": level_value,
+                    "filters": ["redact"],
+                    "formatter": log_format,
+                    "stream": "ext://sys.stderr",
+                }
+            },
+            "root": {"level": level_value, "handlers": ["default"]},
+        }
+    )

--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -18,6 +18,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from library.io_utils import CsvConfig, write_rows  # noqa: E402
+from library.logging_utils import configure_logging  # noqa: E402
 
 LOGGER = logging.getLogger(__name__)
 
@@ -50,7 +51,7 @@ def main() -> None:
     compares their SHA-256 hashes.  A mismatch results in a ``RuntimeError``.
     """
 
-    logging.basicConfig(level=logging.INFO)
+    configure_logging("INFO")
 
     cfg = CsvConfig(sep=",", encoding="utf-8", list_format="json")
     rows = _sample_rows()

--- a/scripts/chembl2uniprot_main.py
+++ b/scripts/chembl2uniprot_main.py
@@ -26,10 +26,13 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 LIB_DIR = ROOT / "library"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
 from chembl2uniprot.mapping import map_chembl_to_uniprot  # noqa: E402
+from library.logging_utils import configure_logging  # noqa: E402
 
 
 DEFAULT_LOG_LEVEL = "INFO"
@@ -78,6 +81,8 @@ def main(argv: list[str] | None = None) -> None:
         help="File encoding for CSV input and output",
     )
     args = parser.parse_args(argv)
+
+    configure_logging(args.log_level, log_format=args.log_format)
 
     schema = ROOT / "schemas" / "config.schema.json"
     if args.config:

--- a/scripts/data_profiling_main.py
+++ b/scripts/data_profiling_main.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import argparse
-import logging
+import sys
 from pathlib import Path
 from typing import Sequence
 
-from library.data_profiling import analyze_table_quality
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from library.data_profiling import analyze_table_quality  # noqa: E402
+from library.logging_utils import configure_logging  # noqa: E402
 
 DEFAULT_LOG_LEVEL = "INFO"
 
@@ -31,7 +36,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
-    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    configure_logging(args.log_level)
 
     table_name = args.output_prefix or str(Path(args.input).with_suffix(""))
     analyze_table_quality(args.input, table_name=table_name)

--- a/scripts/dump_gtop_target.py
+++ b/scripts/dump_gtop_target.py
@@ -15,6 +15,7 @@ from typing import List, cast
 import pandas as pd
 import yaml
 from library.data_profiling import analyze_table_quality
+from library.logging_utils import configure_logging
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -94,7 +95,7 @@ def read_ids(path: Path, column: str) -> List[str]:
 def main() -> None:
     """Main entry point for the script."""
     args = parse_args()
-    logging.basicConfig(level=getattr(logging, args.log_level.upper()))
+    configure_logging(args.log_level)
     cfg_dict = _load_config(Path(args.config))
     gcfg = cfg_dict.get("gtop", {})
     client = GtoPClient(

--- a/scripts/get_hgnc_by_uniprot.py
+++ b/scripts/get_hgnc_by_uniprot.py
@@ -8,10 +8,13 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 LIB_DIR = ROOT / "library"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
 from hgnc_client import map_uniprot_to_hgnc  # noqa: E402
+from library.logging_utils import configure_logging  # noqa: E402
 
 DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_SEP = ","
@@ -42,6 +45,8 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--sep", default=DEFAULT_SEP, help="CSV field separator")
     parser.add_argument("--encoding", default=DEFAULT_ENCODING, help="File encoding")
     args = parser.parse_args(argv)
+
+    configure_logging(args.log_level)
 
     if args.config:
         config_path = Path(args.config)

--- a/scripts/get_target_data_main.py
+++ b/scripts/get_target_data_main.py
@@ -3,18 +3,20 @@
 from __future__ import annotations
 
 import argparse
-import logging
 import sys
 from pathlib import Path
 from typing import Sequence
 
 ROOT = Path(__file__).resolve().parents[1]
 LIB_DIR = ROOT / "library"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
 from chembl_targets import TargetConfig, fetch_targets  # noqa: E402
 from data_profiling import analyze_table_quality  # noqa: E402
+from library.logging_utils import configure_logging  # noqa: E402
 
 DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_SEP = ","
@@ -41,7 +43,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     parser.add_argument("--encoding", default=DEFAULT_ENCODING)
     args = parser.parse_args(argv)
 
-    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    configure_logging(args.log_level)
 
     import pandas as pd
 

--- a/scripts/get_uniprot_target_data.py
+++ b/scripts/get_uniprot_target_data.py
@@ -8,12 +8,12 @@ Example
 from __future__ import annotations
 
 import argparse
-import sys
+import json
 import logging
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
-import json
 
 import yaml
 
@@ -35,6 +35,7 @@ from library.uniprot_normalize import (  # noqa: E402
     output_columns,
 )
 from library.orthologs import EnsemblHomologyClient, OmaClient  # noqa: E402
+from library.logging_utils import configure_logging  # noqa: E402
 
 
 DEFAULT_INPUT = "input.csv"
@@ -94,7 +95,7 @@ def main(argv: List[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
-    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    configure_logging(args.log_level)
 
     config = yaml.safe_load((ROOT / "config.yaml").read_text())
     uniprot_cfg = config.get("uniprot", {})

--- a/scripts/iuphar_main.py
+++ b/scripts/iuphar_main.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
-import logging
 from pathlib import Path
 
 from library.iuphar import IUPHARData
+from library.logging_utils import configure_logging
 
 
 def parse_args() -> argparse.Namespace:
@@ -34,10 +34,7 @@ def main() -> None:
     """CLI entry point."""
 
     args = parse_args()
-    logging.basicConfig(
-        level=getattr(logging, args.log_level.upper(), logging.INFO),
-        format="%(levelname)s %(name)s %(message)s",
-    )
+    configure_logging(args.log_level)
     if args.output is None:
         date = dt.date.today().strftime("%Y%m%d")
         stem = Path(args.input).stem

--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -35,6 +35,7 @@ from library.uniprot_enrich.enrich import (
     UniProtClient as UniProtEnrichClient,
     _collect_ec_numbers,
 )
+from library.logging_utils import configure_logging
 
 
 from library.protein_classifier import classify_protein
@@ -656,7 +657,7 @@ def main() -> None:
     """Main entry point for the unified target data pipeline."""
 
     args = parse_args()
-    logging.basicConfig(level=args.log_level.upper())
+    configure_logging(args.log_level)
     pipeline_cfg = load_pipeline_config(args.config)
     pipeline_cfg.list_format = args.list_format
     pipeline_cfg.species_priority = [args.species]

--- a/scripts/protein_classify_main.py
+++ b/scripts/protein_classify_main.py
@@ -20,7 +20,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from library.protein_classifier import classify_protein
-from library.chembl2uniprot.logging_utils import configure_logging
+from library.logging_utils import configure_logging
 from library.data_profiling import analyze_table_quality
 
 DEFAULT_LOG_LEVEL = "INFO"

--- a/scripts/uniprot_enrich_main.py
+++ b/scripts/uniprot_enrich_main.py
@@ -37,7 +37,7 @@ if str(ROOT) not in sys.path:
 
 
 from library.uniprot_enrich import enrich_uniprot
-from library.chembl2uniprot.logging_utils import configure_logging
+from library.logging_utils import configure_logging
 
 
 DEFAULT_LOG_LEVEL = "INFO"
@@ -78,7 +78,7 @@ def main(argv: list[str] | None = None) -> None:
         help="Logging output format",
     )
     args = parser.parse_args()
-    configure_logging(args.log_level, json_logs=args.log_format == "json")
+    configure_logging(args.log_level, log_format=args.log_format)
 
     target = args.output or args.input
     if args.output:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -5,18 +5,38 @@ import json
 import logging
 import sys
 
-from chembl2uniprot.logging_utils import configure_logging
+from typing import Any, cast
+
 import pytest
+
+from library.logging_utils import configure_logging
 
 
 def test_json_logging_with_redaction(monkeypatch: pytest.MonkeyPatch) -> None:
-    """configure_logging emits JSON and redacts secrets."""
+    """``configure_logging`` emits JSON output and redacts secrets."""
+
     stream = io.StringIO()
     monkeypatch.setattr(sys, "stderr", stream)
-    configure_logging("INFO", json_logs=True)
+
+    configure_logging("INFO", log_format="json")
+
     logger = logging.getLogger("test")
-    logger.info("token=SECRET")
+    logger.info(
+        "token=SECRET",
+        extra={"api_key": "dont_show", "nested": {"password": "value"}},
+    )
+
     output = stream.getvalue().strip()
     data = json.loads(output)
+
     assert data["message"] == "token=***"
     assert data["level"] == "INFO"
+    assert data["extra"]["api_key"] == "***"
+    assert data["extra"]["nested"]["password"] == "***"
+
+
+def test_configure_logging_rejects_unknown_format() -> None:
+    """Unsupported log formats raise a :class:`ValueError`."""
+
+    with pytest.raises(ValueError):
+        configure_logging("INFO", log_format=cast(Any, "xml"))


### PR DESCRIPTION
## Summary
- add a reusable logging utility with JSON formatting and secret redaction
- update CLI entry points to configure logging via the shared helper and keep compatibility imports
- extend logging tests to cover structured output and invalid format handling

## Testing
- `pytest`
- `ruff check library/logging_utils.py library/chembl2uniprot/logging_utils.py scripts/chembl2uniprot_main.py scripts/check_determinism.py scripts/data_profiling_main.py scripts/dump_gtop_target.py scripts/get_uniprot_target_data.py scripts/get_target_data_main.py scripts/get_hgnc_by_uniprot.py scripts/iuphar_main.py scripts/pipeline_targets_main.py scripts/protein_classify_main.py scripts/uniprot_enrich_main.py tests/test_logging.py`
- `mypy --config-file mypy.ini library/logging_utils.py tests/test_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68c85ca2883083248fdb0da7eda70007