### PR TITLE
Improve Semantic Scholar throttling and add tests

### DIFF
--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import logging
 from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, List
 
 import pandas as pd
@@ -13,9 +14,6 @@ try:  # pragma: no cover - поддержка импорта без контек
     from .http_client import CacheConfig, HttpClient
 except ImportError:  # pragma: no cover
     from http_client import CacheConfig, HttpClient  # type: ignore[no-redef]
-
-import logging
-from dataclasses import dataclass
 
 LOGGER = logging.getLogger(__name__)
 
@@ -58,19 +56,18 @@ class ChemblClient:
         }
         try:
             response = self._http.request("get", url, headers=headers)
-            if response.status_code == 404:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            status_code = exc.response.status_code if exc.response is not None else None
+            if status_code == 404:
                 LOGGER.warning(
                     "%s %s не найден (404)", resource.capitalize(), identifier
                 )
                 return None
-            response.raise_for_status()
-        except requests.HTTPError:
             LOGGER.exception("Не удалось получить %s %s", resource, identifier)
             raise
         except requests.RequestException:
-            LOGGER.exception(
-                "Сетевая ошибка при получении %s %s", resource, identifier
-            )
+            LOGGER.exception("Сетевая ошибка при получении %s %s", resource, identifier)
             raise
 
         payload: Dict[str, Any] = response.json()
@@ -90,7 +87,9 @@ class ChemblClient:
         )
 
     def _fetch_many(
-        self, identifiers: Iterable[str], fetcher: Callable[[str], Dict[str, Any] | None]
+        self,
+        identifiers: Iterable[str],
+        fetcher: Callable[[str], Dict[str, Any] | None],
     ) -> List[Dict[str, Any]]:
         records: List[Dict[str, Any]] = []
         for identifier in identifiers:

