### PR TITLE
Document optional 404 retries in HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ python scripts/chembl2uniprot_main.py --config my_config.yaml
 
 Always define the environment variables in the shell session before launching the CLI so that the overrides are visible to the Python process.
 
+#### HTTP retry configuration
+
+Network-bound scripts rely on `library.http_client.HttpClient`, which retries transient HTTP errors listed in `status_forcelist`. The default value, exposed as `library.http_client.DEFAULT_STATUS_FORCELIST`, targets rate limits and server-side failures (408, 409, 429, 500, 502, 503, 504) and intentionally skips `404 Not Found`. Retrying missing resources usually wastes the retry budget and slows down processing, so only opt in when a specific API is known to return temporary 404 responses. To enable this behaviour, provide a custom list in the configuration file, for example:
+
+```yaml
+pipeline:
+  status_forcelist: [404, 408, 409, 429, 500, 502, 503, 504]
+```
+
+or construct an HTTP client directly with `HttpClient(..., status_forcelist=DEFAULT_STATUS_FORCELIST | {404})` for carefully scoped scripts.
+
 ### Running the Pipeline
 
 The main entry point for the unified pipeline is `scripts/pipeline_targets_main.py`. This script orchestrates the entire data acquisition and normalization process.

--- a/scripts/pubmed_main.py
+++ b/scripts/pubmed_main.py
@@ -77,7 +77,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "workers": 1,
         "column_pubmed": "PMID",
         "column_chembl": "document_chembl_id",
-        "status_forcelist": [404, 408, 409, 429, 500, 502, 503, 504],
+        "status_forcelist": [408, 409, 429, 500, 502, 503, 504],
     },
 }
 


### PR DESCRIPTION
## Summary
- remove 404 from the default HTTP retry list, expose `DEFAULT_STATUS_FORCELIST`, and clarify how to opt in via the constructor
- drop 404 from the document pipeline defaults and document when opting into 404 retries is appropriate
- extend the HTTP client tests to cover the new default and explicit 404 retry scenario

## Testing
- ruff check .
- mypy . *(fails: missing third-party typing stubs and duplicate script module detection in existing configuration)*
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ca759df1f883249ca487e88343a73c