### PR TITLE
Fix CLI import paths and add tests

### DIFF
--- a/scripts/_path_utils.py
+++ b/scripts/_path_utils.py
@@ -1,0 +1,43 @@
+"""Helpers for making CLI scripts importable without installation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def ensure_project_root(*, package_dir: str = "library") -> Path:
+    """Insert the project root and package directory into :data:`sys.path`.
+
+    Parameters
+    ----------
+    package_dir:
+        Name of the directory within the project root that contains importable
+        modules. The directory is added to :data:`sys.path` if it exists.
+
+    Returns
+    -------
+    Path
+        Absolute path to the project root directory.
+
+    Notes
+    -----
+    The function is idempotent: repeated calls do not create duplicate
+    :data:`sys.path` entries. The package directory is placed ahead of the
+    project root to allow packages such as ``chembl2uniprot`` (stored inside the
+    ``library`` folder) to be imported as top-level modules when running the
+    scripts directly.
+    """
+
+    script_path = Path(__file__).resolve()
+    project_root = script_path.parent.parent
+    root_str = str(project_root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)
+
+    package_path = project_root / package_dir
+    package_str = str(package_path)
+    if package_path.exists() and package_str not in sys.path:
+        sys.path.insert(0, package_str)
+
+    return project_root

--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -9,13 +9,13 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import sys
 from pathlib import Path
 from typing import Any, Dict, Sequence
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+if __package__ in {None, ""}:
+    from _path_utils import ensure_project_root as _ensure_project_root
+
+    _ensure_project_root()
 
 from library.io_utils import CsvConfig, write_rows  # noqa: E402
 from library.logging_utils import configure_logging  # noqa: E402

--- a/scripts/chembl2uniprot_main.py
+++ b/scripts/chembl2uniprot_main.py
@@ -21,18 +21,17 @@ To use a standalone configuration file ``my_config.yaml``::
 from __future__ import annotations
 
 import argparse
-import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
-LIB_DIR = ROOT / "library"
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-if str(LIB_DIR) not in sys.path:
-    sys.path.insert(0, str(LIB_DIR))
+if __package__ in {None, ""}:
+    from _path_utils import ensure_project_root as _ensure_project_root
+
+    _ensure_project_root()
 
 from chembl2uniprot.mapping import map_chembl_to_uniprot  # noqa: E402
 from library.logging_utils import configure_logging  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 DEFAULT_LOG_LEVEL = "INFO"
@@ -47,8 +46,8 @@ def main(argv: list[str] | None = None) -> None:
     Parameters
     ----------
     argv:
-        Optional list of command line arguments.  When ``None`` the arguments
-        are taken from :data:`sys.argv`.
+        Optional list of command line arguments. When ``None`` the arguments
+        provided via the command line are used.
     """
 
     parser = argparse.ArgumentParser(description="Map ChEMBL IDs to UniProt IDs")

--- a/scripts/chembl_activities_main.py
+++ b/scripts/chembl_activities_main.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-# Ensure the project root is importable when the script is run directly.
 if __package__ in {None, ""}:
-    import sys as _sys
-    from pathlib import Path as _Path
+    from _path_utils import ensure_project_root as _ensure_project_root
 
-    _ROOT = str(_Path(__file__).resolve().parents[1])
-    if _ROOT not in _sys.path:
-        _sys.path.insert(0, _ROOT)
+    _ensure_project_root()
 
 import argparse
 import json

--- a/scripts/chembl_assays_main.py
+++ b/scripts/chembl_assays_main.py
@@ -13,6 +13,11 @@ from typing import Sequence
 
 import pandas as pd
 
+if __package__ in {None, ""}:
+    from _path_utils import ensure_project_root as _ensure_project_root
+
+    _ensure_project_root()
+
 from library.assay_postprocessing import postprocess_assays
 from library.assay_validation import AssaysSchema, validate_assays
 from library.chembl_client import ChemblClient

--- a/scripts/data_profiling_main.py
+++ b/scripts/data_profiling_main.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from pathlib import Path
 from typing import Sequence
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+if __package__ in {None, ""}:
+    from _path_utils import ensure_project_root as _ensure_project_root
+
+    _ensure_project_root()
 
 from library.data_profiling import analyze_table_quality  # noqa: E402
 from library.logging_utils import configure_logging  # noqa: E402

--- a/scripts/dump_gtop_target.py
+++ b/scripts/dump_gtop_target.py
@@ -5,23 +5,19 @@ from __future__ import annotations
 import argparse
 import csv
 import logging
