### PR TITLE
Refine UniProt target script and update dependencies

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -6,6 +6,7 @@ charset-normalizer==3.4.3
 # Editable Git install with no remote (chembl2uniprot==0.1.0)
 -e /workspace/ChEMBL_dataAcquisition
 click==8.2.1
+hypothesis==6.138.17
 idna==3.10
 iniconfig==2.1.0
 jsonschema==4.25.1
@@ -28,6 +29,7 @@ pytz==2025.2
 PyYAML==6.0.2
 referencing==0.36.2
 requests==2.32.5
+requests-cache==1.2.1
 requests-mock==1.12.1
 rpds-py==0.27.1
 ruff==0.13.0

--- a/scripts/get_uniprot_target_data.py
+++ b/scripts/get_uniprot_target_data.py
@@ -1,7 +1,7 @@
 """Retrieve and normalise UniProtKB target information.
 
-Example
--------
+Examples
+--------
 >>> python scripts/get_uniprot_target_data.py --input data.csv --output out.csv
 """
 
@@ -13,31 +13,14 @@ import logging
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-from library.io_utils import CsvConfig, read_ids, write_rows  # noqa: E402
-from library.uniprot_client import (  # noqa: E402
-    NetworkConfig,
-    RateLimitConfig,
-    UniProtClient,
-)
-from library.uniprot_normalize import (  # noqa: E402
-    Isoform,
-    extract_ensembl_gene_ids,
-    extract_isoforms,
-    normalize_entry,
-    output_columns,
-)
-from library.orthologs import EnsemblHomologyClient, OmaClient  # noqa: E402
-from library.http_client import CacheConfig  # noqa: E402
-from library.logging_utils import configure_logging  # noqa: E402
-
+if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+    from library.orthologs import EnsemblHomologyClient, OmaClient
+    from library.uniprot_normalize import Isoform
 
 
 DEFAULT_INPUT = "input.csv"
@@ -47,20 +30,72 @@ DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_SEP = ","
 DEFAULT_ENCODING = "utf-8"
 
+LOGGER = logging.getLogger(__name__)
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ensure_mapping(value: Any, *, section: str) -> dict[str, Any]:
+    """Return ``value`` as a mapping or raise ``ValueError``.
+
+    Args:
+        value: Configuration value to validate.
+        section: Human-readable section name for error messages.
+
+    Returns:
+        dict[str, Any]: Shallow copy of ``value`` when it is mapping-like.
+
+    Raises:
+        ValueError: If ``value`` is not a mapping.
+    """
+
+    if isinstance(value, Mapping):
+        return dict(value)
+    msg = f"Expected '{section}' section to be a mapping"
+    raise ValueError(msg)
+
 
 def _default_output(input_path: Path) -> Path:
-    """Generate a default output file path based on the input path.
+    """Return the default output location for ``input_path``.
 
-    The default path includes the current date to avoid overwriting previous
-    runs.
+    Args:
+        input_path: Source CSV path supplied by the user.
+
+    Returns:
+        Path: Location sharing the directory of ``input_path`` and the
+        ``DEFAULT_OUTPUT`` name pattern containing today's date. This avoids
+        overwriting previous exports when ``--output`` is omitted.
     """
 
     date = datetime.now().strftime("%Y%m%d")
     return input_path.with_name(DEFAULT_OUTPUT.format(date=date))
 
 
-def main(argv: List[str] | None = None) -> None:
-    """Entry point for the UniProt target data retrieval script."""
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the UniProt target data retrieval workflow.
+
+    Args:
+        argv: Optional sequence of command-line arguments.  When ``None``,
+            :data:`sys.argv` is used implicitly.
+    """
+
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+
+    from library.http_client import CacheConfig
+    from library.io_utils import CsvConfig, read_ids, write_rows
+    from library.logging_utils import configure_logging
+    from library.orthologs import EnsemblHomologyClient, OmaClient
+    from library.uniprot_client import (
+        NetworkConfig,
+        RateLimitConfig,
+        UniProtClient,
+    )
+    from library.uniprot_normalize import (
+        extract_ensembl_gene_ids,
+        extract_isoforms,
+        normalize_entry,
+        output_columns,
+    )
 
     parser = argparse.ArgumentParser(description="Fetch UniProt target data")
     parser.add_argument("--input", default=DEFAULT_INPUT, help="Input CSV path")
