### PR TITLE
Filter NaN-like identifiers in chembl2uniprot mapping

### DIFF
--- a/tests/test_chembl2uniprot_library.py
+++ b/tests/test_chembl2uniprot_library.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from chembl2uniprot.mapping import get_ids_from_dataframe  # noqa: E402
+
+
+def test_get_ids_from_dataframe_filters_nan_and_empty_strings() -> None:
+    df = pd.DataFrame(
+        {
+            "chembl_id": [
+                "CHEMBL1",
+                pd.NA,
+                float("nan"),
+                "nan",
+                " NaN ",
+                "",
+                "CHEMBL2",
+                "CHEMBL1",
+            ]
+        }
+    )
+
+    assert get_ids_from_dataframe(df, "chembl_id") == ["CHEMBL1", "CHEMBL2"]


### PR DESCRIPTION
## Summary
- add a dedicated helper to extract identifiers that drops NaNs before casting to strings and removes literal "nan"/empty entries
- reuse the helper within `map_chembl_to_uniprot` and cover the behaviour with a regression test that mixes `NaN` and "nan" values

## Testing
- pytest tests/test_chembl2uniprot_library.py
- ruff check library/chembl2uniprot/mapping.py tests/test_chembl2uniprot_library.py
- black library/chembl2uniprot/mapping.py tests/test_chembl2uniprot_library.py
- mypy library/chembl2uniprot/mapping.py *(fails: missing type stubs for PyYAML/requests)*

------
https://chatgpt.com/codex/tasks/task_e_68c909849cb8832488b95194f367f989