### PR TITLE
Add shared serialization helper with pipe escaping

### DIFF
--- a/scripts/chembl_activities_main.py
+++ b/scripts/chembl_activities_main.py
@@ -8,7 +8,6 @@ if __package__ in {None, ""}:
     _ensure_project_root()
 
 import argparse
-import json
 import logging
 import shlex
 import sys
@@ -23,7 +22,7 @@ from library.chembl_client import ChemblClient
 from library.chembl_library import get_activities
 from library.data_profiling import analyze_table_quality
 from library.io import read_ids
-from library.io_utils import CsvConfig
+from library.io_utils import CsvConfig, serialise_cell
 from library.metadata import write_meta_yaml
 from library.normalize_activities import normalize_activities
 
@@ -46,23 +45,10 @@ def _configure_logging(level: str) -> None:
 def _serialise_complex_columns(df: pd.DataFrame, list_format: str) -> pd.DataFrame:
     result = df.copy()
     for column in result.columns:
-        if result[column].map(lambda value: isinstance(value, (list, dict))).any():
-            result[column] = result[column].map(
-                lambda value: _serialise_value(value, list_format)
-            )
+        result[column] = result[column].map(
+            lambda value: serialise_cell(value, list_format)
+        )
     return result
-
-
-def _serialise_value(value: object, list_format: str) -> object:
-    if isinstance(value, dict):
-        return json.dumps(value, ensure_ascii=False, sort_keys=True)
-    if isinstance(value, list):
-        if list_format == "pipe":
-            return "|".join(
-                json.dumps(item, ensure_ascii=False, sort_keys=True) for item in value
-            )
-        return json.dumps(value, ensure_ascii=False, sort_keys=True)
-    return value
 
 
 def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:

--- a/scripts/chembl_testitems_main.py
+++ b/scripts/chembl_testitems_main.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import logging
 import shlex
 import sys
@@ -22,7 +21,7 @@ from library.chembl_client import ChemblClient
 from library.chembl_library import get_testitems
 from library.data_profiling import analyze_table_quality
 from library.io import read_ids
-from library.io_utils import CsvConfig
+from library.io_utils import CsvConfig, serialise_cell
 from library.metadata import write_meta_yaml
 from library.normalize_testitems import normalize_testitems
 from library.testitem_library import PUBCHEM_BASE_URL, add_pubchem_data
@@ -44,25 +43,12 @@ def _configure_logging(level: str) -> None:
     )
 
 
-def _serialise_value(value: object, list_format: str) -> object:
-    if isinstance(value, dict):
-        return json.dumps(value, ensure_ascii=False, sort_keys=True)
-    if isinstance(value, list):
-        if list_format == "pipe":
-            return "|".join(
-                json.dumps(item, ensure_ascii=False, sort_keys=True) for item in value
-            )
-        return json.dumps(value, ensure_ascii=False, sort_keys=True)
-    return value
-
-
 def _serialise_complex_columns(df: pd.DataFrame, list_format: str) -> pd.DataFrame:
     result = df.copy()
     for column in result.columns:
-        if result[column].map(lambda value: isinstance(value, (list, dict))).any():
-            result[column] = result[column].map(
-                lambda value: _serialise_value(value, list_format)
-            )
+        result[column] = result[column].map(
+            lambda value: serialise_cell(value, list_format)
+        )
     return result
 
 

--- a/tests/data/golden_write_rows_pipe.csv
+++ b/tests/data/golden_write_rows_pipe.csv
@@ -1,0 +1,3 @@
+id,names,meta
+1,alpha\|beta|gamma,"{""id"": ""x\|y"", ""name"": ""value\|with\|pipes""}"
+2,delta|epsilon\|zeta,

--- a/tests/test_pipeline_targets_library.py
+++ b/tests/test_pipeline_targets_library.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import json
 from typing import Any, Dict, List
 
 import pandas as pd
 
+from library.io_utils import serialise_cell
 from pipeline_targets import (
     PipelineConfig,
     _load_serialised_list,
@@ -15,9 +15,7 @@ from pipeline_targets import (
 def _pipe_encode(items: List[Any]) -> str:
     """Return a pipe-serialised string compatible with the pipeline helpers."""
 
-    return "|".join(
-        json.dumps(item, ensure_ascii=False, sort_keys=True) for item in items
-    )
+    return str(serialise_cell(items, "pipe"))
 
 
 def test_load_serialised_list_pipe_json_roundtrip() -> None:
@@ -29,6 +27,14 @@ def test_load_serialised_list_pipe_json_roundtrip() -> None:
 def test_load_serialised_list_pipe_plain_strings() -> None:
     serialised = "alpha|beta|gamma"
     assert _load_serialised_list(serialised, "pipe") == ["alpha", "beta", "gamma"]
+
+
+def test_load_serialised_list_pipe_with_escaped_pipes() -> None:
+    serialised = _pipe_encode(["alpha|beta", {"name": "value|with|pipes"}])
+    assert _load_serialised_list(serialised, "pipe") == [
+        "alpha|beta",
+        {"name": "value|with|pipes"},
+    ]
 
 
 class _DummyUniProt:


### PR DESCRIPTION
## Summary
- add a reusable `serialise_cell` helper in `library/io_utils` to escape pipe-delimited content and reuse it when writing CSV cells
- update the ChEMBL CLI entrypoints and `chembl_targets` to call the helper instead of duplicating JSON join logic
- teach `pipeline_targets` to split escaped pipe strings and extend the IO utilities tests with pipe-focused golden fixtures

## Testing
- ruff check
- black .
- mypy . *(fails: missing type stubs for `requests`/`yaml` modules and duplicate module warning for `scripts.pubmed_main`)*
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca75a079488324b718225cf7dd8e90