### PR TITLE
Stream ChEMBL to UniProt mapping input and add load test

### DIFF
--- a/library/chembl2uniprot/logging_utils.py
+++ b/library/chembl2uniprot/logging_utils.py
@@ -7,10 +7,17 @@ centralised utilities located in :mod:`library.logging_utils`.
 
 from __future__ import annotations
 
-from library.logging_utils import (
-    JsonFormatter,
-    SecretRedactingFilter,
-    configure_logging,
-)
+try:
+    from library.logging_utils import (
+        JsonFormatter,
+        SecretRedactingFilter,
+        configure_logging,
+    )
+except ModuleNotFoundError:  # pragma: no cover - fallback for direct package import
+    from logging_utils import (  # type: ignore[attr-defined]
+        JsonFormatter,
+        SecretRedactingFilter,
+        configure_logging,
+    )
 
 __all__ = ["JsonFormatter", "SecretRedactingFilter", "configure_logging"]

--- a/library/chembl2uniprot/mapping.py
+++ b/library/chembl2uniprot/mapping.py
@@ -7,19 +7,21 @@ Algorithm Notes
 ---------------
 1. Read and validate the YAML configuration file to obtain column names,
    network settings and batching parameters.
-2. Load the input CSV, normalise and deduplicate the ChEMBL identifiers and
-   split them into batches.
+2. Stream the input CSV lazily, normalise and deduplicate the ChEMBL
+   identifiers and split them into batches without materialising the full
+   dataset in memory.
 3. For each batch, submit an ID mapping job to the UniProt service, polling
    for completion when necessary and fetching the resulting mapping.
-4. Combine all retrieved mappings, merge them back into the original DataFrame
-   and emit a CSV with an additional column containing the UniProt IDs.
+4. Combine all retrieved mappings and write the augmented CSV row by row while
+   appending the UniProt identifiers as an additional column.
 """
 
 from __future__ import annotations
 
+import csv
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Sequence, cast, Literal
+from typing import Any, Dict, Iterable, Iterator, List, Set, cast, Literal
 import hashlib
 import json
 import logging
@@ -49,25 +51,77 @@ LOGGER = logging.getLogger(__name__)
 # Helper classes and functions
 
 
-def _chunked(seq: Sequence[str], size: int) -> Iterable[List[str]]:
-    """Yield ``seq`` in chunks of ``size``.
+def _chunked(seq: Iterable[str], size: int) -> Iterator[List[str]]:
+    """Yield ``seq`` in lists containing at most ``size`` elements.
 
     Parameters
     ----------
     seq:
-        The sequence to chunk.
+        The iterable to chunk. The iterable is consumed lazily which makes the
+        helper suitable for generators.
     size:
-        The size of each chunk.
+        The maximum size of each chunk. ``size`` must be a positive integer.
 
     Returns
     -------
-    Iterable[List[str]]
-        An iterable of lists, where each list is a chunk of the original
-        sequence.
+    Iterator[List[str]]
+        An iterator over lists containing up to ``size`` elements from
+        ``seq``.
     """
 
-    for i in range(0, len(seq), size):
-        yield list(seq[i : i + size])
+    if size <= 0:
+        raise ValueError("size must be positive")
+
+    chunk: List[str] = []
+    for item in seq:
+        chunk.append(item)
+        if len(chunk) == size:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
+
+
+def _stream_unique_ids(
+    path: Path, column: str, *, sep: str, encoding: str
+) -> Iterator[str]:
+    """Yield trimmed, unique identifiers from a CSV column lazily.
+
+    Parameters
+    ----------
+    path:
+        CSV file that stores the raw identifiers.
+    column:
+        Name of the column containing the identifier values.
+    sep:
+        Column separator used in the CSV file.
+    encoding:
+        Text encoding used to decode the CSV file.
+
+    Yields
+    ------
+    Iterator[str]
+        Unique identifier strings in order of appearance with surrounding
+        whitespace removed. Empty values and case-insensitive ``"nan"``
+        literals are skipped.
+    """
+
+    with path.open("r", encoding=encoding, newline="") as handle:
+        reader = csv.DictReader(handle, delimiter=sep)
+        if reader.fieldnames is None or column not in reader.fieldnames:
+            msg = f"Missing required column '{column}'"
+            raise KeyError(msg)
+
+        seen: Set[str] = set()
+        for row in reader:
+            raw_value = row.get(column)
+            if raw_value is None:
+                continue
+            value = str(raw_value).strip()
+            if not value or value.lower() == "nan" or value in seen:
+                continue
+            seen.add(value)
+            yield value
 
 
 @dataclass
