### PR TITLE
Ensure CLI scripts can import project modules when run directly

### DIFF
--- a/scripts/chembl_activities_main.py
+++ b/scripts/chembl_activities_main.py
@@ -2,6 +2,15 @@
 
 from __future__ import annotations
 
+# Ensure the project root is importable when the script is run directly.
+if __package__ in {None, ""}:
+    import sys as _sys
+    from pathlib import Path as _Path
+
+    _ROOT = str(_Path(__file__).resolve().parents[1])
+    if _ROOT not in _sys.path:
+        _sys.path.insert(0, _ROOT)
+
 import argparse
 import json
 import logging


### PR DESCRIPTION
## Summary
- ensure the ChEMBL activities CLI adjusts `sys.path` when executed as a standalone script so `library` modules remain importable from the project root

## Testing
- ruff check scripts/chembl_activities_main.py
- black --check scripts/chembl_activities_main.py
- pytest
- mypy . *(fails: existing missing type stubs and typing issues unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c916d4e5048324a93d67e0fd3f1698