@@ -95,25 +130,47 @@ def main(argv: List[str] | None = None) -> None:
         default=DEFAULT_LOG_LEVEL,
         help="Logging level (INFO, DEBUG, ... )",
     )
+    parser.add_argument(
+        "--log-format",
+        choices=("human", "json"),
+        default="human",
+        help="Logging output format (human or json)",
+    )
     args = parser.parse_args(argv)
 
-    configure_logging(args.log_level)
+    configure_logging(args.log_level, log_format=args.log_format)
 
-    config = yaml.safe_load((ROOT / "config.yaml").read_text())
-    uniprot_cfg = config.get("uniprot", {})
-    output_cfg = config.get("output", {})
-    orth_cfg = config.get("orthologs", {})
-    global_cache = CacheConfig.from_dict(config.get("http_cache"))
+    config_data = yaml.safe_load((ROOT / "config.yaml").read_text())
+    config = _ensure_mapping(config_data, section="root configuration")
+    uniprot_cfg = _ensure_mapping(config.get("uniprot", {}), section="uniprot")
+    output_cfg = _ensure_mapping(config.get("output", {}), section="output")
+    orth_cfg = _ensure_mapping(config.get("orthologs", {}), section="orthologs")
 
-    list_format = output_cfg.get("list_format", "json")
-    include_seq = args.include_sequence or output_cfg.get("include_sequence", False)
-    sep = args.sep or output_cfg.get("sep", DEFAULT_SEP)
-    encoding = args.encoding or output_cfg.get("encoding", DEFAULT_ENCODING)
-    include_iso = args.with_isoforms or uniprot_cfg.get("include_isoforms", False)
-    use_fasta_stream = uniprot_cfg.get("use_fasta_stream_for_isoform_ids", True)
+    http_cache_raw = config.get("http_cache")
+    http_cache_cfg = (
+        _ensure_mapping(http_cache_raw, section="http_cache")
+        if http_cache_raw is not None
+        else None
+    )
+    global_cache = CacheConfig.from_dict(http_cache_cfg)
+
+    list_format = str(output_cfg.get("list_format", "json") or "json")
+    include_seq = bool(
+        args.include_sequence or output_cfg.get("include_sequence", False)
+    )
+    sep_value = args.sep or output_cfg.get("sep") or DEFAULT_SEP
+    if not isinstance(sep_value, str):
+        msg = "CSV separator must be a string"
+        raise ValueError(msg)
+    encoding_value = args.encoding or output_cfg.get("encoding") or DEFAULT_ENCODING
+    if not isinstance(encoding_value, str):
+        msg = "File encoding must be a string"
+        raise ValueError(msg)
+    include_iso = bool(args.with_isoforms or uniprot_cfg.get("include_isoforms", False))
+    use_fasta_stream = bool(uniprot_cfg.get("use_fasta_stream_for_isoform_ids", True))
 
     # Use configuration defaults when CLI options are omitted
-    csv_cfg = CsvConfig(sep=sep, encoding=encoding, list_format=list_format)
+    csv_cfg = CsvConfig(sep=sep_value, encoding=encoding_value, list_format=list_format)
 
     client = UniProtClient(
         base_url=uniprot_cfg.get("base_url", "https://rest.uniprot.org/uniprotkb"),
@@ -145,19 +202,25 @@ def main(argv: List[str] | None = None) -> None:
     )
 
     accessions = read_ids(input_path, args.column, csv_cfg)
-    rows: List[Dict[str, Any]] = []
-    iso_rows: List[Dict[str, str]] = []
+    rows: list[dict[str, Any]] = []
+    iso_rows: list[dict[str, str]] = []
 
     cols = output_columns(include_seq)
 
-    target_species: List[str] = []
+    target_species: list[str] = []
     ensembl_client: EnsemblHomologyClient | None = None
     oma_client: OmaClient | None = None
