### PR TITLE
Stop retrying 404 responses and cover ChemblClient

### DIFF
--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -15,7 +15,6 @@ except ImportError:  # pragma: no cover
     from http_client import CacheConfig, HttpClient  # type: ignore[no-redef]
 
 import logging
-from dataclasses import dataclass
 
 LOGGER = logging.getLogger(__name__)
 

--- a/library/http_client.py
+++ b/library/http_client.py
@@ -292,7 +292,7 @@ class HttpClient:
             # Если передан cache_config, используем create_http_session, иначе обычную сессию
             self.session = create_http_session(cache_config)
         self.status_forcelist = set(
-            status_forcelist or {404, 408, 409, 429, 500, 502, 503, 504}
+            status_forcelist or {408, 409, 429, 500, 502, 503, 504}
         )
         self.backoff_multiplier = backoff_multiplier
 

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -44,3 +44,15 @@ def test_get_documents_parses_response() -> None:
         df = get_documents(["DOC1"], cfg=cfg, client=client)
     assert df.loc[0, "document_chembl_id"] == "DOC1"
     assert df.loc[0, "pubmed_id"] == "1"
+
+
+def test_fetch_assay_returns_none_on_404() -> None:
+    """``ChemblClient.fetch_assay`` yields ``None`` when the resource is missing."""
+
+    http = HttpClient(timeout=1.0, max_retries=2, rps=0)
+    client = ChemblClient(http_client=http)
+    assay_id = "CHEMBL404"
+    url = f"{client.base_url.rstrip('/')}/assay/{assay_id}.json"
+    with requests_mock.Mocker() as m:
+        m.get(url, status_code=404, json={"detail": "not found"})
+        assert client.fetch_assay(assay_id) is None

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -110,3 +110,16 @@ def test_http_client_falls_back_when_retry_after_invalid(
     assert response.json() == {"status": "ok"}
     assert sleeps
     assert pytest.approx(0.5, rel=1e-3) == sleeps[0]
+
+
+def test_http_client_returns_404_without_retry(requests_mock) -> None:
+    """Non-retriable 404 responses are returned as-is without extra attempts."""
+
+    url = "https://example.org/missing"
+    requests_mock.get(url, status_code=404, json={"detail": "not found"})
+    client = HttpClient(timeout=1, max_retries=3, rps=0)
+
+    response = client.request("get", url)
+
+    assert response.status_code == 404
+    assert requests_mock.call_count == 1


### PR DESCRIPTION
## Summary
- stop treating HTTP 404 as a transient status in the HTTP client
- add regression coverage ensuring 404 responses return None from ChemblClient

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c92a30fb248324b580a49b7b1677fe