### PR TITLE
Refactor ortholog clients to use shared HttpClient

### DIFF
--- a/tests/test_orthologs.py
+++ b/tests/test_orthologs.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from typing import Any
 
-from library.orthologs import EnsemblHomologyClient
-from library.uniprot_normalize import extract_ensembl_gene_ids
-from library.uniprot_client import NetworkConfig, RateLimitConfig
+import requests
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from library.orthologs import EnsemblHomologyClient  # type: ignore  # noqa: E402
+from library.uniprot_normalize import extract_ensembl_gene_ids  # type: ignore  # noqa: E402
+from library.uniprot_client import NetworkConfig, RateLimitConfig  # type: ignore  # noqa: E402
 
 
 class DummyResponse:
@@ -18,10 +25,92 @@ class DummyResponse:
         return self._data
 
 
+class DummyHttpClient:
+    def __init__(self, responses: list[requests.Response | Exception]) -> None:
+        self.responses = list(responses)
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
+        self.calls.append((method, url, kwargs))
+        if not self.responses:
+            raise AssertionError("No responses configured")
+        result = self.responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def make_response(
+    status: int,
+    payload: Any | None = None,
+    *,
+    headers: dict[str, str] | None = None,
+) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status
+    response.url = "https://example.org/test"
+    if headers:
+        response.headers.update(headers)
+    if payload is not None:
+        response._content = json.dumps(payload).encode("utf-8")
+        response.headers.setdefault("Content-Type", "application/json")
+    else:
+        response._content = b""
+    return response
+
+
 def test_extract_ensembl_gene_ids() -> None:
     entry = json.loads(Path("tests/data/uniprot_with_ensembl.json").read_text())
     ids = extract_ensembl_gene_ids(entry)
     assert ids == ["ENSG00000144285"]
+
+
+def test_ensembl_request_success() -> None:
+    response = make_response(200, {"hello": "world"})
+    http_client = DummyHttpClient([response])
+    client = EnsemblHomologyClient(
+        base_url="https://example.org",
+        network=NetworkConfig(timeout_sec=1, max_retries=1),
+        rate_limit=RateLimitConfig(rps=1),
+        http_client=http_client,
+    )
+    result = client._request("https://example.org/homology", [("a", "b")])
+    assert result is response
+    assert len(http_client.calls) == 1
+    method, url, kwargs = http_client.calls[0]
+    assert method == "get"
+    assert url == "https://example.org/homology"
+    assert kwargs["headers"]["Accept"] == "application/json"
+    assert kwargs["params"] == [("a", "b")]
+
+
+def test_ensembl_request_handles_server_error() -> None:
+    response = make_response(500)
+    error = requests.HTTPError(response=response)
+    http_client = DummyHttpClient([error])
+    client = EnsemblHomologyClient(
+        base_url="https://example.org",
+        network=NetworkConfig(timeout_sec=1, max_retries=1),
+        rate_limit=RateLimitConfig(rps=1),
+        http_client=http_client,
+    )
+    result = client._request("https://example.org/homology", [])
+    assert result is None
+    assert len(http_client.calls) == 1
+
+
+def test_ensembl_request_handles_retry_after_header() -> None:
+    response = make_response(429, headers={"Retry-After": "1"})
+    error = requests.HTTPError(response=response)
+    http_client = DummyHttpClient([error])
+    client = EnsemblHomologyClient(
+        base_url="https://example.org",
+        network=NetworkConfig(timeout_sec=1, max_retries=1),
+        rate_limit=RateLimitConfig(rps=1),
+        http_client=http_client,
+    )
+    result = client._request("https://example.org/homology", [])
+    assert result is None
 
 
 def test_ensembl_homology_client_parsing(monkeypatch: Any) -> None:


### PR DESCRIPTION
## Summary
- wrap `EnsemblHomologyClient` around the shared `HttpClient`, preserving caching helpers while normalising HTTP error handling
- switch the fallback `OmaClient` to the shared HTTP layer for consistent configuration
- extend the ortholog tests to cover success, HTTP 500 and Retry-After scenarios via a dummy client

## Testing
- `black library/orthologs.py tests/test_orthologs.py`
- `ruff check library/orthologs.py tests/test_orthologs.py`
- `pytest tests/test_orthologs.py`
- `mypy --config-file mypy.ini library/orthologs.py`


------
https://chatgpt.com/codex/tasks/task_e_68ca7b6610748324b0ea03d811559070