### PR TITLE
Stop retrying 404 responses

### DIFF
--- a/library/http_client.py
+++ b/library/http_client.py
@@ -292,7 +292,7 @@ class HttpClient:
             # Если передан cache_config, используем create_http_session, иначе обычную сессию
             self.session = create_http_session(cache_config)
         self.status_forcelist = set(
-            status_forcelist or {404, 408, 409, 429, 500, 502, 503, 504}
+            status_forcelist or {408, 409, 429, 500, 502, 503, 504}
         )
         self.backoff_multiplier = backoff_multiplier
 

--- a/scripts/pubmed_main.py
+++ b/scripts/pubmed_main.py
@@ -75,7 +75,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "workers": 1,
         "column_pubmed": "PMID",
         "column_chembl": "document_chembl_id",
-        "status_forcelist": [404, 408, 409, 429, 500, 502, 503, 504],
+        "status_forcelist": [408, 409, 429, 500, 502, 503, 504],
     },
 }
 

--- a/tests/test_chembl_activities_pipeline.py
+++ b/tests/test_chembl_activities_pipeline.py
@@ -46,6 +46,7 @@ def test_chembl_client_handles_activity_404(
 
     client = ChemblClient(base_url=base_url)
     assert client.fetch_activity("CHEMBL404") is None
+    assert requests_mock.call_count == 1
 
 
 def test_get_activities_batches_requests() -> None:

--- a/tests/test_chembl_assays_pipeline.py
+++ b/tests/test_chembl_assays_pipeline.py
@@ -43,6 +43,7 @@ def test_chembl_client_handles_404(requests_mock: requests_mock_lib.Mocker) -> N
 
     client = ChemblClient(base_url=base_url)
     assert client.fetch_assay("CHEMBL404") is None
+    assert requests_mock.call_count == 1
 
 
 def test_get_assays_batches_requests() -> None:


### PR DESCRIPTION
## Summary
- remove HTTP 404 from the default retry list so missing resources return gracefully
- align the PubMed pipeline defaults with the updated retry configuration
- update the ChEMBL pipeline tests to assert that 404 responses are not retried

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c92a57b72c8324993c99c6c0ea866d