### PR TITLE
Add molecule extraction pipeline

### DIFF
--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -15,7 +15,6 @@ except ImportError:  # pragma: no cover
     from http_client import CacheConfig, HttpClient  # type: ignore[no-redef]
 
 import logging
-from dataclasses import dataclass
 
 LOGGER = logging.getLogger(__name__)
 
@@ -58,19 +57,18 @@ class ChemblClient:
         }
         try:
             response = self._http.request("get", url, headers=headers)
-            if response.status_code == 404:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            status_code = exc.response.status_code if exc.response is not None else None
+            if status_code == 404:
                 LOGGER.warning(
                     "%s %s не найден (404)", resource.capitalize(), identifier
                 )
                 return None
-            response.raise_for_status()
-        except requests.HTTPError:
             LOGGER.exception("Не удалось получить %s %s", resource, identifier)
             raise
         except requests.RequestException:
-            LOGGER.exception(
-                "Сетевая ошибка при получении %s %s", resource, identifier
-            )
+            LOGGER.exception("Сетевая ошибка при получении %s %s", resource, identifier)
             raise
 
         payload: Dict[str, Any] = response.json()
@@ -89,8 +87,17 @@ class ChemblClient:
             "activity", activity_id, id_field="activity_chembl_id"
         )
 
+    def fetch_molecule(self, molecule_id: str) -> Dict[str, Any] | None:
+        """Вернуть JSON для ``molecule_id``."""
+
+        return self._fetch_resource(
+            "molecule", molecule_id, id_field="molecule_chembl_id"
+        )
+
     def _fetch_many(
-        self, identifiers: Iterable[str], fetcher: Callable[[str], Dict[str, Any] | None]
+        self,
+        identifiers: Iterable[str],
+        fetcher: Callable[[str], Dict[str, Any] | None],
     ) -> List[Dict[str, Any]]:
         records: List[Dict[str, Any]] = []
         for identifier in identifiers:
@@ -110,6 +117,11 @@ class ChemblClient:
         """Получить несколько payloads для активностей."""
 
         return self._fetch_many(activity_ids, self.fetch_activity)
+
+    def fetch_many_molecules(self, molecule_ids: Iterable[str]) -> List[Dict[str, Any]]:
+        """Получить несколько payloads для молекул."""
+
+        return self._fetch_many(molecule_ids, self.fetch_molecule)
 
     def request_json(self, url: str, *, cfg: ApiCfg, timeout: float) -> Dict[str, Any]:
         """Вернуть JSON payload для ``url`` используя http."""

--- a/library/chembl_library.py
+++ b/library/chembl_library.py
@@ -108,3 +108,32 @@ def get_activities(
         log_label="activities",
         dedupe_column="activity_chembl_id",
     )
+
+
+def get_testitems(
+    client: ChemblClient,
+    molecule_ids: Iterable[str],
+    *,
+    chunk_size: int = 20,
+) -> pd.DataFrame:
+    """Fetch molecule metadata for ``molecule_ids``.
+
+    Parameters
+    ----------
+    client:
+        Instance of :class:`ChemblClient` responsible for network requests.
+    molecule_ids:
+        Iterable of molecule identifiers to fetch from the ChEMBL API.
+    chunk_size:
+        Number of identifiers to process in a single batch.  Adjusting the
+        chunk size can improve determinism when operating under flaky network
+        conditions.
+    """
+
+    return _fetch_dataframe(
+        fetch=client.fetch_many_molecules,
+        identifiers=molecule_ids,
+        chunk_size=chunk_size,
+        log_label="molecules",
+        dedupe_column="molecule_chembl_id",
+    )

