### PR TITLE
Configure pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,23 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.5
+    rev: v0.4.8
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]
   - repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 24.4.2
     hooks:
       - id: black
         language_version: python3.12
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest --maxfail=1
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ The primary goal of this project is to provide a deterministic and configurable 
     pip install -e .[dev]
     ```
 
+3.  Install the pre-commit hooks to ensure consistent formatting, linting, type
+    checking, and tests before each commit:
+    ```bash
+    pre-commit install
+    ```
+
 ## Project Structure
 
 The repository is organized as follows:


### PR DESCRIPTION
## Summary
- expand the pre-commit configuration to run ruff, black, mypy, and pytest with --maxfail=1
- document how to install the repository's pre-commit hooks in the installation instructions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8eafe486c8324b651a38d257540c2