### PR TITLE
Add ChEMBL activity extraction pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ The `scripts/` directory contains several other scripts for performing specific 
 *   `dump_gtop_target.py`: Download comprehensive GtoPdb target information.
 *   `protein_classify_main.py`: Classify proteins based on UniProt data.
 *   `uniprot_enrich_main.py`: Enrich a CSV file with additional UniProt annotations.
+*   `chembl_assays_main.py`: Retrieve, validate, and export ChEMBL assay metadata with quality reports.
+*   `chembl_activities_main.py`: Stream activity identifiers, fetch ChEMBL activity records, normalise/validate them, and emit quality reports.
 
 For detailed usage information for each script, run it with the `--help` flag.
 
@@ -149,3 +151,31 @@ mypy .
 ## License
 
 This project is licensed under the MIT License. See the `LICENSE` file for details.
+#### ChEMBL activities extraction
+
+The `chembl_activities_main.py` script orchestrates the end-to-end retrieval and
+validation of ChEMBL activity records. Key features include streaming input ID
+reading, optional limits for sampling large files, resilient API access with a
+configurable User-Agent, deterministic normalisation, schema-based validation
+with JSON sidecar reports, and automatic quality profiling alongside metadata
+sidecars.
+
+Example commands:
+
+```bash
+# Inspect the input file without making API calls or writing outputs
+python scripts/chembl_activities_main.py --input activities.csv --dry-run
+
+# Download, normalise, and validate activities with explicit limits and output paths
+python scripts/chembl_activities_main.py \
+    --input activities.csv \
+    --output output_activities.csv \
+    --column activity_chembl_id \
+    --limit 1000 \
+    --chunk-size 10 \
+    --log-level DEBUG
+```
+
+Validation errors are persisted to `<output>.errors.json` while dataset metadata
+is written to `<output>.meta.yaml`. Quality and correlation reports are produced
+alongside the main CSV file.

--- a/library/__init__.py
+++ b/library/__init__.py
@@ -11,4 +11,13 @@ __all__ = [
     "protein_classifier",
     "iuphar",
     "data_profiling",
+    "chembl_client",
+    "chembl_library",
+    "assay_postprocessing",
+    "normalize_assays",
+    "assay_validation",
+    "normalize_activities",
+    "activity_validation",
+    "metadata",
+    "io",
 ]

--- a/library/activity_validation.py
+++ b/library/activity_validation.py
@@ -1,0 +1,132 @@
+"""Validation utilities for normalised activity tables."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Iterable, List, Mapping, Type
+
+import pandas as pd
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ActivitiesSchema(BaseModel):
+    """Pydantic model describing a validated activity record."""
+
+    model_config = ConfigDict(extra="allow")
+
+    activity_chembl_id: str
+    assay_chembl_id: str
+    molecule_chembl_id: str | None = None
+    parent_molecule_chembl_id: str | None = None
+    document_chembl_id: str | None = None
+    target_chembl_id: str | None = None
+    record_id: int | None = None
+    activity_id: int | None = None
+    standard_type: str | None = None
+    standard_relation: str | None = None
+    standard_units: str | None = None
+    standard_value: float | None = None
+    standard_upper_value: float | None = None
+    standard_lower_value: float | None = None
+    pchembl_value: float | None = None
+    potential_duplicate: bool | None = None
+    data_validity_comment: str | None = None
+    data_validity_warning: bool | None = None
+    activity_comment: str | None = None
+    type: str | None = None
+    relation: str | None = None
+    units: str | None = None
+
+    @field_validator("activity_chembl_id", "assay_chembl_id", mode="before")
+    @classmethod
+    def _ensure_non_empty(cls, value: Any) -> str:
+        if not value:
+            msg = "value must not be empty"
+            raise ValueError(msg)
+        return str(value)
+
+    @classmethod
+    def ordered_columns(cls) -> List[str]:
+        """Return the columns defined by the schema in declaration order."""
+
+        return list(cls.model_fields.keys())
+
+
+def _coerce_record(row: pd.Series) -> dict[str, Any]:
+    clean: dict[str, Any] = {}
+    for key, value in row.items():
+        if pd.isna(value):
+            clean[key] = None
+        else:
+            clean[key] = value
+    return clean
+
+
+def validate_activities(
+    df: pd.DataFrame,
+    schema: Type[ActivitiesSchema] = ActivitiesSchema,
+    *,
+    errors_path: Path,
+) -> pd.DataFrame:
+    """Validate rows in ``df`` against ``schema`` and write failures."""
+
+    if df.empty:
+        LOGGER.info("Validation skipped because the DataFrame is empty")
+        return df
+
+    required_fields = [
+        name
+        for name, field in schema.model_fields.items()
+        if field.is_required()  # type: ignore[attr-defined]
+    ]
+    missing_required = [field for field in required_fields if field not in df.columns]
+    if missing_required:
+        LOGGER.warning(
+            "Input data is missing required columns: %s",
+            ", ".join(sorted(missing_required)),
+        )
+
+    valid_rows: List[dict[str, Any]] = []
+    errors: List[dict[str, Any]] = []
+
+    def _normalise_error_details(
+        details: Iterable[Mapping[str, Any]],
+    ) -> list[dict[str, Any]]:
+        normalised: list[dict[str, Any]] = []
+        for entry in details:
+            clean_entry = dict(entry)
+            ctx = clean_entry.get("ctx")
+            if isinstance(ctx, dict):
+                clean_entry["ctx"] = {key: str(value) for key, value in ctx.items()}
+            normalised.append(clean_entry)
+        return normalised
+
+    for index, row in df.iterrows():
+        payload = _coerce_record(row)
+        try:
+            record = schema(**payload)
+        except ValidationError as exc:
+            LOGGER.warning("Validation error for row %s: %s", index, exc)
+            errors.append(
+                {
+                    "index": int(index),
+                    "errors": _normalise_error_details(exc.errors()),
+                    "row": payload,
+                }
+            )
+            continue
+        valid_rows.append(record.model_dump())
+
+    if errors:
+        errors_path.parent.mkdir(parents=True, exist_ok=True)
+        with errors_path.open("w", encoding="utf-8") as handle:
+            json.dump(errors, handle, ensure_ascii=False, indent=2)
+        LOGGER.info("Validation produced %d error records", len(errors))
+    elif errors_path.exists():
+        errors_path.unlink()
+
+    return pd.DataFrame(valid_rows)

--- a/library/assay_postprocessing.py
+++ b/library/assay_postprocessing.py
@@ -1,0 +1,56 @@
+"""Post-processing helpers for normalised assay tables."""
+
+from __future__ import annotations
+
+import logging
+from typing import List
+
+import pandas as pd
+
+LOGGER = logging.getLogger(__name__)
+
+
+REQUIRED_COLUMNS: List[str] = [
+    "assay_chembl_id",
+    "document_chembl_id",
+    "target_chembl_id",
+]
+
+
+def postprocess_assays(df: pd.DataFrame) -> pd.DataFrame:
+    """Return ``df`` augmented with ``assay_with_same_target``.
+
+    The function groups rows by ``document_chembl_id`` and ``target_chembl_id``
+    and counts how many assays share the same pair.  Missing identifiers are
+    treated as their own group so that orphaned records still receive a count.
+    """
+
+    missing = [column for column in REQUIRED_COLUMNS if column not in df.columns]
+    if missing:
+        msg = f"Missing required columns for post-processing: {', '.join(missing)}"
+        raise KeyError(msg)
+
+    if df.empty:
+        LOGGER.info("Received empty DataFrame for post-processing")
+        result = df.copy()
+        result["assay_with_same_target"] = pd.Series(dtype="int64")
+        return result
+
+    result = df.copy()
+
+    def _strip(value: object) -> object:
+        if isinstance(value, str):
+            text = value.strip()
+            return text if text else None
+        return value
+
+    result["__doc_norm"] = result["document_chembl_id"].map(_strip)
+    result["__target_norm"] = result["target_chembl_id"].map(_strip)
+    counts = (
+        result.groupby(["__doc_norm", "__target_norm"], dropna=False)["assay_chembl_id"]
+        .transform("count")
+        .astype("int64")
+    )
+    result["assay_with_same_target"] = counts
+    result.drop(columns=["__doc_norm", "__target_norm"], inplace=True)
+    return result

--- a/library/assay_validation.py
+++ b/library/assay_validation.py
@@ -1,0 +1,126 @@
+"""Validation utilities for normalised assay tables."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Iterable, List, Mapping
+
+import pandas as pd
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AssaysSchema(BaseModel):
+    """Pydantic model describing a validated assay record."""
+
+    model_config = ConfigDict(extra="allow")
+
+    assay_chembl_id: str
+    document_chembl_id: str
+    target_chembl_id: str | None = None
+    assay_category: str | None = None
+    assay_group: str | None = None
+    assay_type: str | None = None
+    assay_type_description: str | None = None
+    assay_organism: str | None = None
+    assay_test_type: str | None = None
+    assay_cell_type: str | None = None
+    assay_tissue: str | None = None
+    assay_tax_id: str | None = None
+    assay_with_same_target: int
+    confidence_score: int | None = None
+    confidence_description: str | None = None
+    relationship_type: str | None = None
+    relationship_description: str | None = None
+    bao_format: str | None = None
+    bao_label: str | None = None
+
+    @field_validator("assay_chembl_id", mode="before")
+    @classmethod
+    def _ensure_non_empty(cls, value: Any) -> str:
+        if not value:
+            raise ValueError("assay_chembl_id must not be empty")
+        return str(value)
+
+    @field_validator("assay_with_same_target", mode="before")
+    @classmethod
+    def _ensure_positive(cls, value: Any) -> int:
+        if value is None:
+            raise ValueError("assay_with_same_target is required")
+        int_value = int(value)
+        if int_value < 0:
+            raise ValueError("assay_with_same_target must be non-negative")
+        return int_value
+
+    @classmethod
+    def ordered_columns(cls) -> List[str]:
+        """Return the columns defined by the schema in declaration order."""
+
+        return list(cls.model_fields.keys())
+
+
+def _coerce_record(row: pd.Series) -> dict[str, Any]:
+    clean: dict[str, Any] = {}
+    for key, value in row.items():
+        if pd.isna(value):
+            clean[key] = None
+        else:
+            clean[key] = value
+    return clean
+
+
+def validate_assays(
+    df: pd.DataFrame,
+    schema: type[AssaysSchema] = AssaysSchema,
+    *,
+    errors_path: Path,
+) -> pd.DataFrame:
+    """Validate rows in ``df`` against ``schema`` and write failures."""
+
+    if df.empty:
+        LOGGER.info("Validation skipped because the DataFrame is empty")
+        return df
+
+    valid_rows: List[dict[str, Any]] = []
+    errors: List[dict[str, Any]] = []
+
+    def _normalise_error_details(
+        details: Iterable[Mapping[str, Any]],
+    ) -> list[dict[str, Any]]:
+        normalised: list[dict[str, Any]] = []
+        for entry in details:
+            clean_entry = dict(entry)
+            ctx = clean_entry.get("ctx")
+            if isinstance(ctx, dict):
+                clean_entry["ctx"] = {key: str(value) for key, value in ctx.items()}
+            normalised.append(clean_entry)
+        return normalised
+
+    for index, row in df.iterrows():
+        payload = _coerce_record(row)
+        try:
+            record = schema(**payload)
+        except ValidationError as exc:
+            LOGGER.warning("Validation error for row %s: %s", index, exc)
+            errors.append(
+                {
+                    "index": int(index),
+                    "errors": _normalise_error_details(exc.errors()),
+                    "row": payload,
+                }
+            )
+            continue
+        valid_rows.append(record.model_dump())
+
+    if errors:
+        errors_path.parent.mkdir(parents=True, exist_ok=True)
+        with errors_path.open("w", encoding="utf-8") as handle:
+            json.dump(errors, handle, ensure_ascii=False, indent=2)
+        LOGGER.info("Validation produced %d error records", len(errors))
+    elif errors_path.exists():
+        errors_path.unlink()
+
+    return pd.DataFrame(valid_rows)

