### PR TITLE
Expose PubChem CLI retry tuning and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,25 @@ All command line entry points accept `--log-format` to switch between the
 default human-readable output and structured JSON logs, complementing the
 existing `--log-level` control.
 
+#### `chembl_testitems_main.py`
+
+The `chembl_testitems_main.py` CLI fetches molecule metadata from ChEMBL and
+optionally enriches the results with PubChem descriptors.  In addition to the
+existing `--pubchem-timeout`, `--pubchem-base-url`, and `--pubchem-user-agent`
+flags, the following options fine-tune the PubChem HTTP client:
+
+* `--pubchem-max-retries` – maximum retry attempts before giving up (default:
+  `3`).
+* `--pubchem-rps` – allowed PubChem requests per second (default: `5.0`).
+* `--pubchem-backoff` – exponential backoff multiplier applied between
+  retries (default: `1.0`).
+* `--pubchem-retry-penalty` – additional cooldown in seconds added after each
+  retry cycle (default: `5.0`).
+
+Combine these parameters to comply with local rate limits or API usage
+guidelines.  All supplied values are captured in the CLI metadata sidecar to
+aid reproducibility.
+
 ## Library
 
 The `library/` directory contains the core logic of the pipeline, organized into several modules:

--- a/data/output/output.testitem_all.csv.meta.yaml
+++ b/data/output/output.testitem_all.csv.meta.yaml
@@ -18,6 +18,10 @@ config:
   dictionary: null
   smiles_column: canonical_smiles
   pubchem_timeout: 10.0
+  pubchem_max_retries: 3
+  pubchem_rps: 5.0
+  pubchem_backoff: 1.0
+  pubchem_retry_penalty: 5.0
   pubchem_base_url: https://pubchem.ncbi.nlm.nih.gov/rest/pug
   pubchem_user_agent: ChEMBLDataAcquisition/1.0
   dry_run: false

--- a/library/testitem_library.py
+++ b/library/testitem_library.py
@@ -182,6 +182,12 @@ class _PubChemRequest:
     properties: Sequence[str]
     http_client: HttpClient
 
