### PR TITLE
Use HttpClient for PubChem enrichment and add resilience tests

### DIFF
--- a/library/testitem_library.py
+++ b/library/testitem_library.py
@@ -16,14 +16,19 @@ Algorithm Notes
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
 import re
+from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Mapping, MutableMapping, Sequence
 from urllib.parse import quote
 
 import pandas as pd
 import requests  # type: ignore[import-untyped]
+
+try:  # pragma: no cover - импорт для тестовых окружений без пакета
+    from .http_client import HttpClient
+except ImportError:  # pragma: no cover
+    from http_client import HttpClient  # type: ignore[no-redef]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -42,6 +47,20 @@ PUBCHEM_INT_FIELDS: frozenset[str] = frozenset(
     ["CID", "HBondDonorCount", "HBondAcceptorCount", "RotatableBondCount"]
 )
 PUBCHEM_FLOAT_FIELDS: frozenset[str] = frozenset(["MolecularWeight", "TPSA", "XLogP"])
+
+PUBCHEM_DEFAULT_MAX_RETRIES = 3
+PUBCHEM_DEFAULT_RPS = 5.0
+PUBCHEM_DEFAULT_BACKOFF = 1.0
+PUBCHEM_DEFAULT_RETRY_PENALTY = 5.0
+PUBCHEM_STATUS_FORCELIST: tuple[int, ...] = (
+    408,
+    409,
+    429,
+    500,
+    502,
+    503,
+    504,
+)
 
 
 def _to_snake_case(value: str) -> str:
@@ -87,13 +106,81 @@ def _prepare_columns(properties: Sequence[str]) -> Dict[str, str]:
     return {prop: f"pubchem_{_to_snake_case(prop)}" for prop in properties}
 
 
+def _int_from_config(config: Mapping[str, Any], key: str, default: int) -> int:
+    value = config.get(key, default)
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive branch
+        raise ValueError(f"{key} must be an integer, got {value!r}") from exc
+
+
+def _float_from_config(config: Mapping[str, Any], key: str, default: float) -> float:
+    value = config.get(key, default)
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive branch
+        raise ValueError(f"{key} must be a float, got {value!r}") from exc
+
+
+def _status_forcelist_from_config(
+    config: Mapping[str, Any], key: str, default: tuple[int, ...]
+) -> tuple[int, ...]:
+    value = config.get(key)
+    if value is None:
+        return default
+    if isinstance(value, (str, bytes)):
+        raise TypeError("status_forcelist must be an iterable of integers")
+    try:
+        iterator = iter(value)
+    except TypeError as exc:  # pragma: no cover - defensive branch
+        raise TypeError("status_forcelist must be an iterable of integers") from exc
+    result: list[int] = []
+    for item in iterator:
+        try:
+            result.append(int(item))
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive branch
+            raise ValueError("status_forcelist entries must be integers") from exc
+    return tuple(result)
+
+
+def _build_http_client(
+    *,
+    timeout: float,
+    http_client: HttpClient | None,
+    http_client_config: Mapping[str, Any] | None,
+    session: requests.Session | None,
+) -> HttpClient:
+    if http_client is not None:
+        return http_client
+    config = http_client_config or {}
+    max_retries = _int_from_config(config, "max_retries", PUBCHEM_DEFAULT_MAX_RETRIES)
+    rps = _float_from_config(config, "rps", PUBCHEM_DEFAULT_RPS)
+    backoff = _float_from_config(config, "backoff_multiplier", PUBCHEM_DEFAULT_BACKOFF)
+    penalty = _float_from_config(
+        config, "retry_penalty_seconds", PUBCHEM_DEFAULT_RETRY_PENALTY
+    )
+    status_forcelist = _status_forcelist_from_config(
+        config, "status_forcelist", PUBCHEM_STATUS_FORCELIST
+    )
+
+    return HttpClient(
+        timeout=(timeout, timeout),
+        max_retries=max_retries,
+        rps=rps,
+        backoff_multiplier=backoff,
+        retry_penalty_seconds=penalty,
+        status_forcelist=status_forcelist,
+        session=session,
+    )
+
+
 @dataclass(slots=True)
 class _PubChemRequest:
     base_url: str
     user_agent: str
     timeout: float