-
-import sys
-
-
 from pathlib import Path
 from typing import List, cast
 
 import pandas as pd
 import yaml
-from library.data_profiling import analyze_table_quality
-from library.logging_utils import configure_logging
 
+if __package__ in {None, ""}:
+    from _path_utils import ensure_project_root as _ensure_project_root
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+    _ensure_project_root()
 
+from library.data_profiling import analyze_table_quality  # noqa: E402
+from library.logging_utils import configure_logging  # noqa: E402
 from library.gtop_client import GtoPClient, GtoPConfig, resolve_target  # noqa: E402
 from library.http_client import CacheConfig  # noqa: E402
 from library.gtop_normalize import (  # noqa: E402

--- a/scripts/get_hgnc_by_uniprot.py
+++ b/scripts/get_hgnc_by_uniprot.py
@@ -3,18 +3,17 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
-LIB_DIR = ROOT / "library"
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-if str(LIB_DIR) not in sys.path:
-    sys.path.insert(0, str(LIB_DIR))
+if __package__ in {None, ""}:
+    from _path_utils import ensure_project_root as _ensure_project_root
+
+    _ensure_project_root()
 
 from hgnc_client import map_uniprot_to_hgnc  # noqa: E402
 from library.logging_utils import configure_logging  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
 
 DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_SEP = ","
@@ -28,8 +27,8 @@ def main(argv: list[str] | None = None) -> None:
     Parameters
     ----------
     argv:
-        Optional list of command line arguments. If not provided, `sys.argv`
-        will be used.
+        Optional list of command line arguments. When ``None`` the values
+        supplied on the command line are used.
     """
 
     parser = argparse.ArgumentParser(description="Map UniProt accessions to HGNC IDs")

--- a/scripts/get_target_data_main.py
+++ b/scripts/get_target_data_main.py
@@ -3,16 +3,13 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from pathlib import Path
 from typing import Sequence
 
-ROOT = Path(__file__).resolve().parents[1]
-LIB_DIR = ROOT / "library"
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-if str(LIB_DIR) not in sys.path:
-    sys.path.insert(0, str(LIB_DIR))
+if __package__ in {None, ""}:
+    from _path_utils import ensure_project_root as _ensure_project_root
+
+    _ensure_project_root()
 
 from chembl_targets import TargetConfig, fetch_targets  # noqa: E402
 from data_profiling import analyze_table_quality  # noqa: E402
@@ -29,8 +26,8 @@ def main(argv: Sequence[str] | None = None) -> None:
     Parameters
     ----------
     argv:
-        Optional list of command line arguments. If not provided, `sys.argv`
-        will be used.
+        Optional list of command line arguments. When ``None`` the CLI values
+        provided by the user are used.
     """
     parser = argparse.ArgumentParser(description="Download ChEMBL target data")
     parser.add_argument("--input", required=True, help="Input CSV file")

--- a/scripts/get_uniprot_target_data.py
+++ b/scripts/get_uniprot_target_data.py
@@ -10,13 +10,17 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import sys
 from datetime import datetime
 from pathlib import Path
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 import yaml
+
+if __package__ in {None, ""}:
+    from _path_utils import ensure_project_root as _ensure_project_root
+
+    _ensure_project_root()
 
 if TYPE_CHECKING:  # pragma: no cover - imported for typing only
     from library.orthologs import EnsemblHomologyClient, OmaClient
@@ -73,12 +77,9 @@ def main(argv: Sequence[str] | None = None) -> None:
     """Run the UniProt target data retrieval workflow.
 
     Args:
-        argv: Optional sequence of command-line arguments.  When ``None``,
-            :data:`sys.argv` is used implicitly.
+        argv: Optional sequence of command-line arguments. When ``None``,
+            the arguments provided via the command line are used implicitly.
     """
-
-    if str(ROOT) not in sys.path:
-        sys.path.insert(0, str(ROOT))
 
     from library.http_client import CacheConfig
     from library.io_utils import CsvConfig, read_ids, write_rows

--- a/scripts/iuphar_main.py
+++ b/scripts/iuphar_main.py
@@ -6,6 +6,11 @@ import argparse
 import datetime as dt
 from pathlib import Path
 
+if __package__ in {None, ""}:
+    from _path_utils import ensure_project_root as _ensure_project_root
+
+    _ensure_project_root()
+
 from library.iuphar import IUPHARData
 from library.logging_utils import configure_logging
 

--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -1,13 +1,9 @@
-# ruff: noqa: E402
-
 """CLI entry point for the unified target data pipeline."""
 
 from __future__ import annotations
 
 import argparse
 import logging
-
-import sys
 from pathlib import Path
 
 from typing import Any, Callable, Dict, Iterable, List, Sequence
@@ -16,10 +12,10 @@ import pandas as pd
 import yaml  # type: ignore[import]
 from tqdm.auto import tqdm
 
+if __package__ in {None, ""}:
+    from _path_utils import ensure_project_root as _ensure_project_root
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+    _ensure_project_root()
 
 
 from library.chembl_targets import TargetConfig, fetch_targets

--- a/scripts/protein_classify_main.py
+++ b/scripts/protein_classify_main.py
@@ -11,13 +11,13 @@ import argparse
 import json
 from datetime import datetime
 from pathlib import Path
-import sys
 
 import pandas as pd
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+if __package__ in {None, ""}:
+    from _path_utils import ensure_project_root as _ensure_project_root
+
+    _ensure_project_root()
 
 from library.protein_classifier import classify_protein
 from library.logging_utils import configure_logging

--- a/scripts/uniprot_enrich_main.py
+++ b/scripts/uniprot_enrich_main.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E402
 """Command line interface for :mod:`uniprot_enrich`.
 
 This script enriches a CSV file containing UniProt accessions with additional
@@ -24,16 +23,12 @@ separator::
 from __future__ import annotations
 
 import argparse
-
-
-import sys
-from pathlib import Path
 import shutil
 
+if __package__ in {None, ""}:
+    from _path_utils import ensure_project_root as _ensure_project_root
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+    _ensure_project_root()
 
 
 from library.uniprot_enrich import enrich_uniprot
@@ -52,7 +47,7 @@ def main(argv: list[str] | None = None) -> None:
     ----------
     argv:
         Optional list of command line arguments. When ``None`` the arguments
-        are taken from :data:`sys.argv`.
+        provided on the command line are used.
     """
 
     parser = argparse.ArgumentParser(description="Enrich UniProt data in a CSV file")

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -1,0 +1,42 @@
+"""Tests for the CLI path helper utilities."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import _path_utils  # noqa: E402
+
+
+def test_ensure_project_root_inserts_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``ensure_project_root`` should add the root and library directories."""
+
+    monkeypatch.setattr(sys, "path", ["/tmp"])
+    project_root = _path_utils.ensure_project_root()
+    library_path = project_root / "library"
+
+    assert sys.path[0] == str(library_path)
+    assert sys.path[1] == str(project_root)
+    assert library_path.exists()
+
+
+def test_ensure_project_root_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Running the helper twice must not duplicate ``sys.path`` entries."""
+
+    monkeypatch.setattr(sys, "path", ["/tmp"])
+    first_root = _path_utils.ensure_project_root()
+    second_root = _path_utils.ensure_project_root()
+
+    assert first_root == second_root
+    occurrences_root = [entry for entry in sys.path if entry == str(first_root)]
+    occurrences_library = [
+        entry for entry in sys.path if entry == str(first_root / "library")
+    ]
+    assert len(occurrences_root) == 1
+    assert len(occurrences_library) == 1


### PR DESCRIPTION
## Summary
- add a reusable helper that inserts the repository root and library folder onto `sys.path` for direct CLI execution
- update every CLI script to call the helper and clean up stale imports and docstrings
- add regression tests covering the new path helper

## Testing
- python scripts/chembl_assays_main.py -h
- ruff check scripts/_path_utils.py scripts/check_determinism.py scripts/chembl2uniprot_main.py scripts/chembl_activities_main.py scripts/chembl_assays_main.py scripts/data_profiling_main.py scripts/dump_gtop_target.py scripts/get_hgnc_by_uniprot.py scripts/get_target_data_main.py scripts/get_uniprot_target_data.py scripts/iuphar_main.py scripts/pipeline_targets_main.py scripts/protein_classify_main.py scripts/uniprot_enrich_main.py tests/test_path_utils.py
- mypy --config-file mypy.ini --follow-imports=skip scripts/_path_utils.py scripts/check_determinism.py scripts/chembl2uniprot_main.py scripts/chembl_activities_main.py scripts/chembl_assays_main.py scripts/data_profiling_main.py scripts/dump_gtop_target.py scripts/get_hgnc_by_uniprot.py scripts/get_target_data_main.py scripts/get_uniprot_target_data.py scripts/iuphar_main.py scripts/pipeline_targets_main.py scripts/protein_classify_main.py scripts/uniprot_enrich_main.py tests/test_path_utils.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9191d6a3c83248f8e576095dd4cf3