### PR TITLE
Add utilities to retrieve ChEMBL tissue metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ python scripts/pipeline_targets_main.py \
 The `scripts/` directory contains several other scripts for performing specific tasks:
 
 *   `chembl2uniprot_main.py`: Map ChEMBL IDs to UniProt accessions.
+*   `chembl_tissue_main.py`: Download tissue metadata directly from ChEMBL.
 *   `get_target_data_main.py`: Download target metadata from ChEMBL.
 *   `get_uniprot_target_data.py`: Retrieve and normalize detailed information about UniProt targets.
 *   `get_hgnc_by_uniprot.py`: Map UniProt accessions to HGNC identifiers.

--- a/docs/chembl_tissue.md
+++ b/docs/chembl_tissue.md
@@ -1,0 +1,113 @@
+# ChEMBL Tissue Retrieval Utilities
+
+This document describes the reusable library function and accompanying command
+line interface for downloading tissue metadata from the public
+[ChEMBL](https://www.ebi.ac.uk/chembl/) API.
+
+## Dependencies
+
+The functionality relies on the following project dependencies (minimum
+versions match those declared in `pyproject.toml`):
+
+- Python 3.10+
+- `requests` ≥ 2.31
+- `requests-cache` ≥ 1.0 (optional, enables local HTTP caching)
+- `tenacity` ≥ 8.2
+- `pandas` ≥ 1.5 (only needed when working with other project components)
+
+For development and testing we recommend installing the optional dependencies:
+
+- `pytest` ≥ 7.4
+- `requests-mock` ≥ 1.11
+- `black` ≥ 23.0
+- `ruff` ≥ 0.1
+- `mypy` ≥ 1.4
+
+## Installation
+
+Create a virtual environment and install the project in editable mode together
+with the development extras:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -e .[dev]
+```
+
+The CLI uses the project's logging helpers which automatically integrate with
+the configured logging format.
+
+## Library Usage
+
+The module `library.chembl_tissue_client` exposes the high level helper
+`fetch_tissue_record`:
+
+```python
+from library.chembl_tissue_client import fetch_tissue_record
+
+record = fetch_tissue_record("CHEMBL3988026")
+print(record["pref_name"])  # "Uterine cervix"
+```
+
+`fetch_tissue_record` accepts optional `TissueConfig` and `HttpClient`
+instances.  Use these parameters to customise timeouts, caching behaviour and
+rate limiting.  When fetching multiple identifiers you may prefer the
+`fetch_tissues` helper which deduplicates identifiers and returns a list of
+payload dictionaries.
+
+## Command Line Interface
+
+The script `scripts/chembl_tissue_main.py` wraps the library helper in a
+repeatable CLI.  It can download a single tissue record or process a CSV file
+containing multiple identifiers.
+
+### Basic Usage
+
+Fetch a single record and print the location of the generated JSON file:
+
+```bash
+python scripts/chembl_tissue_main.py \
+    --chembl-id CHEMBL3988026 \
+    --output data/output/tissue.json
+```
+
+Process a CSV file with a column named `tissue_chembl_id` and skip identifiers
+that are not available in ChEMBL:
+
+```bash
+python scripts/chembl_tissue_main.py \
+    --input data/tissues.csv \
+    --output data/output/tissues.json \
+    --skip-missing
+```
+
+### Configuration Flags
+
+- `--log-level`: logging verbosity (default `INFO`).
+- `--log-format`: either `human` or `json`.
+- `--sep` / `--encoding`: configure the CSV parser.
+- `--base-url`, `--timeout`, `--max-retries`, `--rps`: network tuning options.
+- `--cache-path` and `--cache-ttl`: enable persistent HTTP caching.
+- `--skip-missing`: continue when identifiers are invalid or not present.
+
+If no `--output` path is provided, the script writes to
+`output_<input_name>_<YYYYMMDD>.json` in the current working directory.
+
+## Running Tests
+
+Execute the targeted unit tests via `pytest`:
+
+```bash
+pytest tests/test_chembl_tissue_client.py tests/test_chembl_tissue_main.py
+```
+
+The complete project test suite (`pytest`), formatter (`black`), linter
+(`ruff`) and type checker (`mypy`) should all succeed before submitting
+changes:
+
+```bash
+pytest
+black --check .
+ruff check .
+mypy .
+```

--- a/library/chembl_tissue_client.py
+++ b/library/chembl_tissue_client.py
@@ -1,0 +1,255 @@
+"""Client utilities for retrieving ChEMBL tissue metadata.
+
+The :func:`fetch_tissue_record` helper exposes a small, well-typed API for
+querying the public ChEMBL REST endpoint that serves tissue information.
+
+Algorithm Notes
+---------------
+1. Normalise the provided ChEMBL identifier (trim whitespace and upper-case).
+2. Compose the REST endpoint URL using the configured base URL.
+3. Issue an HTTP GET request with retry and rate limiting via
+   :class:`~library.http_client.HttpClient`.
+4. Decode the JSON payload and validate the presence of required fields.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import re
+from typing import Dict, Iterable, List, Sequence
+
+import requests
+
+try:  # pragma: no cover - fallback for test environments
+    from .http_client import CacheConfig, HttpClient
+except ImportError:  # pragma: no cover
+    from http_client import CacheConfig, HttpClient  # type: ignore[no-redef]
+
+LOGGER = logging.getLogger(__name__)
+
+_TISSUE_ID_PATTERN = re.compile(r"^CHEMBL\d+$")
+
+
+@dataclass
+class TissueConfig:
+    """Configuration for accessing the ChEMBL tissue endpoint.
+
+    Parameters
+    ----------
+    base_url:
+        Base URL of the ChEMBL API.
+    timeout_sec:
+        Timeout (in seconds) applied to individual HTTP requests.
+    max_retries:
+        Number of retry attempts for transient HTTP errors (>=500 status
+        codes or network issues).
+    rps:
+        Maximum requests per second enforced via a token bucket rate limiter.
+    cache:
+        Optional :class:`CacheConfig` enabling persistent HTTP caching.
+    required_fields:
+        Iterable of fields expected to be present in the JSON payload. Missing
+        fields result in a :class:`ValueError`.
+    """
+
+    base_url: str = "https://www.ebi.ac.uk/chembl/api/data"
+    timeout_sec: float = 30.0
+    max_retries: int = 3
+    rps: float = 2.0
+    cache: CacheConfig | None = None
+    required_fields: Sequence[str] = (
+        "tissue_chembl_id",
+        "pref_name",
+    )
+
+    def build_tissue_url(self, tissue_id: str) -> str:
+        """Return the absolute URL for a tissue resource."""
+
+        base = self.base_url.rstrip("/")
+        return f"{base}/tissue/{tissue_id}.json"
+
+
+def create_http_client(config: TissueConfig) -> HttpClient:
+    """Return an :class:`HttpClient` configured from ``config``."""
+
+    return HttpClient(
+        timeout=config.timeout_sec,
+        max_retries=config.max_retries,
+        rps=config.rps,
+        cache_config=config.cache,
+    )
+
+
+class TissueNotFoundError(RuntimeError):
+    """Raised when the requested tissue record does not exist."""
+
+
+def normalise_tissue_id(value: str) -> str:
+    """Return a canonical, upper-case tissue identifier.
+
+    Parameters
+    ----------
+    value:
+        Raw identifier that may include leading/trailing whitespace or be in a
+        lower-case representation.
+
+    Returns
+    -------
+    str
+        Normalised tissue identifier in upper-case form.
+
+    Raises
+    ------
+    ValueError
+        Raised when ``value`` is empty after stripping whitespace.
+    """
+
+    if value is None:
+        raise ValueError("Tissue identifier must not be None")
+    tissue_id = value.strip().upper()
+    if not tissue_id:
+        raise ValueError("Tissue identifier must not be empty")
+    if not _TISSUE_ID_PATTERN.match(tissue_id):
+        raise ValueError("Tissue identifier must match the pattern 'CHEMBL<digits>'")
+    return tissue_id
+
+
+def _validate_payload(payload: Dict[str, object], *, required: Iterable[str]) -> None:
+    """Ensure the decoded payload contains ``required`` fields."""
+
+    missing = [field for field in required if field not in payload]
+    if missing:
+        raise ValueError(
+            "Missing required fields in tissue payload: " + ", ".join(sorted(missing))
+        )
+
+
+def _fetch_tissue(
+    chembl_id: str, config: TissueConfig, client: HttpClient
+) -> Dict[str, object]:
+    """Return the decoded payload for a single ChEMBL tissue identifier."""
+
+    url = config.build_tissue_url(chembl_id)
+    LOGGER.debug("Requesting tissue %s from %s", chembl_id, url)
+    response = client.request("get", url, headers={"Accept": "application/json"})
+    if response.status_code == requests.codes.not_found:
+        raise TissueNotFoundError(f"Tissue record {chembl_id!r} not found")
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:  # pragma: no cover - exercised via integration
+        LOGGER.error("ChEMBL tissue request for %s failed: %s", chembl_id, exc)
+        raise
+    try:
+        payload = response.json()
+    except ValueError as exc:  # pragma: no cover - defensive guard
+        raise ValueError("Failed to decode tissue JSON payload") from exc
+    _validate_payload(payload, required=config.required_fields)
+    payload_id = str(payload.get("tissue_chembl_id", "")).upper()
+    if payload_id and payload_id != chembl_id:
+        raise ValueError(
+            "Tissue identifier mismatch: requested %s but received %s"
+            % (chembl_id, payload_id)
+        )
+    return payload
+
+
+def fetch_tissue_record(
+    chembl_id: str,
+    *,
+    config: TissueConfig | None = None,
+    client: HttpClient | None = None,
+) -> Dict[str, object]:
+    """Retrieve metadata for a single tissue from ChEMBL.
+
+    Parameters
+    ----------
+    chembl_id:
+        Tissue ChEMBL identifier (case-insensitive). Whitespace is stripped and
+        the value is normalised to upper-case.
+    config:
+        Optional :class:`TissueConfig` overriding connection settings.
+    client:
+        Optional pre-configured :class:`HttpClient`. When omitted, a new client
+        is created based on ``config``.
+
+    Returns
+    -------
+    Dict[str, object]
+        Parsed JSON payload representing the tissue.
+    """
+
+    tissue_id = normalise_tissue_id(chembl_id)
+    cfg = config or TissueConfig()
+    http_client = client or create_http_client(cfg)
+    return _fetch_tissue(tissue_id, cfg, http_client)
+
+
+def fetch_tissues(
+    ids: Sequence[str],
+    *,
+    config: TissueConfig | None = None,
+    client: HttpClient | None = None,
+    continue_on_error: bool = False,
+) -> List[Dict[str, object]]:
+    """Retrieve multiple tissue records in sequence.
+
+    Parameters
+    ----------
+    ids:
+        Sequence of ChEMBL tissue identifiers. Duplicates are ignored while
+        preserving input order.
+    config:
+        Optional :class:`TissueConfig` instance.
+    client:
+        Optional shared :class:`HttpClient`.
+    continue_on_error:
+        When ``True`` any :class:`ValueError`, :class:`TissueNotFoundError` or
+        :class:`requests.RequestException` is logged and skipped instead of
+        aborting the entire retrieval process.
+    """
+
+    cfg = config or TissueConfig()
+    http_client = client or create_http_client(cfg)
+    results: List[Dict[str, object]] = []
+    seen: set[str] = set()
+    for raw in ids:
+        try:
+            tissue_id = normalise_tissue_id(raw)
+        except ValueError as exc:
+            if continue_on_error:
+                LOGGER.warning("Skipping invalid tissue identifier %r: %s", raw, exc)
+                continue
+            raise
+        if tissue_id in seen:
+            LOGGER.debug("Skipping duplicate tissue identifier %s", tissue_id)
+            continue
+        seen.add(tissue_id)
+        try:
+            results.append(_fetch_tissue(tissue_id, cfg, http_client))
+        except TissueNotFoundError as exc:
+            if continue_on_error:
+                LOGGER.warning("%s", exc)
+                continue
+            raise
+        except requests.RequestException as exc:
+            LOGGER.error("Network error while fetching %s: %s", tissue_id, exc)
+            if continue_on_error:
+                continue
+            raise
+        except ValueError as exc:
+            LOGGER.error("Invalid payload for %s: %s", tissue_id, exc)
+            if continue_on_error:
+                continue
+            raise
+    return results
+
+
+__all__ = [
+    "TissueConfig",
+    "TissueNotFoundError",
+    "create_http_client",
+    "fetch_tissue_record",
+    "fetch_tissues",
+    "normalise_tissue_id",
+]

--- a/scripts/chembl_tissue_main.py
+++ b/scripts/chembl_tissue_main.py
@@ -1,0 +1,332 @@
+"""Command line interface for downloading ChEMBL tissue metadata.
+
+The utility accepts either a single ChEMBL tissue identifier via
+``--chembl-id`` or a CSV file containing multiple identifiers.  Retrieved
+records are written as a JSON array while logging progress and validation
+issues.
+
+Algorithm Notes
+---------------
+1. Parse command line options and configure structured logging.
+2. Collect tissue identifiers from CLI arguments and optional CSV input.
+3. Iterate over the identifiers, calling
+   :func:`library.chembl_tissue_client.fetch_tissue_record` for each entry.
+4. Serialise the resulting list of dictionaries into a UTF-8 encoded JSON file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import List, Sequence
+
+import requests
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB_DIR = ROOT / "library"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from library.chembl_tissue_client import (  # noqa: E402
+    TissueConfig,
+    TissueNotFoundError,
+    create_http_client,
+    fetch_tissue_record,
+    normalise_tissue_id,
+)
+from library.http_client import CacheConfig  # noqa: E402
+from library.logging_utils import configure_logging  # noqa: E402
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_INPUT = "input.csv"
+DEFAULT_ENCODING = "utf-8"
+DEFAULT_SEP = ","
+DEFAULT_COLUMN = "tissue_chembl_id"
+DEFAULT_LOG_LEVEL = "INFO"
+DEFAULT_LOG_FORMAT = "human"
+DEFAULT_TIMEOUT = 30.0
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_RPS = 2.0
+DEFAULT_BASE_URL = TissueConfig().base_url
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Return the command line parser used by :func:`main`."""
+
+    parser = argparse.ArgumentParser(
+        description="Download ChEMBL tissue metadata and serialise as JSON.",
+    )
+    parser.add_argument(
+        "--chembl-id",
+        help="Single tissue ChEMBL identifier to retrieve.",
+    )
+    parser.add_argument(
+        "--input",
+        default=DEFAULT_INPUT,
+        help=(
+            "Path to CSV file containing tissue identifiers. Defaults to"
+            f" {DEFAULT_INPUT}."
+        ),
+    )
+    parser.add_argument(
+        "--column",
+        default=DEFAULT_COLUMN,
+        help="Name of the CSV column containing tissue identifiers.",
+    )
+    parser.add_argument(
+        "--output",
+        help=(
+            "Destination JSON file. When omitted the file is named "
+            "output_<input>_<YYYYMMDD>.json in the current directory."
+        ),
+    )
+    parser.add_argument(
+        "--log-level",
+        default=DEFAULT_LOG_LEVEL,
+        help="Logging level (e.g. INFO, DEBUG).",
+    )
+    parser.add_argument(
+        "--log-format",
+        choices=["human", "json"],
+        default=DEFAULT_LOG_FORMAT,
+        help="Logging output format.",
+    )
+    parser.add_argument(
+        "--sep",
+        default=DEFAULT_SEP,
+        help="CSV delimiter used when reading --input.",
+    )
+    parser.add_argument(
+        "--encoding",
+        default=DEFAULT_ENCODING,
+        help="Encoding of the input CSV file and the generated JSON output.",
+    )
+    parser.add_argument(
+        "--dictionary",
+        help=(
+            "Optional dictionary file path (reserved for compatibility with"
+            " other tools)."
+        ),
+    )
+    parser.add_argument(
+        "--base-url",
+        default=DEFAULT_BASE_URL,
+        help="Base URL for the ChEMBL API.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT,
+        help="HTTP timeout in seconds.",
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=DEFAULT_MAX_RETRIES,
+        help="Maximum number of retry attempts for failed HTTP requests.",
+    )
+    parser.add_argument(
+        "--rps",
+        type=float,
+        default=DEFAULT_RPS,
+        help="Requests per second limit for the ChEMBL API.",
+    )
+    parser.add_argument(
+        "--cache-path",
+        help="Enable persistent HTTP caching at the given filesystem path.",
+    )
+    parser.add_argument(
+        "--cache-ttl",
+        type=float,
+        default=0.0,
+        help="Time-to-live for cached responses in seconds (requires --cache-path).",
+    )
+    parser.add_argument(
+        "--skip-missing",
+        action="store_true",
+        help="Skip identifiers that fail validation or are missing in ChEMBL.",
+    )
+    return parser
+
+
+def _default_output_path(input_path: Path) -> Path:
+    """Return the default output path derived from ``input_path``."""
+
+    date_str = datetime.utcnow().strftime("%Y%m%d")
+    stem = input_path.stem or "input"
+    filename = f"output_{stem}_{date_str}.json"
+    return Path(filename)
+
+
+def _read_identifiers_from_csv(
+    csv_path: Path,
+    *,
+    column: str,
+    sep: str,
+    encoding: str,
+) -> List[str]:
+    """Return identifiers from ``csv_path`` extracted from ``column``."""
+
+    with csv_path.open("r", encoding=encoding, newline="") as handle:
+        reader = csv.DictReader(handle, delimiter=sep)
+        if reader.fieldnames is None or column not in reader.fieldnames:
+            raise ValueError(
+                f"Input file {csv_path} does not contain required column {column!r}"
+            )
+        values: List[str] = []
+        for row in reader:
+            raw_value = row.get(column)
+            if raw_value is None:
+                continue
+            cleaned = raw_value.strip()
+            if cleaned:
+                values.append(cleaned)
+    return values
+
+
+def _collect_identifiers(
+    args: argparse.Namespace,
+) -> List[str]:
+    """Collect tissue identifiers from CLI arguments and optional CSV input."""
+
+    identifiers: List[str] = []
+    if args.chembl_id:
+        identifiers.append(args.chembl_id)
+    input_path = Path(args.input)
+    if input_path.exists():
+        identifiers.extend(
+            _read_identifiers_from_csv(
+                input_path, column=args.column, sep=args.sep, encoding=args.encoding
+            )
+        )
+    elif not args.chembl_id:
+        raise FileNotFoundError(
+            f"Input file {input_path} not found and no --chembl-id provided"
+        )
+    return identifiers
+
+
+def _build_cache_config(args: argparse.Namespace) -> CacheConfig | None:
+    """Construct a :class:`CacheConfig` instance from CLI arguments."""
+
+    if not args.cache_path:
+        return None
+    if args.cache_ttl <= 0:
+        LOGGER.warning(
+            "Ignoring cache configuration because --cache-ttl is not positive",
+        )
+        return None
+    return CacheConfig(enabled=True, path=args.cache_path, ttl_seconds=args.cache_ttl)
+
+
+def _write_output(records: Sequence[dict], output_path: Path, *, encoding: str) -> None:
+    """Serialise ``records`` to ``output_path`` as UTF-8 encoded JSON."""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding=encoding) as handle:
+        json.dump(records, handle, ensure_ascii=False, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Program entry point returning an exit status code."""
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    configure_logging(args.log_level, log_format=args.log_format)
+
+    if args.dictionary:
+        LOGGER.info("Dictionary parameter is currently unused: %s", args.dictionary)
+
+    try:
+        raw_ids = _collect_identifiers(args)
+    except (FileNotFoundError, ValueError) as exc:
+        LOGGER.error("%s", exc)
+        return 1
+
+    normalised_ids: List[str] = []
+    seen: set[str] = set()
+    for raw in raw_ids:
+        try:
+            tissue_id = normalise_tissue_id(raw)
+        except ValueError as exc:
+            if args.skip_missing:
+                LOGGER.warning("Skipping invalid identifier %r: %s", raw, exc)
+                continue
+            LOGGER.error("Invalid identifier %r: %s", raw, exc)
+            return 1
+        if tissue_id in seen:
+            LOGGER.debug("Skipping duplicate identifier %s", tissue_id)
+            continue
+        seen.add(tissue_id)
+        normalised_ids.append(tissue_id)
+
+    if not normalised_ids:
+        LOGGER.error("No valid tissue identifiers supplied")
+        return 1
+
+    cache_config = _build_cache_config(args)
+    config = TissueConfig(
+        base_url=args.base_url,
+        timeout_sec=args.timeout,
+        max_retries=args.max_retries,
+        rps=args.rps,
+        cache=cache_config,
+    )
+    client = create_http_client(config)
+
+    records: List[dict] = []
+    skipped = 0
+    for tissue_id in normalised_ids:
+        try:
+            records.append(fetch_tissue_record(tissue_id, config=config, client=client))
+        except TissueNotFoundError as exc:
+            if args.skip_missing:
+                LOGGER.warning("%s", exc)
+                skipped += 1
+                continue
+            LOGGER.error("%s", exc)
+            return 1
+        except ValueError as exc:
+            if args.skip_missing:
+                LOGGER.warning("Skipping %s due to invalid payload: %s", tissue_id, exc)
+                skipped += 1
+                continue
+            LOGGER.error("Validation failed for %s: %s", tissue_id, exc)
+            return 1
+        except requests.RequestException as exc:
+            LOGGER.error("Network error while fetching %s: %s", tissue_id, exc)
+            return 1
+
+    if not records:
+        LOGGER.error("No tissue records retrieved")
+        return 1
+
+    output_path = (
+        Path(args.output) if args.output else _default_output_path(Path(args.input))
+    )
+    try:
+        _write_output(records, output_path, encoding=args.encoding)
+    except OSError as exc:
+        LOGGER.error("Failed to write output %s: %s", output_path, exc)
+        return 1
+
+    LOGGER.info(
+        "Wrote %d tissue records to %s%s",
+        len(records),
+        output_path,
+        f" (skipped {skipped})" if skipped else "",
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,3 +8,6 @@ ROOT = Path(__file__).resolve().parents[1]
 LIB_DIR = ROOT / "library"
 if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
+SCRIPTS_DIR = ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))

--- a/tests/test_chembl_tissue_client.py
+++ b/tests/test_chembl_tissue_client.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from chembl_tissue_client import (
+    TissueConfig,
+    TissueNotFoundError,
+    fetch_tissue_record,
+    fetch_tissues,
+    normalise_tissue_id,
+)
+
+
+def test_normalise_tissue_id_strips_and_upper_cases() -> None:
+    assert normalise_tissue_id("  chembl123 ") == "CHEMBL123"
+
+
+@pytest.mark.parametrize("value", [None, "   "])
+def test_normalise_tissue_id_rejects_empty(value: str | None) -> None:
+    with pytest.raises(ValueError):
+        normalise_tissue_id(value)  # type: ignore[arg-type]
+
+
+def test_normalise_tissue_id_rejects_incorrect_pattern() -> None:
+    with pytest.raises(ValueError):
+        normalise_tissue_id("CHEMBLXYZ")
+
+
+def test_fetch_tissue_record_success(requests_mock) -> None:
+    config = TissueConfig(base_url="https://example.org")
+    requests_mock.get(
+        "https://example.org/tissue/CHEMBL42.json",
+        json={"tissue_chembl_id": "CHEMBL42", "pref_name": "Example"},
+    )
+    payload = fetch_tissue_record("chembl42", config=config)
+    assert payload["pref_name"] == "Example"
+
+
+def test_fetch_tissue_record_not_found(requests_mock) -> None:
+    config = TissueConfig(base_url="https://example.org")
+    requests_mock.get("https://example.org/tissue/CHEMBL42.json", status_code=404)
+    with pytest.raises(TissueNotFoundError):
+        fetch_tissue_record("CHEMBL42", config=config)
+
+
+def test_fetch_tissue_record_requires_fields(requests_mock) -> None:
+    config = TissueConfig(base_url="https://example.org")
+    requests_mock.get(
+        "https://example.org/tissue/CHEMBL42.json",
+        json={"pref_name": "Example"},
+    )
+    with pytest.raises(ValueError):
+        fetch_tissue_record("CHEMBL42", config=config)
+
+
+def test_fetch_tissues_continue_on_error(requests_mock) -> None:
+    config = TissueConfig(base_url="https://example.org")
+    requests_mock.get(
+        "https://example.org/tissue/CHEMBL1.json",
+        json={"tissue_chembl_id": "CHEMBL1", "pref_name": "One"},
+    )
+    requests_mock.get("https://example.org/tissue/CHEMBL2.json", status_code=404)
+    results = fetch_tissues(
+        ["CHEMBL1", "CHEMBL2", "CHEMBL1"],
+        config=config,
+        continue_on_error=True,
+    )
+    assert [record["tissue_chembl_id"] for record in results] == ["CHEMBL1"]

--- a/tests/test_chembl_tissue_main.py
+++ b/tests/test_chembl_tissue_main.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import chembl_tissue_main
+
+
+def test_main_fetches_single_identifier(tmp_path, requests_mock) -> None:
+    output_path = tmp_path / "tissue.json"
+    requests_mock.get(
+        "https://example.org/tissue/CHEMBL3988026.json",
+        json={"tissue_chembl_id": "CHEMBL3988026", "pref_name": "Cervix"},
+    )
+    exit_code = chembl_tissue_main.main(
+        [
+            "--chembl-id",
+            "CHEMBL3988026",
+            "--output",
+            str(output_path),
+            "--base-url",
+            "https://example.org",
+            "--log-level",
+            "ERROR",
+        ]
+    )
+    assert exit_code == 0
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert data[0]["pref_name"] == "Cervix"
+
+
+def test_main_reads_csv_and_skips_missing(tmp_path, requests_mock) -> None:
+    input_path = tmp_path / "input.csv"
+    input_path.write_text(
+        "tissue_chembl_id\nCHEMBL3988026\ninvalid\nCHEMBL9999999\n",
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "result.json"
+    requests_mock.get(
+        "https://example.org/tissue/CHEMBL3988026.json",
+        json={"tissue_chembl_id": "CHEMBL3988026", "pref_name": "Cervix"},
+    )
+    requests_mock.get("https://example.org/tissue/CHEMBL9999999.json", status_code=404)
+    exit_code = chembl_tissue_main.main(
+        [
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--base-url",
+            "https://example.org",
+            "--skip-missing",
+            "--log-level",
+            "ERROR",
+        ]
+    )
+    assert exit_code == 0
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert [record["tissue_chembl_id"] for record in data] == ["CHEMBL3988026"]
+
+
+def test_main_errors_when_column_missing(tmp_path) -> None:
+    input_path = tmp_path / "input.csv"
+    input_path.write_text("other\nCHEMBL1\n", encoding="utf-8")
+    exit_code = chembl_tissue_main.main(
+        [
+            "--input",
+            str(input_path),
+            "--base-url",
+            "https://example.org",
+            "--log-level",
+            "ERROR",
+        ]
+    )
+    assert exit_code == 1
+
+
+@pytest.mark.parametrize("invalid_id", ["", "   ", "CHEMBLXYZ", None])
+def test_main_rejects_invalid_identifier(tmp_path, invalid_id) -> None:
+    args = [
+        "--output",
+        str(tmp_path / "out.json"),
+        "--base-url",
+        "https://example.org",
+        "--log-level",
+        "ERROR",
+    ]
+    if invalid_id is None:
+        exit_code = chembl_tissue_main.main(args)
+        assert exit_code == 1
+    else:
+        exit_code = chembl_tissue_main.main(
+            [
+                "--chembl-id",
+                invalid_id,
+                "--output",
+                str(tmp_path / "out.json"),
+                "--base-url",
+                "https://example.org",
+                "--log-level",
+                "ERROR",
+            ]
+        )
+        assert exit_code == 1


### PR DESCRIPTION
## Summary
- add a reusable `chembl_tissue_client` module that validates identifiers, wraps HTTP access and can fetch batches of tissue records from ChEMBL
- provide a documented CLI (`scripts/chembl_tissue_main.py`) for downloading tissue metadata from a single identifier or CSV file and serialising the result to JSON
- document the new tooling and cover it with dedicated unit tests

## Testing
- black library/chembl_tissue_client.py scripts/chembl_tissue_main.py tests/test_chembl_tissue_client.py tests/test_chembl_tissue_main.py
- ruff check .
- mypy --config-file mypy.ini library/chembl_tissue_client.py scripts/chembl_tissue_main.py tests/test_chembl_tissue_client.py tests/test_chembl_tissue_main.py
- pytest tests/test_chembl_tissue_client.py tests/test_chembl_tissue_main.py

------
https://chatgpt.com/codex/tasks/task_e_68c8f0f271388324b27515c0c334c093