### PR TITLE
Add shared CLI utilities and tests

### DIFF
--- a/library/cli_common.py
+++ b/library/cli_common.py
@@ -1,0 +1,154 @@
+"""Shared utilities for command-line interfaces."""
+
+from __future__ import annotations
+
+import shlex
+import sys
+from argparse import Namespace
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from library.io_utils import serialise_cell
+from library.metadata import write_meta_yaml
+
+_EXCLUDED_CONFIG_KEYS = frozenset({"output", "errors_output", "meta_output"})
+
+
+def ensure_output_dir(path: Path) -> Path:
+    """Ensure that the parent directory of ``path`` exists.
+
+    Parameters
+    ----------
+    path:
+        Destination file path.
+
+    Returns
+    -------
+    Path
+        The normalised ``Path`` object pointing to the destination file.
+
+    Raises
+    ------
+    ValueError
+        Raised when ``path`` does not reference a file name.
+    """
+
+    target = Path(path)
+    if target.name == "":
+        msg = "Output path must include a file name"
+        raise ValueError(msg)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def serialise_dataframe(df: pd.DataFrame, list_format: str) -> pd.DataFrame:
+    """Serialise non-scalar dataframe columns for CSV output.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing data destined for CSV output.
+    list_format:
+        Desired representation for list-like values. Accepted values are
+        ``"json"`` and ``"pipe"``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A new dataframe with the same shape as ``df`` where complex values are
+        serialised into deterministic strings.
+    """
+
+    result = df.copy()
+    for column in result.columns:
+        result[column] = result[column].map(
+            lambda value: serialise_cell(value, list_format)
+        )
+    return result
+
+
+def prepare_cli_config(
+    namespace: Namespace | Mapping[str, Any],
+    *,
+    exclude_keys: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Normalise CLI arguments into a serialisable mapping.
+
+    Parameters
+    ----------
+    namespace:
+        Source of configuration values. Typically an
+        :class:`argparse.Namespace`, but any mapping is accepted.
+    exclude_keys:
+        Iterable of keys that should be omitted from the result. When omitted,
+        standard output-related keys are ignored.
+
+    Returns
+    -------
+    dict[str, Any]
+        Dictionary representation of the namespace with :class:`~pathlib.Path`
+        values converted to strings for YAML serialisation.
+    """
+
+    excluded = set(_EXCLUDED_CONFIG_KEYS if exclude_keys is None else exclude_keys)
+    items = (
+        namespace.items() if isinstance(namespace, Mapping) else vars(namespace).items()
+    )
+
+    normalised: dict[str, Any] = {}
+    for key, value in items:
+        if key in excluded:
+            continue
+        normalised[key] = str(value) if isinstance(value, Path) else value
+    return normalised
+
+
+def write_cli_metadata(
+    output_path: Path,
+    *,
+    row_count: int,
+    column_count: int,
+    namespace: Namespace | Mapping[str, Any],
+    command_parts: Sequence[str] | None = None,
+    meta_path: Path | None = None,
+) -> Path:
+    """Persist a ``.meta.yaml`` companion file next to ``output_path``.
+
+    Parameters
+    ----------
+    output_path:
+        CSV file produced by the CLI.
+    row_count:
+        Number of rows present in the output CSV.
+    column_count:
+        Number of columns present in the output CSV.
+    namespace:
+        CLI arguments used to produce the dataset. Converted to a serialisable
+        mapping via :func:`prepare_cli_config`.
+    command_parts:
+        Sequence of command line arguments used to invoke the CLI. When
+        omitted, the function falls back to :data:`sys.argv`.
+    meta_path:
+        Optional override for the metadata file location. Defaults to
+        ``<output_path>.meta.yaml``.
+
+    Returns
+    -------
+    Path
+        Path to the written metadata file.
+    """
+
+    command_sequence = command_parts if command_parts is not None else tuple(sys.argv)
+    command = " ".join(shlex.quote(part) for part in command_sequence)
+    config = prepare_cli_config(namespace)
+    return write_meta_yaml(
+        Path(output_path),
+        command=command,
+        config=config,
+        row_count=row_count,
+        column_count=column_count,
+        meta_path=meta_path,
+    )

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -1,0 +1,113 @@
+"""Unit tests for :mod:`library.cli_common`."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# ruff: noqa: E402
+from library.cli_common import (
+    ensure_output_dir,
+    prepare_cli_config,
+    serialise_dataframe,
+    write_cli_metadata,
+)
+
+
+def test_ensure_output_dir_creates_parent(tmp_path: Path) -> None:
+    """The helper should create intermediate directories when necessary."""
+
+    destination = tmp_path / "nested" / "output.csv"
+    result = ensure_output_dir(destination)
+
+    assert destination.parent.exists()
+    assert result == destination
+
+
+def test_ensure_output_dir_requires_filename() -> None:
+    """An explicit file name is required to avoid ambiguous destinations."""
+
+    with pytest.raises(ValueError):
+        ensure_output_dir(Path(""))
+
+
+def test_serialise_dataframe_preserves_original() -> None:
+    """Non-scalar values should be serialised without mutating the input."""
+
+    df = pd.DataFrame(
+        {
+            "dict_col": [{"x": 1}, {"y": 2}],
+            "list_col": [[1, 2], ["pipe", "value"]],
+            "str_col": ["pipe|value", "plain"],
+        }
+    )
+
+    serialised = serialise_dataframe(df, "pipe")
+
+    assert serialised is not df
+    assert df.loc[0, "dict_col"] == {"x": 1}
+    assert json.loads(serialised.loc[0, "dict_col"]) == {"x": 1}
+    assert serialised.loc[0, "list_col"] == "1|2"
+    assert serialised.loc[0, "str_col"] == "pipe\\|value"
+
+
+def test_prepare_cli_config_normalises_paths(tmp_path: Path) -> None:
+    """Configuration extraction should serialise paths and drop output keys."""
+
+    namespace = argparse.Namespace(
+        input=tmp_path / "input.csv",
+        output=tmp_path / "out.csv",
+        errors_output=None,
+        meta_output=None,
+        limit=5,
+    )
+
+    config = prepare_cli_config(namespace)
+
+    assert "output" not in config
+    assert "errors_output" not in config
+    assert "meta_output" not in config
+    assert config["input"] == str(tmp_path / "input.csv")
+    assert config["limit"] == 5
+
+
+def test_write_cli_metadata_produces_expected_yaml(tmp_path: Path) -> None:
+    """Metadata writer should honour command quoting and config normalisation."""
+
+    output_path = tmp_path / "reports" / "dataset.csv"
+    ensure_output_dir(output_path)
+    output_path.write_text("col\nvalue\n", encoding="utf-8")
+
+    namespace = argparse.Namespace(
+        input=tmp_path / "input.csv",
+        output=str(output_path),
+        errors_output=None,
+        meta_output=None,
+        limit=7,
+    )
+
+    meta_file = write_cli_metadata(
+        output_path,
+        row_count=1,
+        column_count=1,
+        namespace=namespace,
+        command_parts=["chembl", "--flag", "value with space"],
+    )
+
+    assert meta_file == output_path.with_suffix(".csv.meta.yaml")
+    payload = yaml.safe_load(meta_file.read_text(encoding="utf-8"))
+    assert payload["command"] == "chembl --flag 'value with space'"
+    assert payload["config"]["input"] == str(tmp_path / "input.csv")
+    assert "output" not in payload["config"]
+    assert payload["rows"] == 1
+    assert payload["columns"] == 1


### PR DESCRIPTION
## Summary
- add a `library.cli_common` helper module for directory handling, dataframe serialisation and metadata output
- refactor the ChEMBL activities and test items CLI entry points to use the shared helpers
- expose the PubChem HTTP session from `_PubChemRequest` and streamline CID fetching
- cover the new helpers with focused unit tests

## Testing
- `pytest tests/test_cli_common.py`
- `pytest tests/test_cli.py tests/test_cli_logging_redaction.py tests/test_chembl_activities_pipeline.py tests/test_chembl_testitems_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68cab286811c83249736438c02c274ac