--- a/library/crossref_client.py
+++ b/library/crossref_client.py
@@ -108,7 +108,9 @@ def fetch_crossref_records(
         message = payload.get("message") if isinstance(payload, dict) else None
         if not isinstance(message, dict):
             msg = "Unexpected response payload"
-            LOGGER.warning("Crossref responded with %s for DOI %s", type(payload).__name__, doi)
+            LOGGER.warning(
+                "Crossref responded with %s for DOI %s", type(payload).__name__, doi
+            )
             records[doi] = CrossrefRecord.from_error(doi, msg)
             continue
 
@@ -116,7 +118,9 @@ def fetch_crossref_records(
         title = titles[0].strip() if titles and isinstance(titles[0], str) else None
         subtitles = message.get("subtitle") or []
         subtitle = (
-            subtitles[0].strip() if subtitles and isinstance(subtitles[0], str) else None
+            subtitles[0].strip()
+            if subtitles and isinstance(subtitles[0], str)
+            else None
         )
         subject = _normalise_subject(message.get("subject"))
 

--- a/library/normalize_testitems.py
+++ b/library/normalize_testitems.py
@@ -1,0 +1,246 @@
+"""Normalisation helpers for ChEMBL molecule records.
+
+The :func:`normalize_testitems` function flattens nested JSON structures
+returned by the ChEMBL API into a tabular representation suitable for CSV
+serialisation and validation.
+
+Algorithm Notes
+---------------
+1. Coerce identifiers and categorical fields to upper-case, trimmed strings.
+2. Extract nested dictionaries such as ``molecule_structures`` and
+   ``molecule_properties`` into flat columns.
+3. Normalise list-like attributes (synonyms, ATC codes, cross references)
+   into deterministic, sorted representations.
+4. Preserve numeric metadata as Python ``int``/``float`` types whenever
+   possible, leaving textual descriptors untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable, Mapping
+
+import pandas as pd
+
+LOGGER = logging.getLogger(__name__)
+
+_BOOL_TRUE = {"true", "t", "1", "yes", "y"}
+_BOOL_FALSE = {"false", "f", "0", "no", "n"}
+
+
+def _clean_identifier(value: Any) -> str | None:
+    if value is None:
+        return None
+    candidate = str(value).strip()
+    if not candidate:
+        return None
+    return candidate.upper()
+
+
+def _clean_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return str(value)
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int,)):
+        return int(value)
+    if isinstance(value, float):
+        if pd.isna(value):
+            return None
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return int(float(stripped))
+        except ValueError:
+            return None
+    return None
+
+
+def _coerce_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int,)):
+        return bool(value)
+    if isinstance(value, float):
+        if pd.isna(value):
+            return None
+        return bool(value)
+    if isinstance(value, str):
+        stripped = value.strip().lower()
+        if not stripped:
+            return None
+        if stripped in _BOOL_TRUE:
+            return True
+        if stripped in _BOOL_FALSE:
+            return False
+    return None
+
+
+def _normalise_sequence(values: Iterable[Any]) -> list[str]:
+    items: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = _clean_string(value)
+        if text is None:
+            continue
+        if text in seen:
+            continue
+        seen.add(text)
+        items.append(text)
+    items.sort()
+    return items
+
+
+def _normalise_cross_references(
+    entries: Iterable[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    normalised: list[dict[str, Any]] = []
+    for entry in entries:
+        xref_id = _clean_string(entry.get("xref_id"))
+        xref_src = _clean_string(entry.get("xref_src"))
+        xref_name = _clean_string(entry.get("xref_name"))
+        if not any([xref_id, xref_src, xref_name]):
+            continue
+        normalised.append(
+            {"xref_id": xref_id, "xref_src": xref_src, "xref_name": xref_name}
+        )
+    normalised.sort(
+        key=lambda row: ((row.get("xref_src") or ""), (row.get("xref_id") or ""))
+    )
+    return normalised
+
+
+def _normalise_synonyms(entries: Iterable[Mapping[str, Any]]) -> list[str]:
+    synonyms = []
+    for entry in entries:
+        synonym = _clean_string(entry.get("synonyms"))
+        if synonym is None:
+            continue
+        synonyms.append(synonym)
+    return _normalise_sequence(synonyms)
+
+
+def _coerce_property_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and pd.isna(value):
+            return None
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            if any(char in stripped for char in [".", "e", "E"]):
+                return float(stripped)
+            return int(stripped)
+        except ValueError:
+            return stripped
+    return value
+
+
+def normalize_testitems(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a normalised copy of ``df`` with flattened molecule metadata."""
+
+    if df.empty:
+        return df
+
+    records: list[dict[str, Any]] = []
+    for raw in df.to_dict("records"):
+        identifier = _clean_identifier(raw.get("molecule_chembl_id"))
+        if identifier is None:
+            LOGGER.warning("Skipping record without molecule_chembl_id: %s", raw)
+            continue
+
+        record: dict[str, Any] = {"molecule_chembl_id": identifier}
+        record["pref_name"] = _clean_string(raw.get("pref_name"))
+        record["molecule_type"] = _clean_string(raw.get("molecule_type"))
+        record["structure_type"] = _clean_string(raw.get("structure_type"))
+        record["chirality"] = _coerce_int(raw.get("chirality"))
+        record["availability_type"] = _coerce_int(raw.get("availability_type"))
+        record["max_phase"] = _coerce_int(raw.get("max_phase"))
+        record["first_approval"] = _coerce_int(raw.get("first_approval"))
+        record["usan_year"] = _coerce_int(raw.get("usan_year"))
+        record["black_box_warning"] = _coerce_bool(raw.get("black_box_warning"))
+        record["prodrug"] = _coerce_bool(raw.get("prodrug"))
+        record["oral"] = _coerce_bool(raw.get("oral"))
+        record["parenteral"] = _coerce_bool(raw.get("parenteral"))
+        record["topical"] = _coerce_bool(raw.get("topical"))
+        record["natural_product"] = _coerce_bool(raw.get("natural_product"))
+        record["polymer_flag"] = _coerce_bool(raw.get("polymer_flag"))
+        record["first_in_class"] = _coerce_bool(raw.get("first_in_class"))
+        record["dosed_ingredient"] = _coerce_bool(raw.get("dosed_ingredient"))
+        record["therapeutic_flag"] = _coerce_bool(raw.get("therapeutic_flag"))
+
+        structures = raw.get("molecule_structures") or {}
+        if isinstance(structures, Mapping):
+            record["canonical_smiles"] = _clean_string(
+                structures.get("canonical_smiles")
+            )
+            record["standard_inchi"] = _clean_string(structures.get("standard_inchi"))
+            record["standard_inchi_key"] = _clean_string(
+                structures.get("standard_inchi_key")
+            )
+
+        hierarchy = raw.get("molecule_hierarchy") or {}
+        if isinstance(hierarchy, Mapping):
+            parent_id = _clean_identifier(hierarchy.get("parent_chembl_id"))
+            salt_id = _clean_identifier(hierarchy.get("molecule_chembl_id"))
+            if parent_id and parent_id != identifier:
+                record["parent_chembl_id"] = parent_id
+            if salt_id and parent_id and salt_id != parent_id:
+                record["salt_chembl_id"] = salt_id
+            active_id = _clean_identifier(hierarchy.get("active_chembl_id"))
+            if active_id and active_id not in {identifier, parent_id, salt_id}:
+                record["active_chembl_id"] = active_id
+
+        atc_codes = raw.get("atc_classifications")
+        if isinstance(atc_codes, Iterable) and not isinstance(atc_codes, (str, bytes)):
+            record["atc_classifications"] = _normalise_sequence(atc_codes)
+
+        synonyms = raw.get("molecule_synonyms")
+        if isinstance(synonyms, Iterable):
+            synonym_entries = [
+                entry for entry in synonyms if isinstance(entry, Mapping)
+            ]
+            if synonym_entries:
+                record["synonyms"] = _normalise_synonyms(synonym_entries)
+
+        cross_refs = raw.get("cross_references")
+        if isinstance(cross_refs, Iterable):
+            ref_entries = [entry for entry in cross_refs if isinstance(entry, Mapping)]
+            if ref_entries:
+                record["cross_references"] = _normalise_cross_references(ref_entries)
+
+        properties = raw.get("molecule_properties")
+        if isinstance(properties, Mapping):
+            for key, value in properties.items():
+                clean_key = f"chembl_{key}"
+                record[clean_key] = _coerce_property_value(value)
+
+        records.append(record)
+
+    normalised = pd.DataFrame.from_records(records)
+    for column in ["canonical_smiles", "standard_inchi", "standard_inchi_key"]:
+        if column not in normalised.columns:
+            normalised[column] = pd.NA
+
+    return normalised
+
+
+__all__ = ["normalize_testitems"]

--- a/library/openalex_client.py
+++ b/library/openalex_client.py
@@ -136,7 +136,9 @@ def fetch_openalex_records(
 
         if not isinstance(item, dict):
             msg = "Unexpected response payload"
-            LOGGER.warning("OpenAlex responded with %s for PMID %s", type(item).__name__, pmid)
+            LOGGER.warning(
+                "OpenAlex responded with %s for PMID %s", type(item).__name__, pmid
+            )
             records[pmid] = OpenAlexRecord.from_error(pmid, msg)
             continue
 
@@ -181,7 +183,9 @@ def fetch_openalex_records(
         key = pmid.strip()
         if not key:
             continue
-        ordered.append(records.get(key, OpenAlexRecord.from_error(key, "PMID not requested")))
+        ordered.append(
+            records.get(key, OpenAlexRecord.from_error(key, "PMID not requested"))
+        )
     return ordered
 
 

--- a/library/pubmed_client.py
+++ b/library/pubmed_client.py
@@ -167,8 +167,12 @@ def _parse_article(article: ET.Element) -> PubMedRecord:
         journal_abbrev = journal_abbrev.strip()
 
     journal_issue = article.find("MedlineCitation/Article/Journal/JournalIssue")
-    volume = _safe_text(journal_issue.find("Volume") if journal_issue is not None else None)
-    issue = _safe_text(journal_issue.find("Issue") if journal_issue is not None else None)
+    volume = _safe_text(
+        journal_issue.find("Volume") if journal_issue is not None else None
+    )
+    issue = _safe_text(
+        journal_issue.find("Issue") if journal_issue is not None else None
+    )
     start_page = article.findtext("MedlineCitation/Article/Pagination/StartPage")
     end_page = article.findtext("MedlineCitation/Article/Pagination/EndPage")
     start_page = start_page.strip() if isinstance(start_page, str) else None
@@ -283,7 +287,9 @@ def fetch_pubmed_records(
         LOGGER.debug("Requesting %d PubMed IDs", len(chunk))
         try:
             resp = client.request("get", API_URL, params=params)
-        except requests.HTTPError as exc:  # pragma: no cover - exercised via status handling
+        except (
+            requests.HTTPError
+        ) as exc:  # pragma: no cover - exercised via status handling
             status = exc.response.status_code if exc.response is not None else "N/A"
             msg = f"HTTP error {status}"
             LOGGER.warning("PubMed batch failed: %s", msg)

--- a/library/semantic_scholar_client.py
+++ b/library/semantic_scholar_client.py
@@ -42,9 +42,11 @@ class SemanticScholarRecord:
             "scholar.PublicationTypes": "|".join(self.publication_types),
             "scholar.Venue": self.venue,
             "scholar.SemanticScholarId": self.paper_id,
-            "scholar.ExternalIds": json.dumps(self.external_ids, separators=(",", ":"))
-            if self.external_ids
-            else None,
+            "scholar.ExternalIds": (
+                json.dumps(self.external_ids, separators=(",", ":"))
+                if self.external_ids
+                else None
+            ),
             "scholar.Error": self.error,
         }
 
@@ -93,7 +95,9 @@ def _parse_item(raw: Any, fallback_pmid: str) -> SemanticScholarRecord:
         publication_types=publication_types,
         venue=venue,
         paper_id=paper_id,
-        external_ids={key: value for key, value in external_ids.items() if value is not None},
+        external_ids={
+            key: value for key, value in external_ids.items() if value is not None
+        },
         error=None,
     )
 
@@ -127,7 +131,10 @@ def fetch_semantic_scholar_records(
 
     records: Dict[str, SemanticScholarRecord] = {}
     for chunk in _chunked(cleaned, chunk_size):
-        payload = {"ids": [f"PMID:{p}" for p in chunk], "fields": ",".join(DEFAULT_FIELDS)}
+        payload = {
+            "ids": [f"PMID:{p}" for p in chunk],
+            "fields": ",".join(DEFAULT_FIELDS),
+        }
         LOGGER.debug("Requesting %d Semantic Scholar IDs", len(chunk))
         try:
             resp = client.request("post", API_URL, json=payload)
@@ -174,14 +181,20 @@ def fetch_semantic_scholar_records(
 
         # Ensure that identifiers missing in the response are represented.
         for pmid in chunk:
-            records.setdefault(pmid, SemanticScholarRecord.from_error(pmid, "PMID missing"))
+            records.setdefault(
+                pmid, SemanticScholarRecord.from_error(pmid, "PMID missing")
+            )
 
     ordered: List[SemanticScholarRecord] = []
     for pmid in pmids:
         key = pmid.strip()
         if not key:
             continue
-        ordered.append(records.get(key, SemanticScholarRecord.from_error(key, "PMID not requested")))
+        ordered.append(
+            records.get(
+                key, SemanticScholarRecord.from_error(key, "PMID not requested")
+            )
+        )
     return ordered
 
 

--- a/library/testitem_library.py
+++ b/library/testitem_library.py
@@ -1,0 +1,236 @@
+"""Utilities for enriching ChEMBL molecules with external annotations.
+
+The :func:`add_pubchem_data` helper augments a molecule table with
+properties sourced from the PubChem PUG REST API.  The function only
+performs one HTTP request per unique SMILES string and caches responses to
+minimise network traffic.
+
+Algorithm Notes
+---------------
+1. Extract all unique, non-empty SMILES strings from the input DataFrame.
+2. For each SMILES string query PubChem for the requested property fields.
+3. Map the returned payload to deterministic ``pubchem_*`` columns.
+4. Populate the original DataFrame with the enriched values, leaving
+   missing entries untouched when the API does not return a match.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import re
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Sequence
+from urllib.parse import quote
+
+import pandas as pd
+import requests  # type: ignore[import-untyped]
+
+LOGGER = logging.getLogger(__name__)
+
+PUBCHEM_BASE_URL = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+PUBCHEM_PROPERTIES: tuple[str, ...] = (
+    "CID",
+    "MolecularFormula",
+    "MolecularWeight",
+    "TPSA",
+    "XLogP",
+    "HBondDonorCount",
+    "HBondAcceptorCount",
+    "RotatableBondCount",
+)
+PUBCHEM_INT_FIELDS: frozenset[str] = frozenset(
+    ["CID", "HBondDonorCount", "HBondAcceptorCount", "RotatableBondCount"]
+)
+PUBCHEM_FLOAT_FIELDS: frozenset[str] = frozenset(["MolecularWeight", "TPSA", "XLogP"])
+
+
+def _to_snake_case(value: str) -> str:
+    step1 = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", value)
+    step2 = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", step1)
+    return step2.replace("-", "_").lower()
+
+
+def _normalise_numeric(property_name: str, value: Any) -> Any:
+    if value is None:
+        return None
+    if property_name in PUBCHEM_INT_FIELDS:
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            try:
+                return int(float(stripped))
+            except ValueError:
+                return None
+        if isinstance(value, (int, float)):
+            return int(value)
+        return None
+    if property_name in PUBCHEM_FLOAT_FIELDS:
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            try:
+                return float(stripped)
+            except ValueError:
+                return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return value
+
+
+def _prepare_columns(properties: Sequence[str]) -> Dict[str, str]:
+    return {prop: f"pubchem_{_to_snake_case(prop)}" for prop in properties}
+
+
+@dataclass(slots=True)
+class _PubChemRequest:
+    base_url: str
+    user_agent: str
+    timeout: float
+    session: requests.Session
+    properties: Sequence[str]
+
+    def fetch(self, smiles: str) -> Mapping[str, object]:
+        encoded = quote(smiles, safe="")
+        url = (
+            f"{self.base_url.rstrip('/')}/compound/smiles/{encoded}/property/"
+            f"{','.join(self.properties)}/JSON"
+        )
+        headers = {"Accept": "application/json", "User-Agent": self.user_agent}
+        try:
+            response = self.session.get(url, timeout=self.timeout, headers=headers)
+            if response.status_code == 404:
+                LOGGER.debug("PubChem returned 404 for SMILES %s", smiles)
+                return {}
+            response.raise_for_status()
+        except requests.HTTPError:
+            LOGGER.warning(
+                "HTTP error when requesting PubChem properties for %s", smiles
+            )
+            return {}
+        except requests.RequestException:
+            LOGGER.warning(
+                "Network error when requesting PubChem properties for %s", smiles
+            )
+            return {}
+
+        payload = response.json()
+        properties = payload.get("PropertyTable", {}).get("Properties", [])
+        if not properties:
+            return {}
+        record = properties[0]
+        return {
+            prop: _normalise_numeric(prop, record.get(prop)) for prop in self.properties
+        }
+
+
+def _unique_smiles(values: Iterable[object]) -> list[str]:
+    unique: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        if raw is None:
+            continue
+        candidate = str(raw).strip()
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        unique.append(candidate)
+    unique.sort()
+    return unique
+
+
+def add_pubchem_data(
+    df: pd.DataFrame,
+    *,
+    smiles_column: str = "canonical_smiles",
+    properties: Sequence[str] = PUBCHEM_PROPERTIES,
+    timeout: float = 10.0,
+    session: requests.Session | None = None,
+    base_url: str = PUBCHEM_BASE_URL,
+    user_agent: str = "ChEMBLDataAcquisition/1.0",
+) -> pd.DataFrame:
+    """Augment ``df`` with PubChem descriptors based on SMILES strings.
+
+    Parameters
+    ----------
+    df:
+        Input molecule table.  The function returns ``df`` unchanged when the
+        frame is empty or does not contain ``smiles_column``.
+    smiles_column:
+        Name of the column containing SMILES representations used to query the
+        PubChem service.
+    properties:
+        Sequence of property names requested from the API.  Defaults to the
+        ``PUBCHEM_PROPERTIES`` tuple defined in this module.
+    timeout:
+        Socket timeout for PubChem HTTP requests in seconds.
+    session:
+        Optional :class:`requests.Session` to reuse connections during testing.
+        When omitted a temporary session is created and closed automatically.
+    base_url:
+        Base URL of the PubChem PUG REST API.
+    user_agent:
+        Custom ``User-Agent`` header sent with each HTTP request.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A copy of the input frame enriched with ``pubchem_*`` columns.  Missing
+        annotations remain represented as ``pd.NA`` values.
+    """
+
+    if df.empty:
+        LOGGER.debug("Skipping PubChem enrichment for empty DataFrame")
+        return df
+    if smiles_column not in df.columns:
+        LOGGER.warning(
+            "SMILES column '%s' not found; skipping PubChem enrichment", smiles_column
+        )
+        return df
+    if not properties:
+        LOGGER.debug("No PubChem properties requested; returning original DataFrame")
+        return df
+
+    owns_session = session is None
+    http = session or requests.Session()
+    request = _PubChemRequest(
+        base_url=base_url,
+        user_agent=user_agent,
+        timeout=timeout,
+        session=http,
+        properties=properties,
+    )
+
+    columns_map = _prepare_columns(properties)
+    enriched = df.copy()
+    for column in columns_map.values():
+        if column not in enriched.columns:
+            enriched[column] = pd.NA
+
+    cache: MutableMapping[str, Mapping[str, object]] = {}
+    try:
+        for smiles in _unique_smiles(enriched[smiles_column].tolist()):
+            cache[smiles] = request.fetch(smiles)
+
+        for idx, raw_smiles in enriched[smiles_column].items():
+            smiles_value = None if raw_smiles is None else str(raw_smiles).strip()
+            if not smiles_value:
+                continue
+            data = cache.get(smiles_value, {})
+            for prop, column in columns_map.items():
+                value = data.get(prop)
+                if value is not None:
+                    enriched.at[idx, column] = value
+    finally:
+        if owns_session:
+            http.close()
+
+    return enriched
+
+
+__all__ = ["add_pubchem_data", "PUBCHEM_PROPERTIES"]

--- a/library/testitem_validation.py
+++ b/library/testitem_validation.py
@@ -1,0 +1,218 @@
+"""Validation schema for normalised ChEMBL test item tables."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+import numpy as np
+import pandas as pd
+from pandas.api.types import is_scalar
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestitemsSchema(BaseModel):
+    """Pydantic model describing a validated molecule record."""
+
+    model_config = ConfigDict(extra="allow")
+
+    molecule_chembl_id: str
+    canonical_smiles: str
+    standard_inchi_key: str
+    pref_name: str | None = None
+    molecule_type: str | None = None
+    structure_type: str | None = None
+    salt_chembl_id: str | None = None
+    parent_chembl_id: str | None = None
+    max_phase: int | None = None
+    chembl_full_mwt: float | None = None
+    chembl_alogp: float | None = None
+    chembl_num_ro5_violations: int | None = None
+    chembl_molecular_species: str | None = None
+    pubchem_cid: int | None = None
+    pubchem_molecular_formula: str | None = None
+    pubchem_molecular_weight: float | None = None
+    pubchem_tpsa: float | None = None
+    pubchem_x_log_p: float | None = None
+    pubchem_h_bond_donor_count: int | None = None
+    pubchem_h_bond_acceptor_count: int | None = None
+    pubchem_rotatable_bond_count: int | None = None
+
+    @field_validator(
+        "molecule_chembl_id", "canonical_smiles", "standard_inchi_key", mode="before"
+    )
+    @classmethod
+    def _ensure_non_empty(cls, value: Any) -> str:
+        if value is None:
+            raise ValueError("value must not be empty")
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                raise ValueError("value must not be empty")
+            return stripped
+        return str(value)
+
+    @field_validator("max_phase", mode="before")
+    @classmethod
+    def _coerce_phase(cls, value: Any) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            try:
+                int_value = int(float(stripped))
+            except ValueError as exc:  # pragma: no cover - defensive branch
+                raise ValueError("max_phase must be an integer") from exc
+            if int_value < 0:
+                raise ValueError("max_phase must be non-negative")
+            return int_value
+        try:
+            int_value = int(value)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive branch
+            raise ValueError("max_phase must be an integer") from exc
+        if int_value < 0:
+            raise ValueError("max_phase must be non-negative")
+        return int_value
+
+    @field_validator(
+        "chembl_full_mwt",
+        "chembl_alogp",
+        "chembl_num_ro5_violations",
+        "pubchem_cid",
+        "pubchem_molecular_weight",
+        "pubchem_tpsa",
+        "pubchem_x_log_p",
+        "pubchem_h_bond_donor_count",
+        "pubchem_h_bond_acceptor_count",
+        "pubchem_rotatable_bond_count",
+        mode="before",
+    )
+    @classmethod
+    def _coerce_numeric(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            if isinstance(value, float) and np.isnan(value):
+                return None
+            return value
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            try:
+                if any(char in stripped for char in [".", "e", "E"]):
+                    return float(stripped)
+                return int(stripped)
+            except ValueError:
+                return stripped
+        return value
+
+    @classmethod
+    def ordered_columns(cls) -> list[str]:
+        """Return the columns defined by the schema in declaration order."""
+
+        return list(cls.model_fields.keys())
+
+
+def _is_missing_scalar(value: Any) -> bool:
+    try:
+        result = pd.isna(value)
+    except (TypeError, ValueError):
+        return False
+    if isinstance(result, (bool, np.bool_)):
+        return bool(result)
+    return False
+
+
+def _coerce_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, np.ndarray):
+        if value.size == 0:
+            return []
+        if value.ndim > 1:
+            flattened = value.flatten()
+            if flattened.size == 0:
+                return []
+            if flattened.size == 1:
+                return _coerce_value(flattened.item())
+            return [_coerce_value(item) for item in flattened.tolist()]
+        if value.size == 1:
+            return _coerce_value(value.item())
+        return [_coerce_value(item) for item in value.tolist()]
+    if isinstance(value, np.generic):
+        scalar_value = value.item()
+        return None if _is_missing_scalar(scalar_value) else scalar_value
+    if is_scalar(value):
+        return None if _is_missing_scalar(value) else value
+    return value
+
+
+def _coerce_record(row: pd.Series) -> dict[str, Any]:
+    clean: dict[str, Any] = {}
+    for key, value in row.items():
+        clean[key] = _coerce_value(value)
+    return clean
+
+
+def validate_testitems(
+    df: pd.DataFrame,
+    schema: type[TestitemsSchema] = TestitemsSchema,
+    *,
+    errors_path: Path,
+) -> pd.DataFrame:
+    """Validate rows in ``df`` against ``schema`` and write failures."""
+
+    if df.empty:
+        LOGGER.info("Validation skipped because the DataFrame is empty")
+        return df
+
+    valid_rows: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+
+    def _normalise_error_details(
+        details: Iterable[Mapping[str, Any]],
+    ) -> list[dict[str, Any]]:
+        normalised: list[dict[str, Any]] = []
+        for entry in details:
+            clean_entry = dict(entry)
+            ctx = clean_entry.get("ctx")
+            if isinstance(ctx, dict):
+                clean_entry["ctx"] = {key: str(value) for key, value in ctx.items()}
+            normalised.append(clean_entry)
+        return normalised
+
+    for index, row in df.iterrows():
+        payload = _coerce_record(row)
+        try:
+            record = schema(**payload)
+        except ValidationError as exc:
+            LOGGER.warning("Validation error for row %s: %s", index, exc)
+            errors.append(
+                {
+                    "index": int(index),
+                    "errors": _normalise_error_details(exc.errors()),
+                    "row": payload,
+                }
+            )
+            continue
+        valid_rows.append(record.model_dump())
+
+    if errors:
+        errors_path.parent.mkdir(parents=True, exist_ok=True)
+        with errors_path.open("w", encoding="utf-8") as handle:
+            json.dump(errors, handle, ensure_ascii=False, indent=2)
+        LOGGER.info("Validation produced %d error records", len(errors))
+    elif errors_path.exists():
+        errors_path.unlink()
+
+    return pd.DataFrame(valid_rows)
+
+
+__all__ = ["validate_testitems", "TestitemsSchema"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ requests-cache>=1.1
 # Development
 pytest>=7.4
 requests-mock>=1.11
+hypothesis>=6.0
 black>=23.0
 ruff>=0.1
 mypy>=1.4

--- a/scripts/chembl_testitems_main.py
+++ b/scripts/chembl_testitems_main.py
@@ -1,0 +1,295 @@
+"""CLI for downloading and normalising ChEMBL molecule metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import shlex
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import pandas as pd
+
+if __package__ in {None, ""}:
+    from _path_utils import ensure_project_root as _ensure_project_root
+
+    _ensure_project_root()
+
+from library.chembl_client import ChemblClient
+from library.chembl_library import get_testitems
+from library.data_profiling import analyze_table_quality
+from library.io import read_ids
+from library.io_utils import CsvConfig
+from library.metadata import write_meta_yaml
+from library.normalize_testitems import normalize_testitems
+from library.testitem_library import PUBCHEM_BASE_URL, add_pubchem_data
+from library.testitem_validation import TestitemsSchema, validate_testitems
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _default_output_name(input_path: str) -> str:
+    stem = Path(input_path).stem or "output"
+    date_suffix = datetime.now().strftime("%Y%m%d")
+    return f"output_{stem}_{date_suffix}.csv"
+
+
+def _configure_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+
+def _serialise_value(value: object, list_format: str) -> object:
+    if isinstance(value, dict):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    if isinstance(value, list):
+        if list_format == "pipe":
+            return "|".join(
+                json.dumps(item, ensure_ascii=False, sort_keys=True) for item in value
+            )
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return value
+
+
+def _serialise_complex_columns(df: pd.DataFrame, list_format: str) -> pd.DataFrame:
+    result = df.copy()
+    for column in result.columns:
+        if result[column].map(lambda value: isinstance(value, (list, dict))).any():
+            result[column] = result[column].map(
+                lambda value: _serialise_value(value, list_format)
+            )
+    return result
+
+
+def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments for the molecule pipeline CLI."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input", default="input.csv", help="Path to the input CSV file"
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Destination CSV file. Defaults to output_<input>_<YYYYMMDD>.csv",
+    )
+    parser.add_argument(
+        "--column", default="molecule_chembl_id", help="Column containing molecule IDs"
+    )
+    parser.add_argument(
+        "--chunk-size", type=int, default=20, help="Number of IDs fetched per batch"
+    )
+    parser.add_argument(
+        "--timeout", type=float, default=30.0, help="HTTP timeout in seconds"
+    )
+    parser.add_argument(
+        "--max-retries", type=int, default=3, help="Maximum retry attempts"
+    )
+    parser.add_argument(
+        "--rps", type=float, default=2.0, help="Maximum requests per second"
+    )
+    parser.add_argument(
+        "--base-url",
+        default="https://www.ebi.ac.uk/chembl/api/data",
+        help="ChEMBL API root",
+    )
+    parser.add_argument(
+        "--user-agent", default="ChEMBLDataAcquisition/1.0", help="User-Agent header"
+    )
+    parser.add_argument("--sep", default=",", help="CSV delimiter")
+    parser.add_argument("--encoding", default="utf-8", help="CSV encoding")
+    parser.add_argument(
+        "--list-format",
+        choices=["json", "pipe"],
+        default="json",
+        help="Serialization format for list columns",
+    )
+    parser.add_argument(
+        "--log-level", default="INFO", help="Logging level (e.g. INFO, DEBUG)"
+    )
+    parser.add_argument(
+        "--errors-output", default=None, help="Path to validation error report"
+    )
+    parser.add_argument(
+        "--meta-output", default=None, help="Optional metadata YAML path"
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of identifiers to process",
+    )
+    parser.add_argument(
+        "--dictionary",
+        default=None,
+        help="Optional dictionary file for downstream enrichment",
+    )
+    parser.add_argument(
+        "--smiles-column",
+        default="canonical_smiles",
+        help="Column containing SMILES strings for PubChem enrichment",
+    )
+    parser.add_argument(
+        "--pubchem-timeout",
+        type=float,
+        default=10.0,
+        help="PubChem HTTP timeout in seconds",
+    )
+    parser.add_argument(
+        "--pubchem-base-url",
+        default=PUBCHEM_BASE_URL,
+        help="PubChem PUG REST base URL",
+    )
+    parser.add_argument(
+        "--pubchem-user-agent",
+        default="ChEMBLDataAcquisition/1.0",
+        help="User-Agent header used for PubChem requests",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Read and validate the input file without fetching or writing output",
+    )
+    return parser.parse_args(args)
+
+
+def _prepare_configuration(namespace: argparse.Namespace) -> dict[str, object]:
+    config: dict[str, object] = {}
+    for key, value in vars(namespace).items():
+        if key in {"output", "errors_output", "meta_output"}:
+            continue
+        if isinstance(value, Path):
+            config[key] = str(value)
+        else:
+            config[key] = value
+    return config
+
+
+def _limited_ids(
+    path: Path, column: str, cfg: CsvConfig, limit: int | None
+) -> Iterable[str]:
+    return read_ids(path, column, cfg, limit=limit)
+
+
+def run_pipeline(
+    args: argparse.Namespace, *, command_parts: Sequence[str] | None = None
+) -> int:
+    """Execute the molecule acquisition pipeline with ``args``."""
+
+    if args.limit is not None and args.limit <= 0:
+        raise ValueError("--limit must be a positive integer")
+
+    input_path = Path(args.input)
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input file {input_path} does not exist")
+
+    output_path = (
+        Path(args.output) if args.output else Path(_default_output_name(args.input))
+    )
+    errors_path = (
+        Path(args.errors_output)
+        if args.errors_output
+        else output_path.with_suffix(f"{output_path.suffix}.errors.json")
+    )
+    meta_path = Path(args.meta_output) if args.meta_output else None
+
+    csv_cfg = CsvConfig(
+        sep=args.sep, encoding=args.encoding, list_format=args.list_format
+    )
+
+    if args.dry_run:
+        count = sum(
+            1 for _ in _limited_ids(input_path, args.column, csv_cfg, args.limit)
+        )
+        LOGGER.info("Dry run complete: %d unique identifiers would be processed", count)
+        return 0
+
+    molecule_ids = _limited_ids(input_path, args.column, csv_cfg, args.limit)
+
+    client = ChemblClient(
+        base_url=args.base_url,
+        timeout=args.timeout,
+        max_retries=args.max_retries,
+        rps=args.rps,
+        user_agent=args.user_agent,
+    )
+
+    molecules_df = get_testitems(client, molecule_ids, chunk_size=args.chunk_size)
+    if molecules_df.empty:
+        LOGGER.warning("No molecule data retrieved; writing empty output")
+        molecules_df = pd.DataFrame(columns=TestitemsSchema.ordered_columns())
+
+    normalised = normalize_testitems(molecules_df)
+    enriched = add_pubchem_data(
+        normalised,
+        smiles_column=args.smiles_column,
+        timeout=args.pubchem_timeout,
+        base_url=args.pubchem_base_url,
+        user_agent=args.pubchem_user_agent,
+    )
+    validated = validate_testitems(enriched, errors_path=errors_path)
+
+    schema_columns = [
+        column
+        for column in TestitemsSchema.ordered_columns()
+        if column in validated.columns
+    ]
+    extra_columns = sorted(
+        [column for column in validated.columns if column not in schema_columns]
+    )
+    ordered_columns = schema_columns + extra_columns
+    if ordered_columns:
+        validated = validated[ordered_columns]
+
+    sort_columns = []
+    if "salt_chembl_id" in validated.columns:
+        sort_columns.append("salt_chembl_id")
+    if "molecule_chembl_id" in validated.columns:
+        sort_columns.append("molecule_chembl_id")
+    if sort_columns:
+        validated = validated.sort_values(sort_columns, na_position="last").reset_index(
+            drop=True
+        )
+
+    serialised = _serialise_complex_columns(validated, args.list_format)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    serialised.to_csv(output_path, index=False, sep=args.sep, encoding=args.encoding)
+
+    if command_parts is None:
+        command_parts = sys.argv
+
+    write_meta_yaml(
+        output_path,
+        command=" ".join(shlex.quote(part) for part in command_parts),
+        config=_prepare_configuration(args),
+        row_count=int(len(serialised)),
+        column_count=int(len(serialised.columns)),
+        meta_path=meta_path,
+    )
+
+    analyze_table_quality(serialised, table_name=str(output_path.with_suffix("")))
+
+    LOGGER.info("Molecule table written to %s", output_path)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point used by the CLI and tests."""
+
+    args = parse_args(argv)
+    _configure_logging(args.log_level)
+    try:
+        cmd_parts = [sys.argv[0], *(argv or sys.argv[1:])]
+        return run_pipeline(args, command_parts=cmd_parts)
+    except Exception as exc:  # pragma: no cover - safety net
+        LOGGER.exception("Fatal error: %s", exc)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/data/testitems_input.csv
+++ b/tests/data/testitems_input.csv
@@ -1,0 +1,3 @@
+molecule_chembl_id
+CHEMBL1
+CHEMBL2

--- a/tests/test_chembl_testitems_pipeline.py
+++ b/tests/test_chembl_testitems_pipeline.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pandas as pd
+import requests_mock as requests_mock_lib
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+read_ids = importlib.import_module("library.io").read_ids
+CsvConfig = importlib.import_module("library.io_utils").CsvConfig
+chembl_testitems_main = importlib.import_module("scripts.chembl_testitems_main").main
+
+
+def test_read_ids_limit(tmp_path: Path) -> None:
+    source = Path(__file__).parent / "data" / "testitems_input.csv"
+    target = tmp_path / "ids.csv"
+    target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    cfg = CsvConfig(sep=",", encoding="utf-8")
+    ids = list(read_ids(target, "molecule_chembl_id", cfg, limit=1))
+    assert ids == ["CHEMBL1"]
+
+
+def test_chembl_testitems_main_dry_run(tmp_path: Path) -> None:
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("molecule_chembl_id\nCHEMBL1\nCHEMBL2\n", encoding="utf-8")
+
+    output_csv = tmp_path / "out.csv"
+    exit_code = chembl_testitems_main(
+        [
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--dry-run",
+            "--log-level",
+            "DEBUG",
+        ]
+    )
+
+    assert exit_code == 0
+    assert not output_csv.exists()
+
+
+def test_chembl_testitems_main_end_to_end(
+    tmp_path: Path, requests_mock: requests_mock_lib.Mocker
+) -> None:
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("molecule_chembl_id\nCHEMBL1\nCHEMBL2\n", encoding="utf-8")
+
+    base_url = "https://chembl.mock"
+    pubchem_base = "https://pubchem.mock/rest/pug"
+
+    def _chembl_payload(
+        identifier: str, smiles: str, inchi_key: str, parent: str | None
+    ) -> dict[str, object]:
+        payload = {
+            "molecule_chembl_id": identifier,
+            "pref_name": f"Compound {identifier[-1]}",
+            "molecule_type": "Small molecule",
+            "molecule_properties": {
+                "full_mwt": "120.5",
+                "alogp": "1.5",
+                "num_ro5_violations": "0",
+                "molecular_species": "NEUTRAL",
+            },
+            "molecule_structures": {
+                "canonical_smiles": smiles,
+                "standard_inchi": f"InChI=1S/{identifier}",
+                "standard_inchi_key": inchi_key,
+            },
+            "molecule_synonyms": [{"synonyms": f"Synonym {identifier}"}],
+            "molecule_hierarchy": {
+                "molecule_chembl_id": identifier,
+                "parent_chembl_id": parent or identifier,
+            },
+        }
+        return payload
+
+    requests_mock.get(
+        f"{base_url}/molecule/CHEMBL1.json",
+        json=_chembl_payload("CHEMBL1", "C", "KEYONE", None),
+    )
+    requests_mock.get(
+        f"{base_url}/molecule/CHEMBL2.json",
+        json=_chembl_payload("CHEMBL2", "CC", "KEYTWO", "CHEMBL1"),
+    )
+
+    def _pubchem_response(cid: int, formula: str) -> dict[str, object]:
+        return {
+            "PropertyTable": {
+                "Properties": [
+                    {
+                        "CID": cid,
+                        "MolecularFormula": formula,
+                        "MolecularWeight": 50.0 + cid,
+                        "TPSA": 10.0,
+                        "XLogP": -0.5,
+                        "HBondDonorCount": 1,
+                        "HBondAcceptorCount": 1,
+                        "RotatableBondCount": 0,
+                    }
+                ]
+            }
+        }
+
+    requests_mock.get(
+        f"{pubchem_base}/compound/smiles/C/property/"
+        "CID,MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
+        json=_pubchem_response(11, "CH4"),
+    )
+    requests_mock.get(
+        f"{pubchem_base}/compound/smiles/CC/property/"
+        "CID,MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
+        json=_pubchem_response(22, "C2H6"),
+    )
+
+    output_csv = tmp_path / "out.csv"
+    exit_code = chembl_testitems_main(
+        [
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--base-url",
+            base_url,
+            "--chunk-size",
+            "1",
+            "--pubchem-base-url",
+            pubchem_base,
+            "--pubchem-timeout",
+            "5",
+            "--log-level",
+            "DEBUG",
+        ]
+    )
+
+    assert exit_code == 0
+    assert output_csv.exists()
+    df = pd.read_csv(output_csv)
+    assert sorted(df["molecule_chembl_id"].tolist()) == ["CHEMBL1", "CHEMBL2"]
+    assert "pubchem_cid" in df.columns
+    assert (
+        int(df.loc[df["molecule_chembl_id"] == "CHEMBL2", "pubchem_cid"].iloc[0]) == 22
+    )
+    assert (
+        df.loc[df["molecule_chembl_id"] == "CHEMBL2", "salt_chembl_id"].iloc[0]
+        == "CHEMBL2"
+    )
+
+    meta_file = output_csv.with_suffix(".csv.meta.yaml")
+    assert meta_file.exists()
+
+    quality_report = Path(f"{output_csv.with_suffix('')}_quality_report_table.csv")
+    assert quality_report.exists()
+    corr_report = Path(
+        f"{output_csv.with_suffix('')}_data_correlation_report_table.csv"
+    )
+    assert corr_report.exists()

--- a/tests/test_testitems_library.py
+++ b/tests/test_testitems_library.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import importlib
+from typing import Iterable, List
+
+import pandas as pd
+import requests_mock as requests_mock_lib
+
+get_testitems = importlib.import_module("library.chembl_library").get_testitems
+add_pubchem_data = importlib.import_module("library.testitem_library").add_pubchem_data
+PUBCHEM_BASE_URL = importlib.import_module("library.testitem_library").PUBCHEM_BASE_URL
+normalize_testitems = importlib.import_module(
+    "library.normalize_testitems"
+).normalize_testitems
+
+
+def test_get_testitems_batches_requests() -> None:
+    calls: List[List[str]] = []
+
+    class DummyClient:
+        def fetch_many_molecules(self, values: Iterable[str]) -> List[dict[str, str]]:
+            batch = list(values)
+            calls.append(batch)
+            return [
+                {
+                    "molecule_chembl_id": molecule_id,
+                    "pref_name": f"Name {molecule_id}",
+                }
+                for molecule_id in batch
+            ]
+
+    df = get_testitems(DummyClient(), ["CHEMBL1", "CHEMBL2", "CHEMBL3"], chunk_size=2)
+    assert list(df["molecule_chembl_id"]) == ["CHEMBL1", "CHEMBL2", "CHEMBL3"]
+    assert calls == [["CHEMBL1", "CHEMBL2"], ["CHEMBL3"]]
+
+
+def test_add_pubchem_data_enriches_dataframe(
+    requests_mock: requests_mock_lib.Mocker,
+) -> None:
+    df = pd.DataFrame(
+        [
+            {"molecule_chembl_id": "CHEMBL1", "canonical_smiles": "C"},
+            {"molecule_chembl_id": "CHEMBL2", "canonical_smiles": "C"},
+            {"molecule_chembl_id": "CHEMBL3", "canonical_smiles": "CC"},
+        ]
+    )
+
+    def _pubchem_response(cid: int, formula: str) -> dict[str, object]:
+        return {
+            "PropertyTable": {
+                "Properties": [
+                    {
+                        "CID": cid,
+                        "MolecularFormula": formula,
+                        "MolecularWeight": 42.0 + cid,
+                        "TPSA": 12.3,
+                        "XLogP": -1.2,
+                        "HBondDonorCount": 1,
+                        "HBondAcceptorCount": 2,
+                        "RotatableBondCount": 0,
+                    }
+                ]
+            }
+        }
+
+    requests_mock.get(
+        f"{PUBCHEM_BASE_URL}/compound/smiles/C/property/"
+        "CID,MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
+        json=_pubchem_response(10, "CH4"),
+    )
+    requests_mock.get(
+        f"{PUBCHEM_BASE_URL}/compound/smiles/CC/property/"
+        "CID,MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
+        json=_pubchem_response(20, "C2H6"),
+    )
+
+    enriched = add_pubchem_data(df)
+    assert requests_mock.call_count == 2
+
+    assert enriched.loc[0, "pubchem_cid"] == 10
+    assert enriched.loc[1, "pubchem_cid"] == 10  # cached duplicate
+    assert enriched.loc[2, "pubchem_cid"] == 20
+    assert enriched.loc[2, "pubchem_molecular_formula"] == "C2H6"
+
+
+def test_add_pubchem_data_handles_missing_smiles() -> None:
+    df = pd.DataFrame([{"molecule_chembl_id": "CHEMBL1"}])
+    result = add_pubchem_data(df)
+    assert result is df
+
+
+def test_normalize_testitems_flattens_payload() -> None:
+    raw = pd.DataFrame(
+        [
+            {
+                "molecule_chembl_id": "chembl1",
+                "pref_name": " Compound ",
+                "molecule_type": "Small molecule",
+                "max_phase": "2",
+                "black_box_warning": "false",
+                "molecule_structures": {
+                    "canonical_smiles": " C ",
+                    "standard_inchi": " InChI ",
+                    "standard_inchi_key": " KEY ",
+                },
+                "molecule_properties": {
+                    "full_mwt": "120.5",
+                    "num_ro5_violations": "0",
+                    "molecular_species": "NEUTRAL",
+                },
+                "molecule_synonyms": [
+                    {"synonyms": "Alias"},
+                    {"synonyms": "Alias "},
+                ],
+                "atc_classifications": ["A01", "A01"],
+                "cross_references": [
+                    {
+                        "xref_id": "X1",
+                        "xref_src": "SRC",
+                        "xref_name": "Name",
+                    },
+                    {"xref_id": "", "xref_src": "", "xref_name": ""},
+                ],
+                "molecule_hierarchy": {
+                    "molecule_chembl_id": "CHEMBL1",
+                    "parent_chembl_id": "CHEMBL0",
+                    "active_chembl_id": "CHEMBL3",
+                },
+            }
+        ]
+    )
+
+    normalised = normalize_testitems(raw)
+    assert normalised.loc[0, "molecule_chembl_id"] == "CHEMBL1"
+    assert normalised.loc[0, "pref_name"] == "Compound"
+    assert normalised.loc[0, "canonical_smiles"] == "C"
+    assert normalised.loc[0, "standard_inchi_key"] == "KEY"
+    assert normalised.loc[0, "chembl_full_mwt"] == 120.5
+    assert normalised.loc[0, "chembl_num_ro5_violations"] == 0
+    assert normalised.loc[0, "chembl_molecular_species"] == "NEUTRAL"
+    assert normalised.loc[0, "synonyms"] == ["Alias"]
+    assert normalised.loc[0, "atc_classifications"] == ["A01"]
+    assert normalised.loc[0, "cross_references"] == [
+        {"xref_id": "X1", "xref_src": "SRC", "xref_name": "Name"}
+    ]
+    assert normalised.loc[0, "parent_chembl_id"] == "CHEMBL0"
+    assert normalised.loc[0, "salt_chembl_id"] == "CHEMBL1"
+    assert normalised.loc[0, "active_chembl_id"] == "CHEMBL3"

--- a/tests/test_testitems_validation.py
+++ b/tests/test_testitems_validation.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+validate_testitems = importlib.import_module(
+    "library.testitem_validation"
+).validate_testitems
+
+
+def test_validate_testitems_writes_errors(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "molecule_chembl_id": "CHEMBL1",
+                "canonical_smiles": "C",
+                "standard_inchi_key": "AAAA",
+            },
+            {
+                "molecule_chembl_id": "CHEMBL2",
+                "canonical_smiles": "",
+                "standard_inchi_key": None,
+            },
+        ]
+    )
+
+    errors_path = tmp_path / "errors.json"
+    validated = validate_testitems(df, errors_path=errors_path)
+
+    assert len(validated) == 1
+    assert not validated["molecule_chembl_id"].isna().any()
+    assert errors_path.exists()
+
+
+def test_validate_testitems_handles_numpy_payloads(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "molecule_chembl_id": "CHEMBL1",
+                "canonical_smiles": np.array(["C"], dtype=object),
+                "standard_inchi_key": np.array(["KEY"], dtype=object),
+                "synonyms": np.array([["one", "two"]], dtype=object),
+            }
+        ]
+    )
+
+    errors_path = tmp_path / "errors.json"
+    validated = validate_testitems(df, errors_path=errors_path)
+
+    assert not errors_path.exists()
+    assert validated.loc[0, "canonical_smiles"] == "C"
+    assert validated.loc[0, "standard_inchi_key"] == "KEY"
+    assert validated.loc[0, "synonyms"] == ["one", "two"]


### PR DESCRIPTION
## Summary
- extend the ChEMBL client/library to retrieve molecule payloads and expose a `get_testitems` helper
- implement molecule normalisation, PubChem enrichment, validation, and a CLI pipeline for generating test item tables
- cover the new workflow with unit/integration tests and record the Hypothesis dependency for reproducible test runs

## Testing
- black library scripts tests
- ruff check .
- mypy library/testitem_library.py library/normalize_testitems.py library/testitem_validation.py scripts/chembl_testitems_main.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c93e05133483249f58581713f22498