--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -1,0 +1,119 @@
+"""HTTP client for retrieving ChEMBL records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any, Callable, Dict, Iterable, List
+
+import requests  # type: ignore[import-untyped]
+
+try:  # pragma: no cover - support importing without package context
+    from .http_client import CacheConfig, HttpClient
+except ImportError:  # pragma: no cover
+    from http_client import CacheConfig, HttpClient  # type: ignore[no-redef]
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ChemblClient:
+    """Client responsible for fetching payloads from the ChEMBL API.
+
+    Parameters
+    ----------
+    base_url:
+        Base URL for the ChEMBL web services.
+    timeout:
+        Request timeout in seconds.
+    max_retries:
+        Number of retry attempts for transient network errors.
+    rps:
+        Maximum number of requests per second; ``0`` disables rate limiting.
+    user_agent:
+        Value for the ``User-Agent`` header used in outgoing HTTP requests.
+    cache_config:
+        Optional :class:`CacheConfig` controlling HTTP caching behaviour.
+    http_client:
+        Pre-configured :class:`HttpClient` instance.  When omitted a new client
+        is created using the provided configuration values.
+    """
+
+    base_url: str = "https://www.ebi.ac.uk/chembl/api/data"
+    timeout: float = 30.0
+    max_retries: int = 3
+    rps: float = 2.0
+    user_agent: str = "ChEMBLDataAcquisition/1.0"
+    cache_config: CacheConfig | None = None
+    http_client: HttpClient | None = None
+
+    def __post_init__(self) -> None:
+        self._http = self.http_client or HttpClient(
+            timeout=self.timeout,
+            max_retries=self.max_retries,
+            rps=self.rps,
+            cache_config=self.cache_config,
+        )
+
+    def _fetch_resource(
+        self, resource: str, identifier: str, *, id_field: str
+    ) -> Dict[str, Any] | None:
+        url = f"{self.base_url.rstrip('/')}/{resource}/{identifier}.json"
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": self.user_agent,
+        }
+        try:
+            response = self._http.request("get", url, headers=headers)
+            if response.status_code == 404:
+                LOGGER.warning(
+                    "%s %s was not found (404)", resource.capitalize(), identifier
+                )
+                return None
+            response.raise_for_status()
+        except requests.HTTPError:
+            LOGGER.exception("Failed to fetch %s %s", resource, identifier)
+            raise
+        except requests.RequestException:
+            LOGGER.exception(
+                "Network error while fetching %s %s", resource, identifier
+            )
+            raise
+
+        payload: Dict[str, Any] = response.json()
+        payload.setdefault(id_field, identifier)
+        return payload
+
+    def fetch_assay(self, assay_id: str) -> Dict[str, Any] | None:
+        """Return the JSON payload for ``assay_id``."""
+
+        return self._fetch_resource("assay", assay_id, id_field="assay_chembl_id")
+
+    def fetch_activity(self, activity_id: str) -> Dict[str, Any] | None:
+        """Return the JSON payload for ``activity_id``."""
+
+        return self._fetch_resource(
+            "activity", activity_id, id_field="activity_chembl_id"
+        )
+
+    def _fetch_many(
+        self, identifiers: Iterable[str], fetcher: Callable[[str], Dict[str, Any] | None]
+    ) -> List[Dict[str, Any]]:
+        records: List[Dict[str, Any]] = []
+        for identifier in identifiers:
+            payload = fetcher(identifier)
+            if payload is not None:
+                records.append(payload)
+        return records
+
+    def fetch_many(self, assay_ids: Iterable[str]) -> List[Dict[str, Any]]:
+        """Fetch multiple assays and return the successful payloads."""
+
+        return self._fetch_many(assay_ids, self.fetch_assay)
+
+    def fetch_many_activities(
+        self, activity_ids: Iterable[str]
+    ) -> List[Dict[str, Any]]:
+        """Fetch multiple activities and return the successful payloads."""
+
+        return self._fetch_many(activity_ids, self.fetch_activity)

--- a/library/chembl_library.py
+++ b/library/chembl_library.py
@@ -1,0 +1,110 @@
+"""High level helpers for retrieving ChEMBL metadata."""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Iterable, Iterator, List
+
+import pandas as pd
+
+try:  # pragma: no cover - allow flat imports during testing
+    from .chembl_client import ChemblClient
+except ImportError:  # pragma: no cover
+    from chembl_client import ChemblClient  # type: ignore[no-redef]
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _chunked(values: Iterable[str], chunk_size: int) -> Iterator[List[str]]:
+    """Yield ``values`` in lists of at most ``chunk_size`` elements."""
+
+    chunk: List[str] = []
+    for value in values:
+        chunk.append(value)
+        if len(chunk) >= chunk_size:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
+
+
+def _fetch_dataframe(
+    *,
+    fetch: Callable[[Iterable[str]], List[dict[str, object]]],
+    identifiers: Iterable[str],
+    chunk_size: int,
+    log_label: str,
+    dedupe_column: str,
+) -> pd.DataFrame:
+    records: List[dict[str, object]] = []
+    for chunk in _chunked(identifiers, chunk_size):
+        LOGGER.info("Fetching %d %s from ChEMBL", len(chunk), log_label)
+        records.extend(fetch(chunk))
+
+    if not records:
+        LOGGER.warning("No %s were retrieved from the API", log_label)
+        return pd.DataFrame()
+
+    df = pd.DataFrame(records)
+    if dedupe_column in df.columns:
+        df = df.drop_duplicates(subset=[dedupe_column]).sort_values(dedupe_column)
+    df.reset_index(drop=True, inplace=True)
+    return df
+
+
+def get_assays(
+    client: ChemblClient,
+    assay_ids: Iterable[str],
+    *,
+    chunk_size: int = 20,
+) -> pd.DataFrame:
+    """Fetch assay metadata for ``assay_ids``.
+
+    Parameters
+    ----------
+    client:
+        Instance of :class:`ChemblClient` responsible for network requests.
+    assay_ids:
+        Iterable of assay identifiers to fetch from the ChEMBL API.
+    chunk_size:
+        Number of identifiers to process in a single batch.  This controls the
+        log granularity and can be tuned for improved determinism when dealing
+        with flaky network conditions.
+    """
+
+    return _fetch_dataframe(
+        fetch=client.fetch_many,
+        identifiers=assay_ids,
+        chunk_size=chunk_size,
+        log_label="assays",
+        dedupe_column="assay_chembl_id",
+    )
+
+
+def get_activities(
+    client: ChemblClient,
+    activity_ids: Iterable[str],
+    *,
+    chunk_size: int = 20,
+) -> pd.DataFrame:
+    """Fetch activity metadata for ``activity_ids``.
+
+    Parameters
+    ----------
+    client:
+        Instance of :class:`ChemblClient` responsible for network requests.
+    activity_ids:
+        Iterable of activity identifiers to fetch from the ChEMBL API.
+    chunk_size:
+        Number of identifiers to process in a single batch.  This controls the
+        log granularity and can be tuned for improved determinism when dealing
+        with flaky network conditions.
+    """
+
+    return _fetch_dataframe(
+        fetch=client.fetch_many_activities,
+        identifiers=activity_ids,
+        chunk_size=chunk_size,
+        log_label="activities",
+        dedupe_column="activity_chembl_id",
+    )

--- a/library/http_client.py
+++ b/library/http_client.py
@@ -25,8 +25,8 @@ from pathlib import Path
 from typing import Any, Mapping, Optional
 
 
-import requests
-import requests_cache
+import requests  # type: ignore[import-untyped]
+import requests_cache  # type: ignore[import-untyped]
 
 from tenacity import (
     retry,

--- a/library/io.py
+++ b/library/io.py
@@ -1,0 +1,78 @@
+"""Streaming CSV helpers for ChEMBL data acquisition.
+
+The :func:`read_ids` generator reads identifiers lazily from disk, ensuring
+that very large input files do not need to be loaded into memory all at once.
+The function mirrors the behaviour of :func:`library.io_utils.read_ids` but
+avoids materialising the full list of identifiers.  Values are normalised to
+upper case and deduplicated while preserving their first-seen order.
+
+Algorithm Notes
+---------------
+1. Stream the CSV file using :class:`csv.DictReader` with the configured
+   delimiter and encoding.
+2. Normalise each value to upper case and strip surrounding whitespace.
+3. Yield unique identifiers, skipping empty entries.
+4. Stop after ``limit`` unique identifiers when requested.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+from pathlib import Path
+from typing import Iterator, Set
+
+from .io_utils import CsvConfig
+
+LOGGER = logging.getLogger(__name__)
+
+
+def read_ids(
+    path: Path, column: str, cfg: CsvConfig, *, limit: int | None = None
+) -> Iterator[str]:
+    """Yield unique identifiers from ``column`` of ``path`` lazily.
+
+    Parameters
+    ----------
+    path:
+        Path to the CSV file containing identifiers.
+    column:
+        Name of the column holding the identifiers of interest.
+    cfg:
+        CSV configuration specifying delimiter and encoding.
+    limit:
+        Optional maximum number of **unique** identifiers to yield. ``None``
+        disables limiting and streams the entire file.
+
+    Yields
+    ------
+    str
+        Upper-case identifier values with surrounding whitespace removed.
+
+    Raises
+    ------
+    KeyError
+        If ``column`` is missing from the CSV header.
+    """
+
+    LOGGER.debug("Reading identifiers from %s (column=%s)", path, column)
+    with path.open("r", encoding=cfg.encoding, newline="") as handle:
+        reader = csv.DictReader(handle, delimiter=cfg.sep)
+        if reader.fieldnames is None or column not in reader.fieldnames:
+            msg = f"Missing required column '{column}'"
+            raise KeyError(msg)
+
+        seen: Set[str] = set()
+        yielded = 0
+        for row in reader:
+            raw_value = (row.get(column) or "").strip()
+            if not raw_value:
+                continue
+            normalised = raw_value.upper()
+            if normalised in seen:
+                continue
+            seen.add(normalised)
+            yield normalised
+            yielded += 1
+            if limit is not None and yielded >= limit:
+                break

