### PR TITLE
Fix PubChem CID enrichment

### DIFF
--- a/library/http_client.py
+++ b/library/http_client.py
@@ -44,7 +44,9 @@ from tenacity.wait import wait_base
 LOGGER = logging.getLogger(__name__)
 
 
-DEFAULT_STATUS_FORCELIST: frozenset[int] = frozenset({408, 409, 429, 500, 502, 503, 504})
+DEFAULT_STATUS_FORCELIST: frozenset[int] = frozenset(
+    {408, 409, 429, 500, 502, 503, 504}
+)
 
 
 def _parse_retry_after(value: str | None) -> float | None:

--- a/tests/test_testitems_library.py
+++ b/tests/test_testitems_library.py
@@ -45,12 +45,11 @@ def test_add_pubchem_data_enriches_dataframe(
         ]
     )
 
-    def _pubchem_response(cid: int, formula: str) -> dict[str, object]:
+    def _pubchem_properties_response(formula: str, cid: int) -> dict[str, object]:
         return {
             "PropertyTable": {
                 "Properties": [
                     {
-                        "CID": cid,
                         "MolecularFormula": formula,
                         "MolecularWeight": 42.0 + cid,
                         "TPSA": 12.3,
@@ -65,17 +64,25 @@ def test_add_pubchem_data_enriches_dataframe(
 
     requests_mock.get(
         f"{PUBCHEM_BASE_URL}/compound/smiles/C/property/"
-        "CID,MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
-        json=_pubchem_response(10, "CH4"),
+        "MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
+        json=_pubchem_properties_response("CH4", 10),
     )
     requests_mock.get(
         f"{PUBCHEM_BASE_URL}/compound/smiles/CC/property/"
-        "CID,MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
-        json=_pubchem_response(20, "C2H6"),
+        "MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
+        json=_pubchem_properties_response("C2H6", 20),
+    )
+    requests_mock.get(
+        f"{PUBCHEM_BASE_URL}/compound/smiles/C/cids/JSON",
+        json={"IdentifierList": {"CID": [10]}},
+    )
+    requests_mock.get(
+        f"{PUBCHEM_BASE_URL}/compound/smiles/CC/cids/JSON",
+        json={"IdentifierList": {"CID": [20]}},
     )
 
     enriched = add_pubchem_data(df)
-    assert requests_mock.call_count == 2
+    assert requests_mock.call_count == 4
 
     assert enriched.loc[0, "pubchem_cid"] == 10
     assert enriched.loc[1, "pubchem_cid"] == 10  # cached duplicate


### PR DESCRIPTION
## Summary
- adjust PubChem enrichment to request physicochemical properties separately from CID lookups
- add shared HTTP helper that logs contextual errors and handles JSON decoding failures
- extend the PubChem enrichment unit test to cover the new CID endpoint calls

## Testing
- `python scripts/chembl_testitems_main.py --input tests/data/testitems_input.csv --limit 2 --output tmp_testitems.csv --log-level INFO`
- `PYTHONPATH=. pytest tests/test_testitems_library.py`
- `black .`
- `ruff check .`
- `mypy --config-file mypy.ini library/testitem_library.py tests/test_testitems_library.py`


------
https://chatgpt.com/codex/tasks/task_e_68ca7891c7c08324874a4fc3c67ba71d