### PR TITLE
Format clients and tests with Ruff

### DIFF
--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -68,9 +68,7 @@ class ChemblClient:
             LOGGER.exception("Не удалось получить %s %s", resource, identifier)
             raise
         except requests.RequestException:
-            LOGGER.exception(
-                "Сетевая ошибка при получении %s %s", resource, identifier
-            )
+            LOGGER.exception("Сетевая ошибка при получении %s %s", resource, identifier)
             raise
 
         payload: Dict[str, Any] = response.json()
@@ -90,7 +88,9 @@ class ChemblClient:
         )
 
     def _fetch_many(
-        self, identifiers: Iterable[str], fetcher: Callable[[str], Dict[str, Any] | None]
+        self,
+        identifiers: Iterable[str],
+        fetcher: Callable[[str], Dict[str, Any] | None],
     ) -> List[Dict[str, Any]]:
         records: List[Dict[str, Any]] = []
         for identifier in identifiers:

--- a/library/crossref_client.py
+++ b/library/crossref_client.py
@@ -108,7 +108,9 @@ def fetch_crossref_records(
         message = payload.get("message") if isinstance(payload, dict) else None
         if not isinstance(message, dict):
             msg = "Unexpected response payload"
-            LOGGER.warning("Crossref responded with %s for DOI %s", type(payload).__name__, doi)
+            LOGGER.warning(
+                "Crossref responded with %s for DOI %s", type(payload).__name__, doi
+            )
             records[doi] = CrossrefRecord.from_error(doi, msg)
             continue
 
@@ -116,7 +118,9 @@ def fetch_crossref_records(
         title = titles[0].strip() if titles and isinstance(titles[0], str) else None
         subtitles = message.get("subtitle") or []
         subtitle = (
-            subtitles[0].strip() if subtitles and isinstance(subtitles[0], str) else None
+            subtitles[0].strip()
+            if subtitles and isinstance(subtitles[0], str)
+            else None
         )
         subject = _normalise_subject(message.get("subject"))
 

--- a/library/openalex_client.py
+++ b/library/openalex_client.py
@@ -136,7 +136,9 @@ def fetch_openalex_records(
 
         if not isinstance(item, dict):
             msg = "Unexpected response payload"
-            LOGGER.warning("OpenAlex responded with %s for PMID %s", type(item).__name__, pmid)
+            LOGGER.warning(
+                "OpenAlex responded with %s for PMID %s", type(item).__name__, pmid
+            )
             records[pmid] = OpenAlexRecord.from_error(pmid, msg)
             continue
 
@@ -181,7 +183,9 @@ def fetch_openalex_records(
         key = pmid.strip()
         if not key:
             continue
-        ordered.append(records.get(key, OpenAlexRecord.from_error(key, "PMID not requested")))
+        ordered.append(
+            records.get(key, OpenAlexRecord.from_error(key, "PMID not requested"))
+        )
     return ordered
 
 

--- a/library/pubmed_client.py
+++ b/library/pubmed_client.py
@@ -167,8 +167,12 @@ def _parse_article(article: ET.Element) -> PubMedRecord:
         journal_abbrev = journal_abbrev.strip()
 
     journal_issue = article.find("MedlineCitation/Article/Journal/JournalIssue")
-    volume = _safe_text(journal_issue.find("Volume") if journal_issue is not None else None)
-    issue = _safe_text(journal_issue.find("Issue") if journal_issue is not None else None)
+    volume = _safe_text(
+        journal_issue.find("Volume") if journal_issue is not None else None
+    )
+    issue = _safe_text(
+        journal_issue.find("Issue") if journal_issue is not None else None
+    )
     start_page = article.findtext("MedlineCitation/Article/Pagination/StartPage")
     end_page = article.findtext("MedlineCitation/Article/Pagination/EndPage")
     start_page = start_page.strip() if isinstance(start_page, str) else None
@@ -283,7 +287,9 @@ def fetch_pubmed_records(
         LOGGER.debug("Requesting %d PubMed IDs", len(chunk))
         try:
             resp = client.request("get", API_URL, params=params)
-        except requests.HTTPError as exc:  # pragma: no cover - exercised via status handling
+        except (
+            requests.HTTPError
+        ) as exc:  # pragma: no cover - exercised via status handling
             status = exc.response.status_code if exc.response is not None else "N/A"
             msg = f"HTTP error {status}"
             LOGGER.warning("PubMed batch failed: %s", msg)

--- a/library/semantic_scholar_client.py
+++ b/library/semantic_scholar_client.py
@@ -93,7 +93,9 @@ def _parse_item(raw: Any, fallback_pmid: str) -> SemanticScholarRecord:
         publication_types=publication_types,
         venue=venue,
         paper_id=paper_id,
-        external_ids={key: value for key, value in external_ids.items() if value is not None},
+        external_ids={
+            key: value for key, value in external_ids.items() if value is not None
+        },
         error=None,
     )
 
@@ -127,7 +129,10 @@ def fetch_semantic_scholar_records(
 
     records: Dict[str, SemanticScholarRecord] = {}
     for chunk in _chunked(cleaned, chunk_size):
-        payload = {"ids": [f"PMID:{p}" for p in chunk], "fields": ",".join(DEFAULT_FIELDS)}
+        payload = {
+            "ids": [f"PMID:{p}" for p in chunk],
+            "fields": ",".join(DEFAULT_FIELDS),
+        }
         LOGGER.debug("Requesting %d Semantic Scholar IDs", len(chunk))
         try:
             resp = client.request("post", API_URL, json=payload)
@@ -174,14 +179,20 @@ def fetch_semantic_scholar_records(
 
         # Ensure that identifiers missing in the response are represented.
         for pmid in chunk:
-            records.setdefault(pmid, SemanticScholarRecord.from_error(pmid, "PMID missing"))
+            records.setdefault(
+                pmid, SemanticScholarRecord.from_error(pmid, "PMID missing")
+            )
 
     ordered: List[SemanticScholarRecord] = []
     for pmid in pmids:
         key = pmid.strip()
         if not key:
             continue
-        ordered.append(records.get(key, SemanticScholarRecord.from_error(key, "PMID not requested")))
+        ordered.append(
+            records.get(
+                key, SemanticScholarRecord.from_error(key, "PMID not requested")
+            )
+        )
     return ordered
 
 

--- a/tests/test_pubmed_main.py
+++ b/tests/test_pubmed_main.py
@@ -165,7 +165,9 @@ def test_run_all_merges_chembl(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         error=None,
     )
 
-    def fake_get_documents(ids: Sequence[str], *, cfg: Any, client: Any, chunk_size: int, timeout: float) -> pd.DataFrame:  # type: ignore[override]
+    def fake_get_documents(
+        ids: Sequence[str], *, cfg: Any, client: Any, chunk_size: int, timeout: float
+    ) -> pd.DataFrame:  # type: ignore[override]
         return chembl_df
 
     def fake_gather(


### PR DESCRIPTION
## Summary
- run `ruff format` on the client modules and PubMed CLI test to align with the configured style

## Testing
- pytest tests/test_pubmed_main.py

------
https://chatgpt.com/codex/tasks/task_e_68c92a39dd3c8324833177a580c9e774