-    session: requests.Session
     properties: Sequence[str]
+    http_client: HttpClient
 
     def fetch(self, smiles: str) -> Mapping[str, object]:
         encoded = quote(smiles, safe="")
@@ -103,23 +190,51 @@ class _PubChemRequest:
         )
         headers = {"Accept": "application/json", "User-Agent": self.user_agent}
         try:
-            response = self.session.get(url, timeout=self.timeout, headers=headers)
-            if response.status_code == 404:
+            response = self.http_client.request(
+                "get", url, headers=headers, timeout=(self.timeout, self.timeout)
+            )
+        except requests.HTTPError as exc:
+            status = exc.response.status_code if exc.response is not None else None
+            if status == 404:
                 LOGGER.debug("PubChem returned 404 for SMILES %s", smiles)
                 return {}
-            response.raise_for_status()
-        except requests.HTTPError:
             LOGGER.warning(
-                "HTTP error when requesting PubChem properties for %s", smiles
+                "HTTP error when requesting PubChem properties for %s",
+                smiles,
+                exc_info=True,
             )
             return {}
         except requests.RequestException:
             LOGGER.warning(
-                "Network error when requesting PubChem properties for %s", smiles
+                "Network error when requesting PubChem properties for %s",
+                smiles,
+                exc_info=True,
             )
             return {}
 
-        payload = response.json()
+        if response.status_code == 404:
+            LOGGER.debug("PubChem returned 404 for SMILES %s", smiles)
+            return {}
+
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            LOGGER.warning(
+                "HTTP error when requesting PubChem properties for %s",
+                smiles,
+                exc_info=True,
+            )
+            return {}
+
+        try:
+            payload = response.json()
+        except ValueError:
+            LOGGER.warning(
+                "Invalid JSON when requesting PubChem properties for %s",
+                smiles,
+                exc_info=True,
+            )
+            return {}
         properties = payload.get("PropertyTable", {}).get("Properties", [])
         if not properties:
             return {}
