### PR TITLE
Respect Retry-After headers in Semantic Scholar client

### DIFF
--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import requests
+import pytest
+import requests  # type: ignore[import-untyped]
 
 from library.http_client import CacheConfig, HttpClient, create_http_session
 
@@ -47,3 +48,65 @@ def test_create_http_session_falls_back_when_cache_dependency_missing(
 
     assert isinstance(session, requests.Session)
     assert "requests-cache" in caplog.text
+
+
+def test_http_client_honours_retry_after(monkeypatch, requests_mock) -> None:
+    """The client sleeps according to ``Retry-After`` headers before retrying."""
+
+    sleeps: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr("tenacity.nap.time.sleep", fake_sleep)
+    url = "https://example.org/throttled"
+    requests_mock.post(
+        url,
+        [
+            {
+                "status_code": 429,
+                "headers": {"Retry-After": "3"},
+                "json": {"detail": "rate limit"},
+            },
+            {"status_code": 200, "json": {"status": "ok"}},
+        ],
+    )
+    client = HttpClient(timeout=1, max_retries=2, rps=0)
+
+    response = client.request("post", url)
+
+    assert response.json() == {"status": "ok"}
+    assert sleeps
+    assert pytest.approx(3.0, rel=1e-3) == sleeps[0]
+
+
+def test_http_client_falls_back_when_retry_after_invalid(
+    monkeypatch, requests_mock
+) -> None:
+    """Invalid ``Retry-After`` values defer to exponential backoff."""
+
+    sleeps: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr("tenacity.nap.time.sleep", fake_sleep)
+    url = "https://example.org/throttled-invalid"
+    requests_mock.get(
+        url,
+        [
+            {
+                "status_code": 429,
+                "headers": {"Retry-After": "not-a-date"},
+                "json": {"detail": "rate limit"},
+            },
+            {"status_code": 200, "json": {"status": "ok"}},
+        ],
+    )
+    client = HttpClient(timeout=1, max_retries=2, rps=0, backoff_multiplier=0.5)
+
+    response = client.request("get", url)
+
+    assert response.json() == {"status": "ok"}
+    assert sleeps
+    assert pytest.approx(0.5, rel=1e-3) == sleeps[0]


### PR DESCRIPTION
## Summary
- parse `Retry-After` headers and feed them into a dedicated Tenacity wait strategy so the HTTP client honours API back-off instructions
- enrich throttling logs with the server-provided delay while preserving existing retry semantics
- add regression coverage verifying the custom wait logic and fallback behaviour when the header is missing or invalid

## Testing
- ruff check library/http_client.py tests/test_http_client.py
- black library/http_client.py tests/test_http_client.py
- mypy library/http_client.py tests/test_http_client.py
- PYTHONPATH=. pytest tests/test_http_client.py

------
https://chatgpt.com/codex/tasks/task_e_68c924c3e5588324bffd601dd8150deb