--- a/scripts/pubmed_main.py
+++ b/scripts/pubmed_main.py
@@ -52,8 +52,10 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "semantic_scholar": {
         "chunk_size": 100,
         "timeout": 30.0,
-        "max_retries": 3,
-        "rps": 3.0,
+        "max_retries": 6,
+        "rps": 0.3,
+        "backoff_multiplier": 5.0,
+        "retry_penalty_seconds": 30.0,
     },
     "openalex": {
         "rps": 1.0,
@@ -126,11 +128,15 @@ def _create_http_client(
     status_forcelist = (
         cfg.get("status_forcelist") or DEFAULT_CONFIG["pipeline"]["status_forcelist"]
     )
+    backoff_multiplier = float(cfg.get("backoff_multiplier", 1.0))
+    retry_penalty_seconds = float(cfg.get("retry_penalty_seconds", 0.0))
     return HttpClient(
         timeout=(timeout_connect, timeout_read),
         max_retries=max_retries,
         rps=rps,
         status_forcelist=status_forcelist,
+        backoff_multiplier=backoff_multiplier,
+        retry_penalty_seconds=retry_penalty_seconds,
     )
 
 

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -5,7 +5,32 @@ from pathlib import Path
 import pytest
 import requests  # type: ignore[import-untyped]
 
-from library.http_client import CacheConfig, HttpClient, create_http_session
+from library.http_client import (
+    CacheConfig,
+    HttpClient,
+    RateLimiter,
+    create_http_session,
+)
+
+
+class FakeClock:
+    """Deterministic clock used to capture sleep durations in tests."""
+
+    def __init__(self) -> None:
+        self.monotonic_time = 0.0
+        self.wall_time = 1_000_000.0
+        self.sleeps: list[float] = []
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.monotonic_time += seconds
+        self.wall_time += seconds
+
+    def monotonic(self) -> float:
+        return self.monotonic_time
+
+    def time(self) -> float:
+        return self.wall_time
 
 
 def test_http_client_uses_cache(tmp_path: Path, requests_mock) -> None:
@@ -50,15 +75,20 @@ def test_create_http_session_falls_back_when_cache_dependency_missing(
     assert "requests-cache" in caplog.text
 
 
+def _patch_clock(monkeypatch, clock: FakeClock) -> None:
+    """Patch time related functions to use ``clock`` for deterministic sleeps."""
+
+    monkeypatch.setattr("tenacity.nap.time.sleep", clock.sleep)
+    monkeypatch.setattr("library.http_client.time.sleep", clock.sleep)
+    monkeypatch.setattr("library.http_client.time.monotonic", clock.monotonic)
+    monkeypatch.setattr("library.http_client.time.time", clock.time)
+
+
 def test_http_client_honours_retry_after(monkeypatch, requests_mock) -> None:
     """The client sleeps according to ``Retry-After`` headers before retrying."""
 
-    sleeps: list[float] = []
-
-    def fake_sleep(seconds: float) -> None:
-        sleeps.append(seconds)
-
-    monkeypatch.setattr("tenacity.nap.time.sleep", fake_sleep)
+    clock = FakeClock()
+    _patch_clock(monkeypatch, clock)
     url = "https://example.org/throttled"
     requests_mock.post(
         url,
@@ -76,8 +106,8 @@ def test_http_client_honours_retry_after(monkeypatch, requests_mock) -> None:
     response = client.request("post", url)
 
     assert response.json() == {"status": "ok"}
-    assert sleeps
-    assert pytest.approx(3.0, rel=1e-3) == sleeps[0]
+    assert clock.sleeps
+    assert pytest.approx(3.0, rel=1e-3) == clock.sleeps[0]
 
 
 def test_http_client_falls_back_when_retry_after_invalid(
@@ -85,12 +115,8 @@ def test_http_client_falls_back_when_retry_after_invalid(
 ) -> None:
     """Invalid ``Retry-After`` values defer to exponential backoff."""
 
-    sleeps: list[float] = []
-
-    def fake_sleep(seconds: float) -> None:
-        sleeps.append(seconds)
-
-    monkeypatch.setattr("tenacity.nap.time.sleep", fake_sleep)
+    clock = FakeClock()
+    _patch_clock(monkeypatch, clock)
     url = "https://example.org/throttled-invalid"
     requests_mock.get(
         url,
@@ -108,5 +134,77 @@ def test_http_client_falls_back_when_retry_after_invalid(
     response = client.request("get", url)
 
     assert response.json() == {"status": "ok"}
-    assert sleeps
-    assert pytest.approx(0.5, rel=1e-3) == sleeps[0]
+    assert clock.sleeps
+    assert pytest.approx(0.5, rel=1e-3) == clock.sleeps[0]
+
+
+def test_http_client_respects_rate_limit_reset_header(
+    monkeypatch, requests_mock
+) -> None:
+    """``X-RateLimit-Reset`` headers act as ``Retry-After`` equivalents."""
+
+    clock = FakeClock()
+    _patch_clock(monkeypatch, clock)
+    url = "https://example.org/rate-limit-reset"
+    requests_mock.get(
+        url,
+        [
+            {
+                "status_code": 429,
+                "headers": {"X-RateLimit-Reset": str(clock.time() + 30)},
+                "json": {"detail": "rate limit"},
+            },
+            {"status_code": 200, "json": {"status": "ok"}},
+        ],
+    )
+    client = HttpClient(timeout=1, max_retries=2, rps=0)
+
+    response = client.request("get", url)
+
+    assert response.json() == {"status": "ok"}
+    assert pytest.approx(30.0, rel=1e-3) == clock.sleeps[0]
+
+
+def test_http_client_penalises_future_requests(monkeypatch, requests_mock) -> None:
+    """Fallback penalty slows down subsequent retries without ``Retry-After``."""
+
+    clock = FakeClock()
+    _patch_clock(monkeypatch, clock)
+    url = "https://example.org/hard-limit"
+    requests_mock.post(
+        url,
+        [
+            {"status_code": 429, "json": {"detail": "limit"}},
+            {"status_code": 200, "json": {"status": "ok"}},
+        ],
+    )
+    client = HttpClient(
+        timeout=1,
+        max_retries=2,
+        rps=0,
+        retry_penalty_seconds=5.0,
+    )
+
+    response = client.request("post", url)
+
+    assert response.json() == {"status": "ok"}
+    # Tenacity waits ``backoff_multiplier`` seconds (defaults to 1.0)
+    # followed by the penalty applied by the rate limiter.
+    assert pytest.approx([1.0, 4.0], rel=1e-3) == clock.sleeps
+
+
+def test_rate_limiter_penalty_blocks_until_elapsed(monkeypatch) -> None:
+    """Rate limiter delays requests until the configured penalty expires."""
+
+    clock = FakeClock()
+    monkeypatch.setattr("library.http_client.time.sleep", clock.sleep)
+    monkeypatch.setattr("library.http_client.time.monotonic", clock.monotonic)
+    limiter = RateLimiter(rps=0)
+
+    limiter.apply_penalty(2.5)
+    limiter.wait()
+
+    assert pytest.approx(2.5, rel=1e-3) == clock.monotonic_time
+    # Subsequent waits without additional penalties do not sleep again.
+    limiter.wait()
+    assert pytest.approx(2.5, rel=1e-3) == clock.monotonic_time


### PR DESCRIPTION
## Summary
- extend the HTTP client with adaptive penalty handling, honoring `Retry-After`/`X-RateLimit-Reset` headers and allowing configurable fallback delays
- slow down the Semantic Scholar defaults and surface new backoff settings through the PubMed CLI helper
- harden unit coverage with deterministic clock helpers and ensure 404 responses from the ChEMBL client return `None`

## Testing
- `black library/http_client.py scripts/pubmed_main.py tests/test_http_client.py`
- `black library/chembl_client.py`
- `ruff check .`
- `mypy --config-file mypy.ini library/http_client.py scripts/pubmed_main.py tests/test_http_client.py library/chembl_client.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c94c83efa48324899dda6d29ece3b4