@@ -501,18 +555,14 @@ def map_chembl_to_uniprot(
     delimiter = cfg.io.csv.multivalue_delimiter
 
     # Compute SHA256 of input file for logging purposes
+    hasher = hashlib.sha256()
     with input_csv_path.open("rb") as fh:
-        file_hash = hashlib.sha256(fh.read()).hexdigest()
+        for chunk in iter(lambda: fh.read(8192), b""):
+            if not chunk:
+                break
+            hasher.update(chunk)
+    file_hash = hasher.hexdigest()
     LOGGER.info("Input file checksum (sha256): %s", file_hash)
-
-    df = pd.read_csv(input_csv_path, sep=sep, encoding=encoding_in)
-    if chembl_col not in df.columns:
-        raise ValueError(f"Missing required column '{chembl_col}' in input CSV")
-
-    # Normalise and deduplicate identifiers
-    unique_ids = get_ids_from_dataframe(df, chembl_col)
-
-    LOGGER.info("Processing %d unique ChEMBL IDs", len(unique_ids))
 
     batch_size = cfg.batch.size
     timeout = cfg.network.timeout_sec
@@ -520,45 +570,70 @@ def map_chembl_to_uniprot(
     rate_limiter = RateLimiter(cfg.uniprot.rate_limit.rps)
 
     mapping: Dict[str, List[str]] = {}
-    for batch in _chunked(unique_ids, batch_size):
-        batch_mapping = _map_batch(batch, cfg.uniprot, rate_limiter, timeout, retry_cfg)
-        mapping.update(batch_mapping)
+    unique_count = 0
+    try:
+        id_iter = _stream_unique_ids(
+            input_csv_path, chembl_col, sep=sep, encoding=encoding_in
+        )
+        for batch in _chunked(id_iter, batch_size):
+            unique_count += len(batch)
+            batch_mapping = _map_batch(
+                batch, cfg.uniprot, rate_limiter, timeout, retry_cfg
+            )
+            for key, value in batch_mapping.items():
+                if not key:
+                    continue
+                normalised_key = str(key).strip()
+                if not normalised_key:
+                    continue
+                mapping[normalised_key] = value
+    except KeyError as exc:
+        msg = f"Missing required column '{chembl_col}' in input CSV"
+        raise ValueError(msg) from exc
+
+    LOGGER.info("Processing %d unique ChEMBL IDs", unique_count)
 
     mapped = sum(1 for v in mapping.values() if v)
-    no_match = len(unique_ids) - mapped
+    no_match = unique_count - mapped
     multi = sum(1 for v in mapping.values() if len(v) > 1)
     LOGGER.info(
         "Summary: unique=%d mapped=%d no_match=%d multi=%d",
-        len(unique_ids),
+        unique_count,
         mapped,
         no_match,
         multi,
     )
 
-    def _join_ids(x: str | float | None) -> str | None:
-        """Join a list of UniProt IDs into a single delimited string.
+    with (
+        input_csv_path.open("r", encoding=encoding_in, newline="") as src,
+        output_csv_path.open("w", encoding=encoding_out, newline="") as dst,
+    ):
+        reader = csv.DictReader(src, delimiter=sep)
+        if reader.fieldnames is None or chembl_col not in reader.fieldnames:
+            msg = f"Missing required column '{chembl_col}' in input CSV"
+            raise ValueError(msg)
 
-        This function is designed to be used with `pandas.Series.map`.
+        fieldnames = list(reader.fieldnames)
+        if out_col not in fieldnames:
+            fieldnames.append(out_col)
 
-        Parameters
-        ----------
-        x:
-            The ChEMBL ID to look up in the mapping.
+        writer = csv.DictWriter(dst, fieldnames=fieldnames, delimiter=sep)
+        writer.writeheader()
 
-        Returns
-        -------
-        str | None
-            A delimited string of UniProt IDs, or None if no mapping exists.
-        """
-        if x is None or x != x:  # NaN check
-            return None
-        ids = mapping.get(str(x).strip())
-        if not ids:
-            return None
-        return delimiter.join(ids)
+        for row in reader:
+            raw_value = row.get(chembl_col)
+            if raw_value is None:
+                row[out_col] = ""
+            else:
+                stripped = str(raw_value).strip()
+                if not stripped or stripped.lower() == "nan":
+                    row[out_col] = ""
+                else:
+                    ids = mapping.get(stripped)
+                    row[out_col] = delimiter.join(ids) if ids else ""
+            writer.writerow(row)
 
-    df[out_col] = df[chembl_col].map(_join_ids)
-
-    df.to_csv(output_csv_path, sep=sep, encoding=encoding_out, index=False)
-    analyze_table_quality(df, table_name=str(Path(output_csv_path).with_suffix("")))
+    analyze_table_quality(
+        output_csv_path, table_name=str(Path(output_csv_path).with_suffix(""))
+    )
     return output_csv_path

--- a/scripts/chembl2uniprot_main.py
+++ b/scripts/chembl2uniprot_main.py
@@ -92,6 +92,10 @@ def main(argv: list[str] | None = None) -> None:
             output_csv_path=Path(args.output) if args.output else None,
             config_path=config_path,
             schema_path=schema_path,
+            log_level=args.log_level,
+            log_format=args.log_format,
+            sep=args.sep,
+            encoding=args.encoding,
         )
     else:
         cfg_path = ROOT / "config.yaml"
@@ -101,6 +105,10 @@ def main(argv: list[str] | None = None) -> None:
             config_path=cfg_path,
             schema_path=schema,
             config_section="chembl2uniprot",
+            log_level=args.log_level,
+            log_format=args.log_format,
+            sep=args.sep,
+            encoding=args.encoding,
         )
 
     print(output)

