### PR TITLE
Improve UniProt mapping pagination and failed ID handling

### DIFF
--- a/library/chembl2uniprot/mapping.py
+++ b/library/chembl2uniprot/mapping.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Sequence, cast, Literal
+from urllib.parse import urljoin
 import hashlib
 import json
 import logging
@@ -43,6 +44,10 @@ except ModuleNotFoundError:  # pragma: no cover
     from ..data_profiling import analyze_table_quality
 
 LOGGER = logging.getLogger(__name__)
+
+
+FAILED_IDS_ERROR_THRESHOLD = 100
+"""Maximum acceptable number of failed identifiers per UniProt job."""
 
 
 # ---------------------------------------------------------------------------
@@ -103,6 +108,72 @@ class RateLimiter:
         if delta < interval:
             time.sleep(interval - delta)
         self.last_call = time.monotonic()
+
+
+@dataclass
+class BatchMappingResult:
+    """Container for the mapping output of a single batch.
+
+    Attributes
+    ----------
+    mapping:
+        Mapping from the original ChEMBL identifiers to the resolved UniProt
+        accessions.
+    failed_ids:
+        Identifiers reported by UniProt in the ``failedIds`` field or inferred
+        as unresolved when the job could not be completed.
+    """
+
+    mapping: Dict[str, List[str]]
+    failed_ids: List[str]
+
+
+def _normalise_failed_ids(raw_failed: Any) -> List[str]:
+    """Normalise the content of a ``failedIds`` payload to a list of strings."""
+
+    if not raw_failed:
+        return []
+
+    if isinstance(raw_failed, list):
+        items = raw_failed
+    else:
+        items = [raw_failed]
+
+    normalised: List[str] = []
+    for item in items:
+        if item is None:
+            continue
+        if isinstance(item, dict):
+            candidate = (
+                item.get("from")
+                or item.get("id")
+                or item.get("identifier")
+                or str(item)
+            )
+        else:
+            candidate = str(item)
+        text = str(candidate).strip()
+        if text:
+            normalised.append(text)
+    return normalised
+
+
+def _log_and_maybe_raise_failed_ids(job_id: str, failed_ids: Sequence[str]) -> None:
+    """Emit diagnostics about failed identifiers and enforce the threshold."""
+
+    if not failed_ids:
+        return
+    LOGGER.warning(
+        "UniProt job %s reported %d failed identifiers: %s",
+        job_id,
+        len(failed_ids),
+        list(failed_ids),
+    )
+    if len(failed_ids) > FAILED_IDS_ERROR_THRESHOLD:
+        raise RuntimeError(
+            "UniProt job %s reported %d failed identifiers (threshold %d)"
+            % (job_id, len(failed_ids), FAILED_IDS_ERROR_THRESHOLD)
+        )
 
 
 def get_ids_from_dataframe(df: pd.DataFrame, column: str) -> List[str]:
@@ -309,7 +380,7 @@ def _fetch_results(
     rate_limiter: RateLimiter,
     timeout: float,
     retry_cfg: RetryConfig,
-) -> Dict[str, List[str]]:
+) -> BatchMappingResult:
     """Fetch the results of a completed UniProt ID mapping job.
 
     Parameters
@@ -327,8 +398,8 @@ def _fetch_results(
 
     Returns
     -------
-    Dict[str, List[str]]
-        A dictionary mapping the original ChEMBL IDs to lists of UniProt IDs.
+    BatchMappingResult
+        Combined mapping information and failed identifiers for the job.
     """
     results_url = (
         cfg.base_url.rstrip("/")
@@ -336,27 +407,40 @@ def _fetch_results(
         + "/"
         + job_id
     )
-    resp = _request_with_retry(
-        "get",
-        results_url,
-        timeout=timeout,
-        rate_limiter=rate_limiter,
-        max_attempts=retry_cfg.max_attempts,
-        backoff=retry_cfg.backoff_sec,
-    )
-    try:
-        payload = resp.json()
-    except json.JSONDecodeError:
-        LOGGER.debug("Unparseable results response: %s", resp.text)
-        raise
-
     mapping: Dict[str, List[str]] = {}
-    for item in payload.get("results", []):
-        frm = item.get("from")
-        to = item.get("to")
-        if frm and to:
-            mapping.setdefault(frm, []).append(to)
-    return mapping
+    failed_ids: List[str] = []
+    next_url: str | None = results_url
+
+    while next_url:
+        resp = _request_with_retry(
+            "get",
+            next_url,
+            timeout=timeout,
+            rate_limiter=rate_limiter,
+            max_attempts=retry_cfg.max_attempts,
+            backoff=retry_cfg.backoff_sec,
+        )
+        try:
+            payload = resp.json()
+        except json.JSONDecodeError:
+            LOGGER.debug("Unparseable results response: %s", resp.text)
+            raise
+
+        for item in payload.get("results", []):
+            frm = item.get("from")
+            to = item.get("to")
+            if frm and to:
+                mapping.setdefault(frm, []).append(to)
+        failed_ids.extend(_normalise_failed_ids(payload.get("failedIds")))
+
+        next_link = payload.get("next")
+        if next_link:
+            next_url = urljoin(results_url, next_link)
+        else:
+            next_url = None
+
+    _log_and_maybe_raise_failed_ids(job_id, failed_ids)
+    return BatchMappingResult(mapping=mapping, failed_ids=failed_ids)
 
 
 def _map_batch(
@@ -365,7 +449,7 @@ def _map_batch(
     rate_limiter: RateLimiter,
     timeout: float,
     retry_cfg: RetryConfig,
-) -> Dict[str, List[str]]:
+) -> BatchMappingResult:
     """Map a batch of ChEMBL IDs to UniProt IDs.
 
     This function handles both synchronous and asynchronous UniProt API
@@ -386,14 +470,14 @@ def _map_batch(
 
     Returns
     -------
-    Dict[str, List[str]]
-        A dictionary mapping ChEMBL IDs to lists of UniProt IDs for the batch.
+    BatchMappingResult
+        Structured information about the resolved mappings and failed IDs.
     """
     try:
         job_payload = _start_job(ids, cfg, rate_limiter, timeout, retry_cfg)
     except Exception as exc:
         LOGGER.warning("Failed to start mapping job for batch %s: %s", ids, exc)
-        return {}
+        return BatchMappingResult(mapping={}, failed_ids=list(ids))
 
     if "jobId" in job_payload:
         job_id = job_payload["jobId"]
@@ -402,7 +486,7 @@ def _map_batch(
             return _fetch_results(job_id, cfg, rate_limiter, timeout, retry_cfg)
         except Exception as exc:  # broad but logged
             LOGGER.warning("Job %s failed: %s", job_id, exc)
-            return {}
+            return BatchMappingResult(mapping={}, failed_ids=list(ids))
 
     # Synchronous result
     if "results" in job_payload:
@@ -412,10 +496,12 @@ def _map_batch(
             to = item.get("to")
             if frm and to:
                 mapping.setdefault(frm, []).append(to)
-        return mapping
+        failed_ids = _normalise_failed_ids(job_payload.get("failedIds"))
+        _log_and_maybe_raise_failed_ids("synchronous", failed_ids)
+        return BatchMappingResult(mapping=mapping, failed_ids=failed_ids)
 
     LOGGER.warning("Unexpected response payload: %s", job_payload)
-    return {}
+    return BatchMappingResult(mapping={}, failed_ids=list(ids))
 
 
 def map_chembl_to_uniprot(
@@ -520,9 +606,18 @@ def map_chembl_to_uniprot(
     rate_limiter = RateLimiter(cfg.uniprot.rate_limit.rps)
 
     mapping: Dict[str, List[str]] = {}
+    failed_identifiers: List[str] = []
     for batch in _chunked(unique_ids, batch_size):
-        batch_mapping = _map_batch(batch, cfg.uniprot, rate_limiter, timeout, retry_cfg)
-        mapping.update(batch_mapping)
+        batch_result = _map_batch(batch, cfg.uniprot, rate_limiter, timeout, retry_cfg)
+        mapping.update(batch_result.mapping)
+        failed_identifiers.extend(batch_result.failed_ids)
+
+    if failed_identifiers:
+        LOGGER.warning(
+            "UniProt mapping reported %d failed identifiers: %s",
+            len(failed_identifiers),
+            failed_identifiers,
+        )
 
     mapped = sum(1 for v in mapping.values() if v)
     no_match = len(unique_ids) - mapped

--- a/tests/test_chembl2uniprot_mapping.py
+++ b/tests/test_chembl2uniprot_mapping.py
@@ -1,0 +1,194 @@
+"""Unit tests for :mod:`chembl2uniprot.mapping`."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, List
+
+import pytest
+
+from chembl2uniprot.config import (
+    IdMappingConfig,
+    PollingConfig,
+    RateLimitConfig,
+    RetryConfig,
+    UniprotConfig,
+)
+from chembl2uniprot.mapping import RateLimiter, _fetch_results, _map_batch
+
+
+@dataclass
+class _DummyResponse:
+    """Simple stand-in for :class:`requests.Response` objects."""
+
+    payload: Dict[str, Any]
+
+    def __post_init__(self) -> None:
+        self.status_code = 200
+        self.text = json.dumps(self.payload)
+
+    def json(self) -> Dict[str, Any]:
+        return self.payload
+
+
+@pytest.fixture
+def uniprot_cfg() -> UniprotConfig:
+    """Return a minimal UniProt configuration for tests."""
+
+    return UniprotConfig(
+        base_url="https://rest.uniprot.org",
+        id_mapping=IdMappingConfig(
+            endpoint="/idmapping/run",
+            status_endpoint="/idmapping/status",
+            results_endpoint="/idmapping/results",
+        ),
+        polling=PollingConfig(interval_sec=0.0),
+        rate_limit=RateLimitConfig(rps=10.0),
+        retry=RetryConfig(max_attempts=1, backoff_sec=0.0),
+    )
+
+
+def _make_request_stub(responses: Iterator[_DummyResponse]):
+    """Create a stub replacing :func:`_request_with_retry`."""
+
+    def _stub(
+        method: str,
+        url: str,
+        *,
+        timeout: float,
+        rate_limiter: RateLimiter,
+        max_attempts: int,
+        backoff: float,
+        **_: Any,
+    ) -> _DummyResponse:
+        try:
+            response = next(responses)
+        except StopIteration:  # pragma: no cover - defensive guard
+            raise AssertionError("Unexpected extra request for %s" % url) from None
+        return response
+
+    return _stub
+
+
+def test_fetch_results_handles_pagination(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    uniprot_cfg: UniprotConfig,
+) -> None:
+    """All result pages should be consumed and combined."""
+
+    payloads = iter(
+        [
+            _DummyResponse(
+                {
+                    "results": [{"from": "CHEMBL1", "to": "P1"}],
+                    "next": "/idmapping/results/123?cursor=abc",
+                }
+            ),
+            _DummyResponse(
+                {
+                    "results": [{"from": "CHEMBL2", "to": "P2"}],
+                    "failedIds": ["CHEMBL3"],
+                }
+            ),
+        ]
+    )
+    requested_urls: List[str] = []
+
+    def _tracking_stub(
+        method: str,
+        url: str,
+        *,
+        timeout: float,
+        rate_limiter: RateLimiter,
+        max_attempts: int,
+        backoff: float,
+        **kwargs: Any,
+    ) -> _DummyResponse:
+        requested_urls.append(url)
+        return _make_request_stub(payloads)(
+            method,
+            url,
+            timeout=timeout,
+            rate_limiter=rate_limiter,
+            max_attempts=max_attempts,
+            backoff=backoff,
+            **kwargs,
+        )
+
+    monkeypatch.setattr("chembl2uniprot.mapping._request_with_retry", _tracking_stub)
+
+    with caplog.at_level(logging.WARNING):
+        result = _fetch_results(
+            "123",
+            uniprot_cfg,
+            RateLimiter(0),
+            timeout=1.0,
+            retry_cfg=RetryConfig(max_attempts=1, backoff_sec=0.0),
+        )
+
+    assert result.mapping == {"CHEMBL1": ["P1"], "CHEMBL2": ["P2"]}
+    assert result.failed_ids == ["CHEMBL3"]
+    assert requested_urls == [
+        "https://rest.uniprot.org/idmapping/results/123",
+        "https://rest.uniprot.org/idmapping/results/123?cursor=abc",
+    ]
+    assert "CHEMBL3" in caplog.text
+
+
+def test_fetch_results_raises_when_failed_threshold_exceeded(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    uniprot_cfg: UniprotConfig,
+) -> None:
+    """A RuntimeError should be raised when too many IDs fail."""
+
+    responses = iter(
+        [
+            _DummyResponse({"results": [], "failedIds": ["CHEMBL1", "CHEMBL2"]}),
+        ]
+    )
+    monkeypatch.setattr(
+        "chembl2uniprot.mapping._request_with_retry",
+        _make_request_stub(responses),
+    )
+    monkeypatch.setattr("chembl2uniprot.mapping.FAILED_IDS_ERROR_THRESHOLD", 1)
+
+    with caplog.at_level(logging.WARNING), pytest.raises(RuntimeError):
+        _fetch_results(
+            "job-5",
+            uniprot_cfg,
+            RateLimiter(0),
+            timeout=1.0,
+            retry_cfg=RetryConfig(max_attempts=1, backoff_sec=0.0),
+        )
+
+    assert "CHEMBL1" in caplog.text
+    assert "job-5" in caplog.text
+
+
+def test_map_batch_returns_failed_ids(
+    monkeypatch: pytest.MonkeyPatch, uniprot_cfg: UniprotConfig
+) -> None:
+    """Synchronous responses should expose failed identifiers in the result."""
+
+    monkeypatch.setattr(
+        "chembl2uniprot.mapping._start_job",
+        lambda *_, **__: {  # type: ignore[misc]
+            "results": [{"from": "CHEMBL1", "to": "P1"}],
+            "failedIds": ["CHEMBL2"],
+        },
+    )
+
+    result = _map_batch(
+        ["CHEMBL1", "CHEMBL2"],
+        uniprot_cfg,
+        RateLimiter(0),
+        timeout=1.0,
+        retry_cfg=RetryConfig(max_attempts=1, backoff_sec=0.0),
+    )
+
+    assert result.mapping == {"CHEMBL1": ["P1"]}
+    assert result.failed_ids == ["CHEMBL2"]


### PR DESCRIPTION
## Summary
- add a BatchMappingResult container and helpers to normalise, log and bound failed UniProt identifiers
- page through UniProt mapping results while aggregating mappings/failed IDs and propagate them through _map_batch and map_chembl_to_uniprot
- cover pagination and failed ID scenarios with dedicated chembl2uniprot mapping tests

## Testing
- black library/chembl2uniprot/mapping.py tests/test_chembl2uniprot_mapping.py
- ruff check library/chembl2uniprot/mapping.py tests/test_chembl2uniprot_mapping.py
- mypy library/chembl2uniprot/mapping.py
- PYTHONPATH=. pytest tests/test_mapping.py tests/test_chembl2uniprot_mapping.py

------
https://chatgpt.com/codex/tasks/task_e_68cae29a7c788324ac0aff89d2a3e566