+    @property
+    def session(self) -> requests.Session:
+        """Expose the underlying :class:`requests.Session` for convenience."""
+
+        return self.http_client.session
+
     def _get_json(
         self,
         url: str,

--- a/tests/test_chembl_testitems_main.py
+++ b/tests/test_chembl_testitems_main.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+chembl_testitems_main = importlib.import_module("scripts.chembl_testitems_main")
+
+
+def test_run_pipeline_passes_pubchem_http_client_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = chembl_testitems_main
+
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("molecule_chembl_id\nCHEMBL1\n", encoding="utf-8")
+
+    output_csv = tmp_path / "out.csv"
+
+    captured: dict[str, Any] = {}
+
+    class DummyClient:  # pragma: no cover - simple stub
+        def __init__(self, **kwargs: Any) -> None:
+            captured["chembl_client"] = kwargs
+
+    def fake_get_testitems(
+        _client: Any, molecule_ids: Any, *, chunk_size: int
+    ) -> pd.DataFrame:
+        captured["chunk_size"] = chunk_size
+        ids = list(molecule_ids)
+        return pd.DataFrame(
+            {
+                "molecule_chembl_id": ids,
+                "canonical_smiles": ["C"] * len(ids),
+            }
+        )
+
+    def fake_normalize(df: pd.DataFrame) -> pd.DataFrame:
+        return df
+
+    def fake_add_pubchem_data(
+        df: pd.DataFrame,
+        *,
+        smiles_column: str,
+        timeout: float,
+        base_url: str,
+        user_agent: str,
+        http_client_config: dict[str, Any] | None = None,
+        **_: Any,
+    ) -> pd.DataFrame:
+        captured["pubchem_kwargs"] = {
+            "smiles_column": smiles_column,
+            "timeout": timeout,
+            "base_url": base_url,
+            "user_agent": user_agent,
+        }
+        captured["http_client_config"] = http_client_config
+        return df
+
+    def fake_validate(
+        df: pd.DataFrame,
+        schema: Any = None,
+        *,
+        errors_path: Path,
+    ) -> pd.DataFrame:
+        _ = schema
+        captured["errors_path"] = errors_path
+        return df
+
+    def fake_write_meta_yaml(
+        output_path: Path,
+        *,
+        command: str,
+        config: dict[str, Any],
+        row_count: int,
+        column_count: int,
+        meta_path: Path | None,
+    ) -> None:
+        captured["meta_output_path"] = output_path
+        captured["meta_command"] = command
+        captured["meta_config"] = config
+        captured["meta_row_count"] = row_count
+        captured["meta_column_count"] = column_count
+        captured["meta_path"] = meta_path
+
+    monkeypatch.setattr(module, "ChemblClient", DummyClient)
+    monkeypatch.setattr(module, "get_testitems", fake_get_testitems)
+    monkeypatch.setattr(module, "normalize_testitems", fake_normalize)
+    monkeypatch.setattr(module, "add_pubchem_data", fake_add_pubchem_data)
+    monkeypatch.setattr(module, "validate_testitems", fake_validate)
+    monkeypatch.setattr(module, "write_meta_yaml", fake_write_meta_yaml)
+    monkeypatch.setattr(module, "analyze_table_quality", lambda *_, **__: None)
+
+    argv = [
+        "--input",
+        str(input_csv),
+        "--output",
+        str(output_csv),
+        "--pubchem-max-retries",
+        "9",
+        "--pubchem-rps",
+        "1.5",
+        "--pubchem-backoff",
+        "2.0",
+        "--pubchem-retry-penalty",
+        "7.5",
+    ]
+    args = module.parse_args(argv)
+
+    exit_code = module.run_pipeline(
+        args,
+        command_parts=["chembl_testitems_main.py", *argv],
+    )
+
+    assert exit_code == 0
+    assert output_csv.exists()
+    assert captured["http_client_config"] == {
+        "max_retries": 9,
+        "rps": 1.5,
+        "backoff_multiplier": 2.0,
+        "retry_penalty_seconds": 7.5,
+    }
+    assert captured["meta_config"]["pubchem_max_retries"] == 9
+    assert captured["meta_config"]["pubchem_rps"] == 1.5
+    assert captured["meta_config"]["pubchem_backoff"] == 2.0
+    assert captured["meta_config"]["pubchem_retry_penalty"] == 7.5
+    assert captured["chunk_size"] == args.chunk_size

--- a/tests/test_chembl_testitems_pipeline.py
+++ b/tests/test_chembl_testitems_pipeline.py
@@ -111,13 +111,21 @@ def test_chembl_testitems_main_end_to_end(
 
     requests_mock.get(
         f"{pubchem_base}/compound/smiles/C/property/"
-        "CID,MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
+        "MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
         json=_pubchem_response(11, "CH4"),
     )
     requests_mock.get(
         f"{pubchem_base}/compound/smiles/CC/property/"
-        "CID,MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
+        "MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
         json=_pubchem_response(22, "C2H6"),
+    )
+    requests_mock.get(
+        f"{pubchem_base}/compound/smiles/C/cids/JSON",
+        json={"IdentifierList": {"CID": [11]}},
+    )
+    requests_mock.get(
+        f"{pubchem_base}/compound/smiles/CC/cids/JSON",
+        json={"IdentifierList": {"CID": [22]}},
     )
 
     output_csv = tmp_path / "out.csv"


### PR DESCRIPTION
## Summary
- add PubChem retry, rate, and backoff tuning flags to the ChEMBL test items CLI and forward them to the enrichment helper
- expose the underlying requests session on `_PubChemRequest` so the CLI can reuse the existing HttpClient wiring
- document the new knobs, refresh the metadata sample, and extend the automated tests to cover the configuration plumbing

## Testing
- `pytest tests/test_chembl_testitems_main.py tests/test_chembl_testitems_pipeline.py`
- `ruff check scripts/chembl_testitems_main.py library/testitem_library.py tests/test_chembl_testitems_main.py tests/test_chembl_testitems_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68cab276ca748324b910bef032ec4cd6