-    orth_cols: List[str] = []
-    orth_rows: List[Dict[str, Any]] = []
+    orth_cols: list[str] = []
+    orth_rows: list[dict[str, Any]] = []
 
     if args.with_orthologs and orth_cfg.get("enabled", True):
-        orth_cache = CacheConfig.from_dict(orth_cfg.get("cache")) or global_cache
+        orth_cache_raw = orth_cfg.get("cache")
+        orth_cache_cfg = (
+            _ensure_mapping(orth_cache_raw, section="orthologs.cache")
+            if orth_cache_raw is not None
+            else None
+        )
+        orth_cache = CacheConfig.from_dict(orth_cache_cfg) or global_cache
         ensembl_client = EnsemblHomologyClient(
             base_url="https://rest.ensembl.org",
             network=NetworkConfig(
@@ -178,7 +241,11 @@ def main(argv: List[str] | None = None) -> None:
             rate_limit=RateLimitConfig(rps=orth_cfg.get("rate_limit_rps", 2)),
             cache=orth_cache,
         )
-        target_species = orth_cfg.get("target_species", [])
+        target_species_raw = orth_cfg.get("target_species", [])
+        if not isinstance(target_species_raw, list):
+            msg = "'orthologs.target_species' must be a list"
+            raise ValueError(msg)
+        target_species = [str(species) for species in target_species_raw]
         orth_cols = [
             "source_uniprot_id",
             "source_ensembl_gene_id",
@@ -199,8 +266,12 @@ def main(argv: List[str] | None = None) -> None:
     for acc in accessions:
         data = client.fetch_entry_json(acc)
         if data is None:
-            logging.warning("No entry for %s", acc)
-            row: Dict[str, Any] = {c: "" for c in cols}
+            LOGGER.warning(
+                "No UniProt entry available for %s",
+                acc,
+                extra={"uniprot_id": acc},
+            )
+            row: dict[str, Any] = {c: "" for c in cols}
             row["uniprot_id"] = acc
             if ensembl_client:
                 row["orthologs_json"] = "[]"
@@ -210,10 +281,10 @@ def main(argv: List[str] | None = None) -> None:
 
         gene_ids = extract_ensembl_gene_ids(data)
 
-        isoforms: List[Isoform] = []
+        isoforms: list[Isoform] = []
         if include_iso:
             entry = data
-            fasta_headers: List[str] = []
+            fasta_headers: list[str] = []
             if use_fasta_stream:
                 fasta_headers = client.fetch_isoforms_fasta(acc)
             isoforms = extract_isoforms(entry, fasta_headers)
@@ -267,7 +338,11 @@ def main(argv: List[str] | None = None) -> None:
                     }
                 )
         elif ensembl_client:
-            logging.warning("No Ensembl gene ID for %s", acc)
+            LOGGER.warning(
+                "Missing Ensembl gene identifier for %s",
+                acc,
+                extra={"uniprot_id": acc},
+            )
             if oma_client:
                 orthologs = oma_client.get_orthologs_by_uniprot(acc)
                 orthologs_json = json.dumps(
@@ -313,7 +388,11 @@ def main(argv: List[str] | None = None) -> None:
             )
         )
         write_rows(orthologs_path, orth_rows, orth_cols, csv_cfg)
-        print(orthologs_path)
+        LOGGER.info(
+            "Ortholog table written to %s",
+            orthologs_path,
+            extra={"path": str(orthologs_path)},
+        )
 
     rows.sort(key=lambda r: r.get("uniprot_id", ""))
     write_rows(output_path, rows, cols, csv_cfg)
@@ -337,7 +416,11 @@ def main(argv: List[str] | None = None) -> None:
         )
         write_rows(iso_out_path, iso_rows, iso_cols, csv_cfg)
 
-    print(output_path)
+    LOGGER.info(
+        "Target table written to %s",
+        output_path,
+        extra={"path": str(output_path)},
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- pin the Hypothesis and requests-cache packages in `requirements.lock`
- refactor `scripts/get_uniprot_target_data.py` to validate configuration data, expose a log-format option, and emit structured log messages instead of prints
- clean up imports and typing in the UniProt target script so it conforms to ruff/black formatting without suppressions

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy --strict --ignore-missing-imports .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c90c20ba348324b234c1e592b70d47