### PR TITLE
Add progress bar to PubMed metadata merge

### DIFF
--- a/scripts/pubmed_main.py
+++ b/scripts/pubmed_main.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Mapping, MutableMapping, Sequence
 
 import pandas as pd
 import yaml
+from tqdm.auto import tqdm
 
 # Ensure imports resolve when the script is executed directly.
 if __package__ in {None, ""}:
@@ -235,13 +236,24 @@ def run_pubmed_command(args: argparse.Namespace, config: Dict[str, Any]) -> None
         openalex_records,
         crossref_records,
     ) = _gather_pubmed_sources(ids, cfg=config)
-    rows = merge_metadata(
-        pubmed_records,
-        scholar_records,
-        openalex_records,
-        crossref_records,
-        max_workers=workers,
-    )
+    if pubmed_records:
+        with tqdm(total=len(pubmed_records), desc="merge metadata") as pbar:
+            rows = merge_metadata(
+                pubmed_records,
+                scholar_records,
+                openalex_records,
+                crossref_records,
+                max_workers=workers,
+                progress_callback=pbar.update,
+            )
+    else:
+        rows = merge_metadata(
+            pubmed_records,
+            scholar_records,
+            openalex_records,
+            crossref_records,
+            max_workers=workers,
+        )
     df = build_dataframe(rows)
     schema = DocumentsSchema(DOCUMENT_SCHEMA_COLUMNS)
     errors = schema.validate(df)
@@ -350,13 +362,24 @@ def run_all_command(args: argparse.Namespace, config: Dict[str, Any]) -> None:
         openalex_records,
         crossref_records,
     ) = _gather_pubmed_sources(pmids, cfg=config)
-    rows = merge_metadata(
-        pubmed_records,
-        scholar_records,
-        openalex_records,
-        crossref_records,
-        max_workers=workers,
-    )
+    if pubmed_records:
+        with tqdm(total=len(pubmed_records), desc="merge metadata") as pbar:
+            rows = merge_metadata(
+                pubmed_records,
+                scholar_records,
+                openalex_records,
+                crossref_records,
+                max_workers=workers,
+                progress_callback=pbar.update,
+            )
+    else:
+        rows = merge_metadata(
+            pubmed_records,
+            scholar_records,
+            openalex_records,
+            crossref_records,
+            max_workers=workers,
+        )
     df_metadata = build_dataframe(rows)
     df_metadata = dataframe_to_strings(df_metadata)
     df_metadata = df_metadata.sort_values(


### PR DESCRIPTION
## Summary
- add a tqdm progress bar when merging PubMed metadata in the dedicated and combined commands
- extend `merge_metadata` with an optional progress callback used by the CLI progress bar

## Testing
- black scripts/pubmed_main.py library/document_pipeline.py
- ruff check scripts/pubmed_main.py library/document_pipeline.py
- mypy --config-file mypy.ini scripts/pubmed_main.py library/document_pipeline.py *(fails: missing third-party type stubs and existing ChemblClient signature expectations)*
- pytest *(fails: missing optional dependency `hypothesis`)*

------
https://chatgpt.com/codex/tasks/task_e_68c92636878c8324bea658323d4624a8