--- a/library/metadata.py
+++ b/library/metadata.py
@@ -1,0 +1,72 @@
+"""Helpers for writing dataset metadata sidecar files."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml  # type: ignore[import-untyped]
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _file_sha256(path: Path, *, chunk_size: int = 1 << 20) -> str:
+    sha = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(chunk_size)
+            if not chunk:
+                break
+            sha.update(chunk)
+    return sha.hexdigest()
+
+
+def write_meta_yaml(
+    output_path: Path,
+    *,
+    command: str,
+    config: Mapping[str, Any],
+    row_count: int,
+    column_count: int,
+    meta_path: Path | None = None,
+) -> Path:
+    """Write dataset metadata next to ``output_path``.
+
+    Parameters
+    ----------
+    output_path:
+        Path to the generated CSV file.
+    command:
+        Command line invocation responsible for generating the data.
+    config:
+        Normalised configuration dictionary captured from the CLI arguments.
+    row_count:
+        Number of rows persisted to the CSV file.
+    column_count:
+        Number of columns in the CSV file.
+    meta_path:
+        Optional destination for the YAML file.  When omitted, the function
+        writes ``<output_path>.meta.yaml``.
+    """
+
+    target = meta_path or output_path.with_suffix(f"{output_path.suffix}.meta.yaml")
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    metadata = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "command": command,
+        "config": dict(config),
+        "output": str(output_path),
+        "sha256": _file_sha256(output_path),
+        "rows": row_count,
+        "columns": column_count,
+    }
+
+    with target.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(metadata, handle, allow_unicode=True, sort_keys=False)
+
+    LOGGER.info("Metadata written to %s", target)
+    return target

--- a/library/normalize_activities.py
+++ b/library/normalize_activities.py
@@ -1,0 +1,160 @@
+"""Deterministic normalisation utilities for activity tables."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Iterable
+
+import pandas as pd
+
+LOGGER = logging.getLogger(__name__)
+
+
+_STRING_COLUMNS: list[str] = [
+    "activity_chembl_id",
+    "assay_chembl_id",
+    "document_chembl_id",
+    "molecule_chembl_id",
+    "parent_molecule_chembl_id",
+    "target_chembl_id",
+    "standard_type",
+    "standard_relation",
+    "standard_units",
+    "type",
+    "relation",
+    "units",
+    "uo_units",
+    "qudt_units",
+    "activity_comment",
+    "data_validity_comment",
+]
+
+_FLOAT_COLUMNS: list[str] = [
+    "standard_value",
+    "standard_upper_value",
+    "standard_lower_value",
+    "pchembl_value",
+    "activity_value",
+]
+
+_INT_COLUMNS: list[str] = ["record_id", "activity_id", "standard_flag"]
+_BOOLEAN_COLUMNS: list[str] = ["potential_duplicate", "data_validity_warning"]
+_MAPPING_COLUMNS: list[str] = [
+    "ligand_efficiency",
+    "molecule_properties",
+    "molecule_hierarchy",
+]
+_COLLECTION_COLUMNS: list[str] = ["activity_properties", "target_components"]
+
+
+def _normalise_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    if pd.isna(value):  # type: ignore[arg-type]
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalise_numeric(value: Any) -> float | None:
+    if value in (None, "") or (isinstance(value, float) and pd.isna(value)):
+        return None
+    numeric = pd.to_numeric([value], errors="coerce")[0]
+    if pd.isna(numeric):
+        return None
+    return float(numeric)
+
+
+def _normalise_integer(value: Any) -> int | None:
+    numeric = _normalise_numeric(value)
+    if numeric is None:
+        return None
+    return int(numeric)
+
+
+def _normalise_boolean(value: Any) -> bool | None:
+    if value in (None, "") or (isinstance(value, float) and pd.isna(value)):
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and not pd.isna(value):  # type: ignore[arg-type]
+        return bool(int(value))
+    text = str(value).strip().lower()
+    if text in {"true", "t", "1", "yes"}:
+        return True
+    if text in {"false", "f", "0", "no"}:
+        return False
+    LOGGER.debug("Unable to normalise boolean value: %s", value)
+    return None
+
+
+def _normalise_mapping(value: Any) -> Any:
+    if value in (None, "") or (isinstance(value, float) and pd.isna(value)):
+        return None
+    if isinstance(value, dict):
+        return {key: value.get(key) for key in sorted(value)}
+    return value
+
+
+def _normalise_collection(value: Any) -> list[Any]:
+    if value in (None, "") or (isinstance(value, float) and pd.isna(value)):
+        return []
+    items: Iterable[Any]
+    if isinstance(value, list):
+        items = value
+    else:
+        items = [value]
+    normalised: list[Any] = []
+    for item in items:
+        if isinstance(item, dict):
+            normalised.append({key: item.get(key) for key in sorted(item)})
+        else:
+            normalised.append(item)
+    normalised.sort(key=lambda obj: json.dumps(obj, ensure_ascii=False, sort_keys=True))
+    return normalised
+
+
+def normalize_activities(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a normalised copy of ``df``.
+
+    Normalisation performs the following steps:
+
+    * String-like columns are stripped of surrounding whitespace and empty
+      values are replaced with ``None``.
+    * Numeric columns are converted to ``Float64`` or ``Int64`` where
+      applicable.
+    * Boolean columns are cast to pandas' nullable boolean dtype.
+    * Mapping and collection columns are sorted deterministically.
+    """
+
+    result = df.copy()
+
+    for column in _STRING_COLUMNS:
+        if column in result.columns:
+            result[column] = result[column].map(_normalise_string)
+
+    for column in _FLOAT_COLUMNS:
+        if column in result.columns:
+            result[column] = result[column].map(_normalise_numeric).astype("Float64")
+
+    for column in _INT_COLUMNS:
+        if column in result.columns:
+            result[column] = result[column].map(_normalise_integer).astype("Int64")
+
+    for column in _BOOLEAN_COLUMNS:
+        if column in result.columns:
+            result[column] = result[column].map(_normalise_boolean).astype("boolean")
+
+    for column in _MAPPING_COLUMNS:
+        if column in result.columns:
+            result[column] = result[column].map(_normalise_mapping)
+
+    for column in _COLLECTION_COLUMNS:
+        if column in result.columns:
+            result[column] = result[column].map(_normalise_collection)
+
+    return result

--- a/library/normalize_assays.py
+++ b/library/normalize_assays.py
@@ -1,0 +1,113 @@
+"""Deterministic normalisation utilities for assay tables."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, List
+
+import pandas as pd
+
+LOGGER = logging.getLogger(__name__)
+
+
+_STRING_COLUMNS: List[str] = [
+    "assay_category",
+    "assay_cell_type",
+    "assay_chembl_id",
+    "assay_group",
+    "assay_organism",
+    "assay_strain",
+    "assay_subcellular_fraction",
+    "assay_tax_id",
+    "assay_test_type",
+    "assay_tissue",
+    "assay_type",
+    "assay_type_description",
+    "bao_format",
+    "bao_label",
+    "cell_chembl_id",
+    "confidence_description",
+    "description",
+    "document_chembl_id",
+    "relationship_description",
+    "relationship_type",
+    "src_assay_id",
+    "target_chembl_id",
+    "tissue_chembl_id",
+]
+
+_NUMERIC_COLUMNS: List[str] = ["confidence_score", "src_id"]
+_COLLECTION_COLUMNS: List[str] = [
+    "assay_classifications",
+    "assay_parameters",
+    "variant_sequence",
+]
+
+
+def _normalise_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    if pd.isna(value):  # type: ignore[arg-type]
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalise_collection(value: Any) -> list[Any]:
+    if value in (None, "") or (isinstance(value, float) and pd.isna(value)):
+        return []
+    items: list[Any]
+    if isinstance(value, list):
+        items = list(value)
+    else:
+        items = [value]
+    normalised: list[Any] = []
+    for item in items:
+        if isinstance(item, dict):
+            normalised.append({key: item.get(key) for key in sorted(item)})
+        else:
+            normalised.append(item)
+    normalised.sort(key=lambda obj: json.dumps(obj, ensure_ascii=False, sort_keys=True))
+    return normalised
+
+
+def normalize_assays(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a normalised copy of ``df``.
+
+    Normalisation performs the following steps:
+
+    * String-like columns are stripped of surrounding whitespace and empty
+      values are replaced with ``None``.
+    * Numeric columns are coerced into nullable integer dtype.
+    * Collection columns (lists of dictionaries) are sorted deterministically
+      with keys ordered alphabetically.
+    """
+
+    result = df.copy()
+
+    for column in _STRING_COLUMNS:
+        if column in result.columns:
+            result[column] = result[column].map(_normalise_string)
+
+    for column in _NUMERIC_COLUMNS:
+        if column in result.columns:
+            result[column] = pd.to_numeric(result[column], errors="coerce").astype(
+                "Int64"
+            )
+
+    if "assay_with_same_target" in result.columns:
+        result["assay_with_same_target"] = (
+            pd.to_numeric(result["assay_with_same_target"], errors="coerce")
+            .fillna(0)
+            .astype("int64")
+        )
+
+    for column in _COLLECTION_COLUMNS:
+        if column in result.columns:
+            result[column] = result[column].map(_normalise_collection)
+
+    return result

--- a/scripts/chembl_activities_main.py
+++ b/scripts/chembl_activities_main.py
@@ -1,0 +1,259 @@
+"""Command line entry point for downloading and normalising ChEMBL activities."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import shlex
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import pandas as pd
+
+from library.activity_validation import ActivitiesSchema, validate_activities
+from library.chembl_client import ChemblClient
+from library.chembl_library import get_activities
+from library.data_profiling import analyze_table_quality
+from library.io import read_ids
+from library.io_utils import CsvConfig
+from library.metadata import write_meta_yaml
+from library.normalize_activities import normalize_activities
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _default_output_name(input_path: str) -> str:
+    stem = Path(input_path).stem or "output"
+    date_suffix = datetime.now().strftime("%Y%m%d")
+    return f"output_{stem}_{date_suffix}.csv"
+
+
+def _configure_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+
+def _serialise_complex_columns(df: pd.DataFrame, list_format: str) -> pd.DataFrame:
+    result = df.copy()
+    for column in result.columns:
+        if result[column].map(lambda value: isinstance(value, (list, dict))).any():
+            result[column] = result[column].map(
+                lambda value: _serialise_value(value, list_format)
+            )
+    return result
+
+
+def _serialise_value(value: object, list_format: str) -> object:
+    if isinstance(value, dict):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    if isinstance(value, list):
+        if list_format == "pipe":
+            return "|".join(
+                json.dumps(item, ensure_ascii=False, sort_keys=True) for item in value
+            )
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return value
+
+
+def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments for the activity pipeline CLI."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input", default="input.csv", help="Path to the input CSV file"
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Destination CSV file. Defaults to output_<input>_<YYYYMMDD>.csv",
+    )
+    parser.add_argument(
+        "--column", default="activity_chembl_id", help="Column containing activity IDs"
+    )
+    parser.add_argument(
+        "--chunk-size", type=int, default=20, help="Number of IDs fetched per batch"
+    )
+    parser.add_argument(
+        "--timeout", type=float, default=30.0, help="HTTP timeout in seconds"
+    )
+    parser.add_argument(
+        "--max-retries", type=int, default=3, help="Maximum retry attempts"
+    )
+    parser.add_argument(
+        "--rps", type=float, default=2.0, help="Maximum requests per second"
+    )
+    parser.add_argument(
+        "--base-url",
+        default="https://www.ebi.ac.uk/chembl/api/data",
+        help="ChEMBL API root",
+    )
+    parser.add_argument(
+        "--user-agent", default="ChEMBLDataAcquisition/1.0", help="User-Agent header"
+    )
+    parser.add_argument("--sep", default=",", help="CSV delimiter")
+    parser.add_argument("--encoding", default="utf-8", help="CSV encoding")
+    parser.add_argument(
+        "--list-format",
+        choices=["json", "pipe"],
+        default="json",
+        help="Serialization format for list columns",
+    )
+    parser.add_argument(
+        "--log-level", default="INFO", help="Logging level (e.g. INFO, DEBUG)"
+    )
+    parser.add_argument(
+        "--errors-output", default=None, help="Path to validation error report"
+    )
+    parser.add_argument(
+        "--meta-output", default=None, help="Optional metadata YAML path"
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of identifiers to process",
+    )
+    parser.add_argument(
+        "--dictionary",
+        default=None,
+        help="Optional dictionary file for downstream enrichment",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Read and validate the input file without fetching or writing output",
+    )
+    return parser.parse_args(args)
+
+
+def _prepare_configuration(namespace: argparse.Namespace) -> dict[str, object]:
+    config: dict[str, object] = {}
+    for key, value in vars(namespace).items():
+        if key in {"output", "errors_output", "meta_output"}:
+            continue
+        if isinstance(value, Path):
+            config[key] = str(value)
+        else:
+            config[key] = value
+    return config
+
+
+def _limited_ids(
+    path: Path, column: str, cfg: CsvConfig, limit: int | None
+) -> Iterable[str]:
+    return read_ids(path, column, cfg, limit=limit)
+
+
+def run_pipeline(
+    args: argparse.Namespace, *, command_parts: Sequence[str] | None = None
+) -> int:
+    """Execute the activity acquisition pipeline with ``args``."""
+
+    if args.limit is not None and args.limit <= 0:
+        raise ValueError("--limit must be a positive integer")
+
+    input_path = Path(args.input)
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input file {input_path} does not exist")
+
+    output_path = (
+        Path(args.output) if args.output else Path(_default_output_name(args.input))
+    )
+    errors_path = (
+        Path(args.errors_output)
+        if args.errors_output
+        else output_path.with_suffix(f"{output_path.suffix}.errors.json")
+    )
+    meta_path = Path(args.meta_output) if args.meta_output else None
+
+    csv_cfg = CsvConfig(
+        sep=args.sep, encoding=args.encoding, list_format=args.list_format
+    )
+
+    if args.dry_run:
+        count = sum(
+            1 for _ in _limited_ids(input_path, args.column, csv_cfg, args.limit)
+        )
+        LOGGER.info("Dry run complete: %d unique identifiers would be processed", count)
+        return 0
+
+    activity_ids = _limited_ids(input_path, args.column, csv_cfg, args.limit)
+
+    client = ChemblClient(
+        base_url=args.base_url,
+        timeout=args.timeout,
+        max_retries=args.max_retries,
+        rps=args.rps,
+        user_agent=args.user_agent,
+    )
+
+    activities_df = get_activities(client, activity_ids, chunk_size=args.chunk_size)
+    if activities_df.empty:
+        LOGGER.warning("No activity data retrieved; writing empty output")
+        activities_df = pd.DataFrame(columns=ActivitiesSchema.ordered_columns())
+
+    normalised = normalize_activities(activities_df)
+    validated = validate_activities(normalised, errors_path=errors_path)
+
+    schema_columns = [
+        column
+        for column in ActivitiesSchema.ordered_columns()
+        if column in validated.columns
+    ]
+    extra_columns = sorted(
+        [column for column in validated.columns if column not in schema_columns]
+    )
+    ordered_columns = schema_columns + extra_columns
+    if ordered_columns:
+        validated = validated[ordered_columns]
+
+    sort_columns = [
+        column
+        for column in ["assay_chembl_id", "molecule_chembl_id", "activity_chembl_id"]
+        if column in validated.columns
+    ]
+    if sort_columns:
+        validated = validated.sort_values(sort_columns).reset_index(drop=True)
+
+    serialised = _serialise_complex_columns(validated, args.list_format)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    serialised.to_csv(output_path, index=False, sep=args.sep, encoding=args.encoding)
+
+    if command_parts is None:
+        command_parts = sys.argv
+
+    write_meta_yaml(
+        output_path,
+        command=" ".join(shlex.quote(part) for part in command_parts),
+        config=_prepare_configuration(args),
+        row_count=int(len(serialised)),
+        column_count=int(len(serialised.columns)),
+        meta_path=meta_path,
+    )
+
+    analyze_table_quality(serialised, table_name=str(output_path.with_suffix("")))
+
+    LOGGER.info("Activity table written to %s", output_path)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point used by the CLI and tests."""
+
+    args = parse_args(argv)
+    _configure_logging(args.log_level)
+    try:
+        cmd_parts = [sys.argv[0], *(argv or sys.argv[1:])]
+        return run_pipeline(args, command_parts=cmd_parts)
+    except Exception as exc:  # pragma: no cover - safety net
+        LOGGER.exception("Fatal error: %s", exc)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/chembl_assays_main.py
+++ b/scripts/chembl_assays_main.py
@@ -1,0 +1,224 @@
+"""Command line entry point for downloading and normalising ChEMBL assays."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import shlex
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+
+from library.assay_postprocessing import postprocess_assays
+from library.assay_validation import AssaysSchema, validate_assays
+from library.chembl_client import ChemblClient
+from library.chembl_library import get_assays
+from library.data_profiling import analyze_table_quality
+from library.io import read_ids
+from library.io_utils import CsvConfig
+from library.metadata import write_meta_yaml
+from library.normalize_assays import normalize_assays
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _default_output_name(input_path: str) -> str:
+    stem = Path(input_path).stem or "output"
+    date_suffix = datetime.now().strftime("%Y%m%d")
+    return f"output_{stem}_{date_suffix}.csv"
+
+
+def _configure_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+
+def _serialise_complex_columns(df: pd.DataFrame, list_format: str) -> pd.DataFrame:
+    result = df.copy()
+    for column in result.columns:
+        if result[column].map(lambda value: isinstance(value, (list, dict))).any():
+            result[column] = result[column].map(
+                lambda value: _serialise_value(value, list_format)
+            )
+    return result
+
+
+def _serialise_value(value: object, list_format: str) -> object:
+    if isinstance(value, dict):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    if isinstance(value, list):
+        if list_format == "pipe":
+            return "|".join(
+                json.dumps(item, ensure_ascii=False, sort_keys=True) for item in value
+            )
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return value
+
+
+def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments for the assay pipeline CLI."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input", default="input.csv", help="Path to the input CSV file"
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Destination CSV file. Defaults to output_<input>_<YYYYMMDD>.csv",
+    )
+    parser.add_argument(
+        "--column", default="assay_chembl_id", help="Column containing assay IDs"
+    )
+    parser.add_argument(
+        "--chunk-size", type=int, default=20, help="Number of IDs fetched per batch"
+    )
+    parser.add_argument(
+        "--timeout", type=float, default=30.0, help="HTTP timeout in seconds"
+    )
+    parser.add_argument(
+        "--max-retries", type=int, default=3, help="Maximum retry attempts"
+    )
+    parser.add_argument(
+        "--rps", type=float, default=2.0, help="Maximum requests per second"
+    )
+    parser.add_argument(
+        "--base-url",
+        default="https://www.ebi.ac.uk/chembl/api/data",
+        help="ChEMBL API root",
+    )
+    parser.add_argument("--sep", default=",", help="CSV delimiter")
+    parser.add_argument("--encoding", default="utf-8", help="CSV encoding")
+    parser.add_argument(
+        "--list-format",
+        choices=["json", "pipe"],
+        default="json",
+        help="Serialization format for list columns",
+    )
+    parser.add_argument(
+        "--log-level", default="INFO", help="Logging level (e.g. INFO, DEBUG)"
+    )
+    parser.add_argument(
+        "--errors-output", default=None, help="Path to validation error report"
+    )
+    parser.add_argument(
+        "--meta-output", default=None, help="Optional metadata YAML path"
+    )
+    return parser.parse_args(args)
+
+
+def _prepare_configuration(namespace: argparse.Namespace) -> dict[str, object]:
+    config: dict[str, object] = {}
+    for key, value in vars(namespace).items():
+        if key in {"output", "errors_output", "meta_output"}:
+            continue
+        if isinstance(value, Path):
+            config[key] = str(value)
+        else:
+            config[key] = value
+    return config
+
+
+def run_pipeline(
+    args: argparse.Namespace, *, command_parts: Sequence[str] | None = None
+) -> int:
+    """Execute the assay acquisition pipeline with ``args``."""
+
+    input_path = Path(args.input)
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input file {input_path} does not exist")
+
+    output_path = (
+        Path(args.output) if args.output else Path(_default_output_name(args.input))
+    )
+    errors_path = (
+        Path(args.errors_output)
+        if args.errors_output
+        else output_path.with_suffix(f"{output_path.suffix}.errors.json")
+    )
+    meta_path = Path(args.meta_output) if args.meta_output else None
+
+    csv_cfg = CsvConfig(
+        sep=args.sep, encoding=args.encoding, list_format=args.list_format
+    )
+    assay_ids = read_ids(input_path, args.column, csv_cfg)
+
+    client = ChemblClient(
+        base_url=args.base_url,
+        timeout=args.timeout,
+        max_retries=args.max_retries,
+        rps=args.rps,
+    )
+
+    assays_df = get_assays(client, assay_ids, chunk_size=args.chunk_size)
+    if assays_df.empty:
+        LOGGER.warning("No assay data retrieved; writing empty output")
+        assays_df = pd.DataFrame(columns=AssaysSchema.ordered_columns())
+
+    processed = postprocess_assays(assays_df)
+    normalised = normalize_assays(processed)
+    validated = validate_assays(normalised, errors_path=errors_path)
+
+    schema_columns = [
+        column
+        for column in AssaysSchema.ordered_columns()
+        if column in validated.columns
+    ]
+    extra_columns = sorted(
+        [column for column in validated.columns if column not in schema_columns]
+    )
+    ordered_columns = schema_columns + extra_columns
+    if ordered_columns:
+        validated = validated[ordered_columns]
+
+    sort_columns = [
+        column
+        for column in ["document_chembl_id", "target_chembl_id", "assay_chembl_id"]
+        if column in validated.columns
+    ]
+    if sort_columns:
+        validated = validated.sort_values(sort_columns).reset_index(drop=True)
+
+    serialised = _serialise_complex_columns(validated, args.list_format)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    serialised.to_csv(output_path, index=False, sep=args.sep, encoding=args.encoding)
+
+    if command_parts is None:
+        command_parts = sys.argv
+
+    write_meta_yaml(
+        output_path,
+        command=" ".join(shlex.quote(part) for part in command_parts),
+        config=_prepare_configuration(args),
+        row_count=int(len(serialised)),
+        column_count=int(len(serialised.columns)),
+        meta_path=meta_path,
+    )
+
+    analyze_table_quality(serialised, table_name=str(output_path.with_suffix("")))
+
+    LOGGER.info("Assay table written to %s", output_path)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point used by the CLI and tests."""
+
+    args = parse_args(argv)
+    _configure_logging(args.log_level)
+    try:
+        cmd_parts = [sys.argv[0], *(argv or sys.argv[1:])]
+        return run_pipeline(args, command_parts=cmd_parts)
+    except Exception as exc:  # pragma: no cover - safety net
+        LOGGER.exception("Fatal error: %s", exc)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/get_uniprot_target_data.py
+++ b/scripts/get_uniprot_target_data.py
@@ -39,7 +39,6 @@ from library.http_client import CacheConfig  # noqa: E402
 from library.logging_utils import configure_logging  # noqa: E402
 
 
-
 DEFAULT_INPUT = "input.csv"
 DEFAULT_OUTPUT = "output_input_{date}.csv"
 DEFAULT_COLUMN = "uniprot_id"

--- a/tests/data/activities_input.csv
+++ b/tests/data/activities_input.csv
@@ -1,0 +1,4 @@
+activity_chembl_id
+CHEMBL100
+CHEMBL101
+CHEMBL100

--- a/tests/data/assays_input.csv
+++ b/tests/data/assays_input.csv
@@ -1,0 +1,5 @@
+assay_chembl_id
+CHEMBL1
+CHEMBL2
+chembl1
+

--- a/tests/test_chembl_activities_pipeline.py
+++ b/tests/test_chembl_activities_pipeline.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+import pandas as pd
+import pytest
+import requests_mock as requests_mock_lib
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+normalize_activities = importlib.import_module(
+    "library.normalize_activities"
+).normalize_activities
+validate_activities = importlib.import_module(
+    "library.activity_validation"
+).validate_activities
+ChemblClient = importlib.import_module("library.chembl_client").ChemblClient
+get_activities = importlib.import_module("library.chembl_library").get_activities
+read_ids = importlib.import_module("library.io").read_ids
+CsvConfig = importlib.import_module("library.io_utils").CsvConfig
+chembl_activities_main = importlib.import_module("scripts.chembl_activities_main").main
+
+
+def test_read_ids_limit(tmp_path: Path) -> None:
+    source = Path(__file__).parent / "data" / "activities_input.csv"
+    target = tmp_path / "ids.csv"
+    target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    cfg = CsvConfig(sep=",", encoding="utf-8")
+    ids = list(read_ids(target, "activity_chembl_id", cfg, limit=1))
+    assert ids == ["CHEMBL100"]
+
+
+def test_chembl_client_handles_activity_404(
+    requests_mock: requests_mock_lib.Mocker,
+) -> None:
+    base_url = "https://chembl.mock"
+    requests_mock.get(f"{base_url}/activity/CHEMBL404.json", status_code=404)
+
+    client = ChemblClient(base_url=base_url)
+    assert client.fetch_activity("CHEMBL404") is None
+
+
+def test_get_activities_batches_requests() -> None:
+    calls: List[List[str]] = []
+
+    class DummyClient:
+        def fetch_many_activities(self, values: Iterable[str]) -> List[dict[str, str]]:
+            batch = list(values)
+            calls.append(batch)
+            return [
+                {
+                    "activity_chembl_id": activity_id,
+                    "assay_chembl_id": f"ASSAY-{activity_id}",
+                }
+                for activity_id in batch
+            ]
+
+    df = get_activities(DummyClient(), ["CHEMBL1", "CHEMBL2", "CHEMBL3"], chunk_size=2)
+    assert list(df["activity_chembl_id"]) == ["CHEMBL1", "CHEMBL2", "CHEMBL3"]
+    assert calls == [["CHEMBL1", "CHEMBL2"], ["CHEMBL3"]]
+
+
+def test_normalize_activities() -> None:
+    raw = pd.DataFrame(
+        [
+            {
+                "activity_chembl_id": " ACT1 ",
+                "assay_chembl_id": " ASSAY1 ",
+                "molecule_chembl_id": " MOL1 ",
+                "standard_value": "10",
+                "standard_flag": "1",
+                "potential_duplicate": "True",
+                "ligand_efficiency": {"LE": 1, "LLE": 2},
+                "activity_properties": [
+                    {"name": "propB", "value": 2},
+                    {"value": 1, "name": "propA"},
+                ],
+            },
+            {
+                "activity_chembl_id": "ACT2",
+                "assay_chembl_id": "ASSAY2",
+                "standard_value": None,
+                "data_validity_warning": "false",
+                "activity_properties": None,
+            },
+        ]
+    )
+
+    normalised = normalize_activities(raw)
+    assert normalised.loc[0, "activity_chembl_id"] == "ACT1"
+    assert normalised.loc[0, "assay_chembl_id"] == "ASSAY1"
+    assert normalised.loc[0, "standard_value"] == pytest.approx(10.0)
+    assert normalised.loc[0, "standard_flag"] == 1
+    assert bool(normalised.loc[0, "potential_duplicate"]) is True
+    assert normalised.loc[0, "ligand_efficiency"] == {"LE": 1, "LLE": 2}
+    assert normalised.loc[0, "activity_properties"] == [
+        {"name": "propA", "value": 1},
+        {"name": "propB", "value": 2},
+    ]
+    assert pd.isna(normalised.loc[1, "standard_value"])
+    assert bool(normalised.loc[1, "data_validity_warning"]) is False
+    assert normalised.loc[1, "activity_properties"] == []
+
+
+def test_validate_activities_writes_errors(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "activity_chembl_id": "CHEMBL1",
+                "assay_chembl_id": "ASSAY1",
+            },
+            {
+                "activity_chembl_id": "",
+                "assay_chembl_id": None,
+            },
+        ]
+    )
+
+    errors_path = tmp_path / "errors.json"
+    validated = validate_activities(df, errors_path=errors_path)
+
+    assert len(validated) == 1
+    assert not validated["activity_chembl_id"].isna().any()
+    assert errors_path.exists()
+    data = json.loads(errors_path.read_text(encoding="utf-8"))
+    assert len(data) == 1
+
+
+def test_chembl_activities_main_dry_run(tmp_path: Path) -> None:
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("activity_chembl_id\nCHEMBL1\nCHEMBL2\n", encoding="utf-8")
+
+    output_csv = tmp_path / "out.csv"
+    exit_code = chembl_activities_main(
+        [
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--dry-run",
+            "--log-level",
+            "DEBUG",
+        ]
+    )
+
+    assert exit_code == 0
+    assert not output_csv.exists()
+
+
+def test_chembl_activities_main_end_to_end(
+    tmp_path: Path, requests_mock: requests_mock_lib.Mocker
+) -> None:
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("activity_chembl_id\nCHEMBL1\nCHEMBL2\n", encoding="utf-8")
+
+    base_url = "https://chembl.mock"
+    payload_template = {
+        "activity_chembl_id": "",
+        "assay_chembl_id": "ASSAY",
+        "molecule_chembl_id": "MOL",
+        "standard_value": 5,
+        "standard_flag": 1,
+        "potential_duplicate": False,
+    }
+    for activity_id in ["CHEMBL1", "CHEMBL2"]:
+        payload = dict(payload_template)
+        payload["activity_chembl_id"] = activity_id
+        requests_mock.get(f"{base_url}/activity/{activity_id}.json", json=payload)
+
+    output_csv = tmp_path / "out.csv"
+    exit_code = chembl_activities_main(
+        [
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--base-url",
+            base_url,
+            "--chunk-size",
+            "1",
+            "--log-level",
+            "DEBUG",
+        ]
+    )
+
+    assert exit_code == 0
+    assert output_csv.exists()
+    df = pd.read_csv(output_csv)
+    assert sorted(df["activity_chembl_id"].tolist()) == ["CHEMBL1", "CHEMBL2"]
+
+    meta_file = output_csv.with_suffix(".csv.meta.yaml")
+    assert meta_file.exists()
+
+    quality_report = Path(f"{output_csv.with_suffix('')}_quality_report_table.csv")
+    assert quality_report.exists()
+    corr_report = Path(
+        f"{output_csv.with_suffix('')}_data_correlation_report_table.csv"
+    )
+    assert corr_report.exists()

--- a/tests/test_chembl_assays_pipeline.py
+++ b/tests/test_chembl_assays_pipeline.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+import importlib
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+import pandas as pd
+import pytest
+import requests_mock as requests_mock_lib
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+assay_postprocessing = importlib.import_module("library.assay_postprocessing")
+normalize_assays = importlib.import_module("library.normalize_assays")
+validate_assays = importlib.import_module("library.assay_validation").validate_assays
+ChemblClient = importlib.import_module("library.chembl_client").ChemblClient
+get_assays = importlib.import_module("library.chembl_library").get_assays
+read_ids = importlib.import_module("library.io").read_ids
+CsvConfig = importlib.import_module("library.io_utils").CsvConfig
+write_meta_yaml = importlib.import_module("library.metadata").write_meta_yaml
+chembl_assays_main = importlib.import_module("scripts.chembl_assays_main").main
+
+
+def test_read_ids_streams_unique(tmp_path: Path) -> None:
+    source = Path(__file__).parent / "data" / "assays_input.csv"
+    target = tmp_path / "ids.csv"
+    target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    cfg = CsvConfig(sep=",", encoding="utf-8")
+    ids = list(read_ids(target, "assay_chembl_id", cfg))
+    assert ids == ["CHEMBL1", "CHEMBL2"]
+
+
+def test_chembl_client_handles_404(requests_mock: requests_mock_lib.Mocker) -> None:
+    base_url = "https://chembl.mock"
+    requests_mock.get(f"{base_url}/assay/CHEMBL404.json", status_code=404)
+
+    client = ChemblClient(base_url=base_url)
+    assert client.fetch_assay("CHEMBL404") is None
+
+
+def test_get_assays_batches_requests() -> None:
+    calls: List[List[str]] = []
+
+    class DummyClient:
+        def fetch_many(self, values: Iterable[str]) -> List[dict[str, str]]:
+            batch = list(values)
+            calls.append(batch)
+            return [
+                {
+                    "assay_chembl_id": assay_id,
+                    "document_chembl_id": f"DOC-{assay_id}",
+                    "target_chembl_id": f"TAR-{assay_id}",
+                }
+                for assay_id in batch
+            ]
+
+    df = get_assays(DummyClient(), ["CHEMBL1", "CHEMBL2", "CHEMBL3"], chunk_size=2)
+    assert list(df["assay_chembl_id"]) == ["CHEMBL1", "CHEMBL2", "CHEMBL3"]
+    assert calls == [["CHEMBL1", "CHEMBL2"], ["CHEMBL3"]]
+
+
+def test_postprocess_and_normalize() -> None:
+    raw = pd.DataFrame(
+        [
+            {
+                "assay_chembl_id": "CHEMBL1",
+                "document_chembl_id": " DOC1 ",
+                "target_chembl_id": "TAR1",
+                "confidence_score": "5",
+                "assay_parameters": [
+                    {"name": "ParamB", "value": 1},
+                    {"value": 2, "name": "ParamA"},
+                ],
+            },
+            {
+                "assay_chembl_id": "CHEMBL2",
+                "document_chembl_id": "DOC1",
+                "target_chembl_id": "TAR1",
+                "confidence_score": "",
+                "assay_parameters": None,
+            },
+        ]
+    )
+
+    processed = assay_postprocessing.postprocess_assays(raw)
+    assert list(processed["assay_with_same_target"]) == [2, 2]
+
+    normalised = normalize_assays.normalize_assays(processed)
+    assert normalised.loc[0, "document_chembl_id"] == "DOC1"
+    assert normalised.loc[0, "assay_with_same_target"] == 2
+    assert list(normalised.loc[0, "assay_parameters"]) == [
+        {"name": "ParamA", "value": 2},
+        {"name": "ParamB", "value": 1},
+    ]
+    assert pd.isna(normalised.loc[1, "confidence_score"])
+
+
+def test_validate_assays_writes_errors(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "assay_chembl_id": "CHEMBL1",
+                "document_chembl_id": "DOC1",
+                "target_chembl_id": "TAR1",
+                "assay_with_same_target": 1,
+            },
+            {
+                "assay_chembl_id": "",
+                "document_chembl_id": "DOC2",
+                "target_chembl_id": "TAR2",
+                "assay_with_same_target": -1,
+            },
+        ]
+    )
+
+    errors_path = tmp_path / "errors.json"
+    validated = validate_assays(df, errors_path=errors_path)
+
+    assert len(validated) == 1
+    assert not validated["assay_chembl_id"].isna().any()
+    assert errors_path.exists()
+    data = json.loads(errors_path.read_text(encoding="utf-8"))
+    assert len(data) == 1
+
+
+def test_write_meta_yaml(tmp_path: Path) -> None:
+    output = tmp_path / "assays.csv"
+    output.write_text("assay_chembl_id\nCHEMBL1\n", encoding="utf-8")
+    meta_path = write_meta_yaml(
+        output,
+        command="python script.py",
+        config={"chunk_size": 10},
+        row_count=1,
+        column_count=1,
+    )
+
+    assert meta_path.exists()
+    metadata = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+    assert metadata["rows"] == 1
+    assert metadata["columns"] == 1
+    assert "sha256" in metadata
+
+
+def test_chembl_assays_main_end_to_end(
+    tmp_path: Path, requests_mock: pytest.LogCaptureFixture
+) -> None:
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("assay_chembl_id\nCHEMBL1\nCHEMBL2\n", encoding="utf-8")
+
+    base_url = "https://chembl.mock"
+    payload_template = {
+        "assay_category": "Binding",
+        "assay_chembl_id": "",
+        "assay_group": "Group",
+        "assay_type": "B",
+        "assay_organism": "Human",
+        "assay_test_type": "IC50",
+        "document_chembl_id": "DOC",
+        "target_chembl_id": "TAR",
+        "confidence_score": 5,
+        "assay_classifications": [{"level": 1, "label": "Test"}],
+    }
+    for assay_id in ["CHEMBL1", "CHEMBL2"]:
+        payload = dict(payload_template)
+        payload["assay_chembl_id"] = assay_id
+        requests_mock.get(f"{base_url}/assay/{assay_id}.json", json=payload)
+
+    output_csv = tmp_path / "out.csv"
+    exit_code = chembl_assays_main(
+        [
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--base-url",
+            base_url,
+            "--chunk-size",
+            "1",
+            "--log-level",
+            "DEBUG",
+        ]
+    )
+
+    assert exit_code == 0
+    assert output_csv.exists()
+    df = pd.read_csv(output_csv)
+    assert sorted(df["assay_chembl_id"].tolist()) == ["CHEMBL1", "CHEMBL2"]
+
+    meta_file = output_csv.with_suffix(".csv.meta.yaml")
+    assert meta_file.exists()
+
+    quality_report = Path(f"{output_csv.with_suffix('')}_quality_report_table.csv")
+    assert quality_report.exists()
+    corr_report = Path(
+        f"{output_csv.with_suffix('')}_data_correlation_report_table.csv"
+    )
+    assert corr_report.exists()


### PR DESCRIPTION
## Summary
- extend the shared I/O and Chembl client helpers with identifier limiting, user-agent support, and activity batching utilities
- add normalization, validation, and a CLI workflow for ChEMBL activities together with documentation updates
- cover the new pipeline with dedicated unit tests and fixture data

## Testing
- ruff check .
- mypy --config-file mypy.ini library/io.py library/chembl_client.py library/chembl_library.py library/normalize_assays.py library/assay_validation.py library/normalize_activities.py library/activity_validation.py library/metadata.py scripts/chembl_assays_main.py scripts/chembl_activities_main.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c8fcfd119483248e55c698a60298bc