--- a/tests/test_chembl2uniprot_cli.py
+++ b/tests/test_chembl2uniprot_cli.py
@@ -1,0 +1,139 @@
+"""Tests for the :mod:`chembl2uniprot` command line interface."""
+
+from __future__ import annotations
+
+import csv
+import itertools
+import math
+import tracemalloc
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import chembl2uniprot_main
+
+SCHEMA_SOURCE = Path(__file__).parent / "data" / "config" / "config.schema.json"
+CONFIG_TEMPLATE = """
+io:
+  input:
+    encoding: "utf-8"
+  output:
+    encoding: "utf-8"
+  csv:
+    separator: ","
+    multivalue_delimiter: "|"
+columns:
+  chembl_id: "target_chembl_id"
+  uniprot_out: "mapped_uniprot_id"
+uniprot:
+  base_url: "https://rest.uniprot.org"
+  id_mapping:
+    endpoint: "/idmapping/run"
+    status_endpoint: "/idmapping/status"
+    results_endpoint: "/idmapping/results"
+    from_db: "ChEMBL"
+    to_db: "UniProtKB"
+  polling:
+    interval_sec: 0
+  rate_limit:
+    rps: 1000
+  retry:
+    max_attempts: 1
+    backoff_sec: 0
+network:
+  timeout_sec: 30
+batch:
+  size: {batch_size}
+logging:
+  level: "ERROR"
+  format: "human"
+"""
+
+
+def test_cli_handles_large_input_without_memory_spikes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Ensure the CLI processes large files lazily and stays within memory limits."""
+
+    total_rows = 100_000
+    batch_size = 1_000
+
+    input_path = tmp_path / "input.csv"
+    output_path = tmp_path / "output.csv"
+    config_path = tmp_path / "config.yaml"
+    schema_path = tmp_path / "config.schema.json"
+
+    config_path.write_text(
+        CONFIG_TEMPLATE.format(batch_size=batch_size), encoding="utf-8"
+    )
+    schema_path.write_text(SCHEMA_SOURCE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    with input_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["target_chembl_id"])
+        for idx in range(total_rows):
+            writer.writerow([f"CHEMBL{idx}"])
+
+    batch_sizes: list[int] = []
+    counter = itertools.count()
+
+    def fake_map_batch(ids, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+        batch_sizes.append(len(ids))
+        return {identifier: [f"UP{next(counter)}"] for identifier in ids}
+
+    import chembl2uniprot.mapping as mapping_module
+
+    monkeypatch.setattr(mapping_module, "_map_batch", fake_map_batch)
+    monkeypatch.setattr(
+        mapping_module,
+        "analyze_table_quality",
+        lambda *args, **kwargs: (None, None),
+    )
+
+    def _fail_read_csv(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError(
+            "pandas.read_csv should not be invoked during streaming execution"
+        )
+
+    monkeypatch.setattr(pd, "read_csv", _fail_read_csv)
+
+    tracemalloc.start()
+    chembl2uniprot_main.main(
+        [
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--config",
+            str(config_path),
+            "--log-level",
+            "ERROR",
+            "--log-format",
+            "human",
+            "--sep",
+            ",",
+            "--encoding",
+            "utf-8",
+        ]
+    )
+    current, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    captured = capsys.readouterr()
+    assert str(output_path) in captured.out
+
+    assert batch_sizes
+    assert max(batch_sizes) <= batch_size
+    assert len(batch_sizes) == math.ceil(total_rows / batch_size)
+
+    assert peak < 80 * 1024 * 1024, f"Peak memory too high: {peak} bytes"
+    assert current < peak
+
+    with output_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        assert reader.fieldnames is not None
+        assert reader.fieldnames[-1] == "mapped_uniprot_id"
+        first_rows = [next(reader) for _ in range(3)]
+
+    assert [row["mapped_uniprot_id"] for row in first_rows] == ["UP0", "UP1", "UP2"]


### PR DESCRIPTION
## Summary
- stream the ChEMBL→UniProt mapper by reading identifiers lazily, batching them without duplicating memory and writing the enriched CSV row by row
- add import fallbacks so the logging helpers remain usable when the chembl2uniprot package is imported directly from the library directory
- pass CLI overrides for logging/CSV options through to the mapper and cover the streaming workflow with a 100k-row load test that stubs the UniProt API

## Testing
- black library/chembl2uniprot/mapping.py scripts/chembl2uniprot_main.py tests/test_chembl2uniprot_cli.py
- ruff check library/chembl2uniprot/mapping.py scripts/chembl2uniprot_main.py tests/test_chembl2uniprot_cli.py library/chembl2uniprot/logging_utils.py
- mypy --config-file mypy.ini library/chembl2uniprot/mapping.py scripts/chembl2uniprot_main.py tests/test_chembl2uniprot_cli.py
- pytest tests/test_mapping.py tests/test_chembl2uniprot_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cae2a007b8832497de0ecea16d0dd3