### PR TITLE
Add ChEMBL cell line fetcher and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ The `scripts/` directory contains several other scripts for performing specific 
 
 *   `chembl2uniprot_main.py`: Map ChEMBL IDs to UniProt accessions.
 *   `get_target_data_main.py`: Download target metadata from ChEMBL.
+*   `get_cell_line_main.py`: Download metadata for specific ChEMBL cell lines and
+    serialise the records as JSON lines.
 *   `get_uniprot_target_data.py`: Retrieve and normalize detailed information about UniProt targets.
 *   `get_hgnc_by_uniprot.py`: Map UniProt accessions to HGNC identifiers.
 *   `dump_gtop_target.py`: Download comprehensive GtoPdb target information.

--- a/library/chembl_cell_lines.py
+++ b/library/chembl_cell_lines.py
@@ -1,0 +1,182 @@
+"""Utilities for retrieving ChEMBL cell line records.
+
+Algorithm Notes
+---------------
+1. Normalise the provided ChEMBL cell line identifier to upper case and
+   validate it is not empty.
+2. Build the ChEMBL API endpoint URL and perform an HTTP GET request using the
+   shared :class:`~library.http_client.HttpClient` with retry and rate limiting.
+3. Treat HTTP ``404`` responses as missing records and raise
+   :class:`CellLineNotFoundError`.
+4. Parse the JSON payload into a Python dictionary and return it to the caller.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any, Dict
+
+import requests
+
+from .http_client import CacheConfig, HttpClient
+
+LOGGER = logging.getLogger(__name__)
+
+CellLineRecord = Dict[str, Any]
+
+
+class CellLineError(RuntimeError):
+    """Base class for cell line related exceptions."""
+
+
+class CellLineNotFoundError(CellLineError):
+    """Raised when the requested cell line identifier does not exist."""
+
+
+class CellLineServiceError(CellLineError):
+    """Raised when the ChEMBL service returns an unexpected response."""
+
+
+@dataclass
+class CellLineConfig:
+    """Configuration controlling network access to the ChEMBL API.
+
+    Parameters
+    ----------
+    base_url:
+        Base URL for the ChEMBL API.
+    timeout_sec:
+        Timeout in seconds applied to HTTP requests.
+    max_retries:
+        Maximum number of retry attempts for transient failures.
+    rps:
+        Maximum number of requests per second. ``0`` disables rate limiting.
+    cache:
+        Optional cache configuration passed to :class:`HttpClient`.
+    """
+
+    base_url: str = "https://www.ebi.ac.uk/chembl/api/data"
+    timeout_sec: float = 30.0
+    max_retries: int = 3
+    rps: float = 2.0
+    cache: CacheConfig | None = None
+
+
+class CellLineClient:
+    """High level client for fetching ChEMBL cell line records."""
+
+    def __init__(self, config: CellLineConfig | None = None) -> None:
+        self.config = config or CellLineConfig()
+        self._http = HttpClient(
+            timeout=self.config.timeout_sec,
+            max_retries=self.config.max_retries,
+            rps=self.config.rps,
+            cache_config=self.config.cache,
+        )
+
+    def fetch_cell_line(self, cell_chembl_id: str) -> CellLineRecord:
+        """Return the raw cell line record for ``cell_chembl_id``.
+
+        Parameters
+        ----------
+        cell_chembl_id:
+            Identifier of the cell line, e.g. ``"CHEMBL3307553"``.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Parsed JSON payload returned by the ChEMBL service.
+
+        Raises
+        ------
+        ValueError
+            If ``cell_chembl_id`` is empty after normalisation.
+        CellLineNotFoundError
+            When the API responds with HTTP ``404``.
+        CellLineServiceError
+            When the response cannot be parsed as JSON.
+        """
+
+        normalised_id = self._normalise_id(cell_chembl_id)
+        url = self._build_url(normalised_id)
+        LOGGER.debug("Fetching cell line data", extra={"cell_chembl_id": normalised_id})
+        response = self._http.request(
+            "get",
+            url,
+            headers={"Accept": "application/json"},
+        )
+        if response.status_code == 404:
+            LOGGER.info("Cell line %s not found", normalised_id)
+            raise CellLineNotFoundError(
+                f"Cell line {normalised_id} not found at {url}",
+            )
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:  # pragma: no cover - network edge case
+            raise CellLineServiceError(
+                f"ChEMBL returned HTTP status {response.status_code} for {url}",
+            ) from exc
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise CellLineServiceError(
+                "Unable to decode response body as JSON",
+            ) from exc
+        if not isinstance(payload, dict):
+            raise CellLineServiceError(
+                "Unexpected payload structure received from ChEMBL",
+            )
+        LOGGER.debug(
+            "Retrieved cell line data", extra={"cell_chembl_id": normalised_id}
+        )
+        return payload
+
+    def _build_url(self, cell_chembl_id: str) -> str:
+        """Return the API endpoint URL for ``cell_chembl_id``."""
+
+        base = self.config.base_url.rstrip("/")
+        return f"{base}/cell_line/{cell_chembl_id}.json"
+
+    @staticmethod
+    def _normalise_id(cell_chembl_id: str) -> str:
+        """Normalise a raw identifier to upper case and trim whitespace."""
+
+        if cell_chembl_id is None:
+            raise ValueError("cell_chembl_id must not be None")
+        normalised = str(cell_chembl_id).strip().upper()
+        if not normalised:
+            raise ValueError("cell_chembl_id must not be empty")
+        return normalised
+
+
+def fetch_cell_line(
+    cell_chembl_id: str, config: CellLineConfig | None = None
+) -> CellLineRecord:
+    """Convenience wrapper returning the record for ``cell_chembl_id``.
+
+    Parameters
+    ----------
+    cell_chembl_id:
+        Identifier of the cell line to fetch.
+    config:
+        Optional :class:`CellLineConfig` overriding network settings.
+
+    Returns
+    -------
+    Dict[str, Any]
+        JSON dictionary returned by the ChEMBL API.
+    """
+
+    client = CellLineClient(config)
+    return client.fetch_cell_line(cell_chembl_id)
+
+
+__all__ = [
+    "CellLineClient",
+    "CellLineConfig",
+    "CellLineError",
+    "CellLineNotFoundError",
+    "CellLineServiceError",
+    "fetch_cell_line",
+]

--- a/scripts/get_cell_line_main.py
+++ b/scripts/get_cell_line_main.py
@@ -1,0 +1,141 @@
+"""Command line interface for downloading ChEMBL cell line metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB_DIR = ROOT / "library"
+if __package__ in {None, ""}:
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+    if str(LIB_DIR) not in sys.path:
+        sys.path.insert(0, str(LIB_DIR))
+
+from library.chembl_cell_lines import (  # noqa: E402
+    CellLineClient,
+    CellLineConfig,
+    CellLineError,
+)
+from library.logging_utils import configure_logging  # noqa: E402
+
+DEFAULT_LOG_LEVEL = "INFO"
+DEFAULT_SEP = ","
+DEFAULT_ENCODING = "utf-8"
+DEFAULT_COLUMN = "cell_chembl_id"
+
+
+def _iter_unique(values: Iterable[str]) -> Iterable[str]:
+    """Yield unique values from ``values`` while preserving order."""
+
+    seen: set[str] = set()
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            yield value
+
+
+def _load_ids_from_csv(path: Path, column: str, sep: str, encoding: str) -> list[str]:
+    """Return cell line identifiers from ``column`` in ``path``."""
+
+    import pandas as pd
+
+    df = pd.read_csv(path, sep=sep, encoding=encoding)
+    if column not in df.columns:
+        raise ValueError(f"Missing column '{column}' in {path}")
+    series = df[column].dropna()
+    return [str(item).strip() for item in series if str(item).strip()]
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Parse command line arguments and download cell line records."""
+
+    parser = argparse.ArgumentParser(
+        description="Download metadata for one or more ChEMBL cell lines",
+    )
+    parser.add_argument(
+        "--cell-line-id",
+        dest="cell_line_ids",
+        action="append",
+        default=[],
+        help="ChEMBL cell line identifier to fetch (repeat for multiple IDs)",
+    )
+    parser.add_argument(
+        "--input",
+        default=None,
+        help="CSV file containing cell line identifiers",
+    )
+    parser.add_argument(
+        "--column",
+        default=DEFAULT_COLUMN,
+        help=f"Name of the column containing identifiers (default: {DEFAULT_COLUMN})",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Path to write the JSON lines output",
+    )
+    parser.add_argument(
+        "--log-level",
+        default=DEFAULT_LOG_LEVEL,
+        help="Logging level",
+    )
+    parser.add_argument(
+        "--sep",
+        default=DEFAULT_SEP,
+        help="Column separator for CSV input",
+    )
+    parser.add_argument(
+        "--encoding",
+        default=DEFAULT_ENCODING,
+        help="File encoding for CSV input",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=CellLineConfig.base_url,
+        help="Override the ChEMBL API base URL",
+    )
+    args = parser.parse_args(argv)
+
+    configure_logging(args.log_level)
+
+    ids = list(args.cell_line_ids)
+    if args.input:
+        input_path = Path(args.input)
+        if not input_path.exists():
+            raise FileNotFoundError(f"Input file {input_path} does not exist")
+        ids.extend(_load_ids_from_csv(input_path, args.column, args.sep, args.encoding))
+
+    ids = list(_iter_unique(i for i in ids if i))
+    if not ids:
+        raise ValueError("No cell line identifiers provided")
+
+    output_path = Path(
+        args.output if args.output else f"output_input_{datetime.utcnow():%Y%m%d}.json"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    client = CellLineClient(
+        CellLineConfig(
+            base_url=args.base_url,
+        )
+    )
+    with output_path.open("w", encoding=args.encoding) as handle:
+        for identifier in ids:
+            try:
+                record = client.fetch_cell_line(identifier)
+            except (CellLineError, ValueError) as exc:
+                raise SystemExit(str(exc)) from exc
+            handle.write(json.dumps(record, ensure_ascii=False, sort_keys=True))
+            handle.write("\n")
+
+    print(output_path)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_chembl_cell_lines.py
+++ b/tests/test_chembl_cell_lines.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+import requests_mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from library.chembl_cell_lines import (  # noqa: E402
+    CellLineClient,
+    CellLineConfig,
+    CellLineNotFoundError,
+    CellLineServiceError,
+    fetch_cell_line,
+)
+
+
+def test_fetch_cell_line_returns_payload(requests_mock: requests_mock.Mocker) -> None:
+    cfg = CellLineConfig(base_url="https://example.org")
+    url = "https://example.org/cell_line/CHEMBL1234.json"
+    payload = {"cell_chembl_id": "CHEMBL1234", "cell_name": "Example"}
+    requests_mock.get(url, json=payload)
+    record = fetch_cell_line("  chembl1234  ", cfg)
+    assert record == payload
+
+
+def test_fetch_cell_line_404(requests_mock: requests_mock.Mocker) -> None:
+    cfg = CellLineConfig(base_url="https://example.org")
+    url = "https://example.org/cell_line/CHEMBL9999.json"
+    requests_mock.get(url, status_code=404)
+    with pytest.raises(CellLineNotFoundError):
+        fetch_cell_line("CHEMBL9999", cfg)
+
+
+def test_fetch_cell_line_invalid_payload(requests_mock: requests_mock.Mocker) -> None:
+    cfg = CellLineConfig(base_url="https://example.org")
+    url = "https://example.org/cell_line/CHEMBL0001.json"
+    requests_mock.get(url, json=[{"unexpected": "structure"}])
+    client = CellLineClient(cfg)
+    with pytest.raises(CellLineServiceError):
+        client.fetch_cell_line("CHEMBL0001")
+
+
+def test_fetch_cell_line_empty_identifier() -> None:
+    client = CellLineClient()
+    with pytest.raises(ValueError):
+        client.fetch_cell_line("   ")
+
+
+def test_fetch_cell_line_none_identifier() -> None:
+    client = CellLineClient()
+    with pytest.raises(ValueError):
+        client.fetch_cell_line(None)  # type: ignore[arg-type]

--- a/tests/test_get_cell_line_main.py
+++ b/tests/test_get_cell_line_main.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import requests_mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from scripts.get_cell_line_main import main  # noqa: E402
+
+
+def test_cli_fetch_single_id(
+    tmp_path: Path, requests_mock: requests_mock.Mocker
+) -> None:
+    output = tmp_path / "cell_lines.json"
+    url = "https://example.org/cell_line/CHEMBL123.json"
+    requests_mock.get(url, json={"cell_chembl_id": "CHEMBL123"})
+    main(
+        [
+            "--cell-line-id",
+            "CHEMBL123",
+            "--output",
+            str(output),
+            "--base-url",
+            "https://example.org",
+        ]
+    )
+    lines = [
+        json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()
+    ]
+    assert lines == [{"cell_chembl_id": "CHEMBL123"}]
+
+
+def test_cli_reads_ids_from_csv(
+    tmp_path: Path, requests_mock: requests_mock.Mocker
+) -> None:
+    csv_path = tmp_path / "ids.csv"
+    csv_path.write_text("cell_chembl_id\nCHEMBL777\n", encoding="utf-8")
+    output = tmp_path / "out.json"
+    url = "https://example.org/cell_line/CHEMBL777.json"
+    requests_mock.get(url, json={"cell_chembl_id": "CHEMBL777"})
+    main(
+        [
+            "--input",
+            str(csv_path),
+            "--output",
+            str(output),
+            "--base-url",
+            "https://example.org",
+        ]
+    )
+    data = [
+        json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()
+    ]
+    assert data == [{"cell_chembl_id": "CHEMBL777"}]


### PR DESCRIPTION
## Summary
- add a reusable `CellLineClient` helper that retrieves and validates ChEMBL cell line records
- provide a CLI utility for exporting cell line metadata as JSON lines
- cover the new functionality with unit tests and update documentation

## Testing
- `black library/chembl_cell_lines.py scripts/get_cell_line_main.py tests/test_chembl_cell_lines.py tests/test_get_cell_line_main.py`
- `ruff check library/chembl_cell_lines.py scripts/get_cell_line_main.py tests/test_chembl_cell_lines.py tests/test_get_cell_line_main.py`
- `mypy --config-file pyproject.toml library/chembl_cell_lines.py tests/test_chembl_cell_lines.py tests/test_get_cell_line_main.py`
- `pytest tests/test_chembl_cell_lines.py tests/test_get_cell_line_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c8f11256848324a3b7288bbf9ccb39