@@ -150,9 +265,11 @@ def add_pubchem_data(
     smiles_column: str = "canonical_smiles",
     properties: Sequence[str] = PUBCHEM_PROPERTIES,
     timeout: float = 10.0,
-    session: requests.Session | None = None,
     base_url: str = PUBCHEM_BASE_URL,
     user_agent: str = "ChEMBLDataAcquisition/1.0",
+    http_client: HttpClient | None = None,
+    http_client_config: Mapping[str, Any] | None = None,
+    session: requests.Session | None = None,
 ) -> pd.DataFrame:
     """Augment ``df`` with PubChem descriptors based on SMILES strings.
 
@@ -169,13 +286,23 @@ def add_pubchem_data(
         ``PUBCHEM_PROPERTIES`` tuple defined in this module.
     timeout:
         Socket timeout for PubChem HTTP requests in seconds.
-    session:
-        Optional :class:`requests.Session` to reuse connections during testing.
-        When omitted a temporary session is created and closed automatically.
     base_url:
         Base URL of the PubChem PUG REST API.
     user_agent:
         Custom ``User-Agent`` header sent with each HTTP request.
+    http_client:
+        Optional :class:`~library.http_client.HttpClient` used for outbound
+        requests. When omitted a new client is created with sensible defaults
+        for retry and rate limiting.
+    http_client_config:
+        Optional mapping overriding the HTTP client defaults. Supported keys are
+        ``max_retries``, ``rps``, ``backoff_multiplier``,
+        ``retry_penalty_seconds`` and ``status_forcelist``. Ignored when
+        ``http_client`` is provided.
+    session:
+        Optional :class:`requests.Session` reused when a new
+        :class:`HttpClient` is instantiated internally. Retained for backwards
+        compatibility with older code paths.
 
     Returns
     -------
@@ -196,14 +323,18 @@ def add_pubchem_data(
         LOGGER.debug("No PubChem properties requested; returning original DataFrame")
         return df
 
-    owns_session = session is None
-    http = session or requests.Session()
+    http = _build_http_client(
+        timeout=timeout,
+        http_client=http_client,
+        http_client_config=http_client_config,
+        session=session,
+    )
     request = _PubChemRequest(
         base_url=base_url,
         user_agent=user_agent,
         timeout=timeout,
-        session=http,
         properties=properties,
+        http_client=http,
     )
 
     columns_map = _prepare_columns(properties)
@@ -213,22 +344,18 @@ def add_pubchem_data(
             enriched[column] = pd.NA
 
     cache: MutableMapping[str, Mapping[str, object]] = {}
-    try:
-        for smiles in _unique_smiles(enriched[smiles_column].tolist()):
-            cache[smiles] = request.fetch(smiles)
+    for smiles in _unique_smiles(enriched[smiles_column].tolist()):
+        cache[smiles] = request.fetch(smiles)
 
-        for idx, raw_smiles in enriched[smiles_column].items():
-            smiles_value = None if raw_smiles is None else str(raw_smiles).strip()
-            if not smiles_value:
-                continue
-            data = cache.get(smiles_value, {})
-            for prop, column in columns_map.items():
-                value = data.get(prop)
-                if value is not None:
-                    enriched.at[idx, column] = value
-    finally:
-        if owns_session:
-            http.close()
+    for idx, raw_smiles in enriched[smiles_column].items():
+        smiles_value = None if raw_smiles is None else str(raw_smiles).strip()
+        if not smiles_value:
+            continue
+        data = cache.get(smiles_value, {})
+        for prop, column in columns_map.items():
+            value = data.get(prop)
+            if value is not None:
+                enriched.at[idx, column] = value
 
     return enriched
 

--- a/tests/test_testitems_library.py
+++ b/tests/test_testitems_library.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 from typing import Iterable, List
 
+import requests  # type: ignore[import-untyped]
 import pandas as pd
 import requests_mock as requests_mock_lib
 
@@ -81,6 +82,49 @@ def test_add_pubchem_data_enriches_dataframe(
     assert enriched.loc[1, "pubchem_cid"] == 10  # cached duplicate
     assert enriched.loc[2, "pubchem_cid"] == 20
     assert enriched.loc[2, "pubchem_molecular_formula"] == "C2H6"
+
+
+def test_add_pubchem_data_handles_invalid_json(
+    requests_mock: requests_mock_lib.Mocker,
+) -> None:
+    df = pd.DataFrame(
+        [
+            {"molecule_chembl_id": "CHEMBL1", "canonical_smiles": "C"},
+        ]
+    )
+
+    requests_mock.get(
+        f"{PUBCHEM_BASE_URL}/compound/smiles/C/property/"
+        "CID,MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
+        text="not-json",
+        status_code=200,
+    )
+
+    enriched = add_pubchem_data(df, http_client_config={"max_retries": 1, "rps": 0.0})
+
+    assert requests_mock.call_count == 1
+    assert pd.isna(enriched.loc[0, "pubchem_cid"])
+
+
+def test_add_pubchem_data_handles_network_errors(
+    requests_mock: requests_mock_lib.Mocker,
+) -> None:
+    df = pd.DataFrame(
+        [
+            {"molecule_chembl_id": "CHEMBL1", "canonical_smiles": "C"},
+        ]
+    )
+
+    requests_mock.get(
+        f"{PUBCHEM_BASE_URL}/compound/smiles/C/property/"
+        "CID,MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
+        exc=requests.exceptions.ConnectTimeout,
+    )
+
+    enriched = add_pubchem_data(df, http_client_config={"max_retries": 1, "rps": 0.0})
+
+    assert requests_mock.call_count == 1
+    assert pd.isna(enriched.loc[0, "pubchem_cid"])
 
 
 def test_add_pubchem_data_handles_missing_smiles() -> None:


### PR DESCRIPTION
## Summary
- refactor `add_pubchem_data` to build or accept an `HttpClient`, honouring retry, retry-after and penalty settings while hardening JSON parsing
- add configurability helpers for the PubChem HTTP client and guard against invalid payloads in `_PubChemRequest`
- extend the test suite with cases for malformed JSON and network failures when enriching PubChem data

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini library/testitem_library.py tests/test_testitems_library.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ca759ade3883248b1f9927fa2f7236