### PR TITLE
Add determinism tracking to metadata and CLI tests

### DIFF
--- a/library/testitem_library.py
+++ b/library/testitem_library.py
@@ -184,9 +184,7 @@ class _PubChemRequest:
 
     @property
     def session(self) -> requests.Session:
-
         """Expose the underlying :class:`requests.Session` for convenience."""
-
 
         return self.http_client.session
 
@@ -250,6 +248,7 @@ class _PubChemRequest:
         results: dict[str, object] = {}
 
         property_fields = list(dict.fromkeys(self.properties))
+        property_success = False
         if property_fields:
             url = (
                 f"{self.base_url.rstrip('/')}/compound/smiles/{encoded}/property/"
@@ -262,8 +261,9 @@ class _PubChemRequest:
                     record = properties[0]
                     for prop in property_fields:
                         results[prop] = _normalise_numeric(prop, record.get(prop))
+                    property_success = True
 
-        if "CID" in self.properties and results.get("CID") is None:
+        if property_success and "CID" in self.properties and results.get("CID") is None:
             cid_url = f"{self.base_url.rstrip('/')}/compound/smiles/{encoded}/cids/JSON"
             payload = self._get_json(cid_url, smiles=smiles, context="CID list")
             if payload is not None:

--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -1,16 +1,16 @@
-"""Utilities for verifying deterministic outputs.
-
-This script writes a small CSV file twice using :func:`write_rows` and
-confirms that the resulting hashes are identical.  It exits with a non-zero
-status if the hashes differ, making it suitable for use in automated tests.
-"""
+"""Utilities for verifying deterministic CSV output and metadata."""
 
 from __future__ import annotations
 
+import argparse
 import hashlib
 import logging
+import shlex
+import sys
 from pathlib import Path
 from typing import Any, Dict, Sequence
+
+import yaml
 
 if __package__ in {None, ""}:
     from _path_utils import ensure_project_root as _ensure_project_root
@@ -19,18 +19,13 @@ if __package__ in {None, ""}:
 
 from library.io_utils import CsvConfig, write_rows  # noqa: E402
 from library.logging_utils import configure_logging  # noqa: E402
+from library.metadata import write_meta_yaml  # noqa: E402
 
 LOGGER = logging.getLogger(__name__)
 
 
 def _hash_file(path: Path) -> str:
-    """Return the SHA-256 hash of ``path``.
-
-    Parameters
-    ----------
-    path:
-        File whose contents will be hashed.
-    """
+    """Return the SHA-256 hash of ``path``."""
 
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
@@ -44,38 +39,89 @@ def _sample_rows() -> Sequence[Dict[str, Any]]:
     ]
 
 
-def main() -> None:
-    """Run the determinism check.
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments for the determinism checker."""
 
-    The function writes the same rows twice to different temporary files and
-    compares their SHA-256 hashes.  A mismatch results in a ``RuntimeError``.
-    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("_determinism_check.csv"),
+        help="Destination CSV used for the comparison",
+    )
+    parser.add_argument(
+        "--keep-artifacts",
+        action="store_true",
+        help="Preserve the generated CSV and metadata for inspection",
+    )
+    return parser.parse_args(argv)
 
+
+def _write_and_record(
+    output_path: Path,
+    rows: Sequence[Dict[str, Any]],
+    columns: Sequence[str],
+    cfg: CsvConfig,
+    *,
+    command: str,
+) -> str:
+    """Write ``rows`` to ``output_path`` and persist metadata."""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    write_rows(output_path, rows, columns, cfg)
+    digest = _hash_file(output_path)
+    LOGGER.info("Wrote %s with hash %s", output_path, digest)
+    write_meta_yaml(
+        output_path,
+        command=command,
+        config={"columns": list(columns), "list_format": cfg.list_format},
+        row_count=len(rows),
+        column_count=len(columns),
+    )
+    return digest
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the determinism check and update ``.meta.yaml`` with the outcome."""
+
+    args = parse_args(argv)
     configure_logging("INFO")
 
     cfg = CsvConfig(sep=",", encoding="utf-8", list_format="json")
     rows = _sample_rows()
-    columns = ["id", "names"]
+    columns = ("id", "names")
+    output_path = args.output.resolve()
+    meta_path = output_path.with_suffix(f"{output_path.suffix}.meta.yaml")
+    command = " ".join(
+        shlex.quote(part) for part in (sys.argv[0], *(argv or sys.argv[1:]))
+    )
 
-    tmp1 = Path("_det_check_1.csv")
-    tmp2 = Path("_det_check_2.csv")
-
-    write_rows(tmp1, rows, columns, cfg)
-    write_rows(tmp2, rows, columns, cfg)
-
-    hash1 = _hash_file(tmp1)
-    hash2 = _hash_file(tmp2)
-
-    LOGGER.info("hash1=%s hash2=%s", hash1, hash2)
-
+    hashes: list[str] = []
     try:
-        if hash1 != hash2:
-            msg = "Non-deterministic output detected"
+        hashes.append(
+            _write_and_record(output_path, rows, columns, cfg, command=command)
+        )
+        hashes.append(
+            _write_and_record(output_path, rows, columns, cfg, command=command)
+        )
+
+        if hashes[0] != hashes[1]:
+            msg = "Non-deterministic output detected: %s != %s" % (hashes[0], hashes[1])
             raise RuntimeError(msg)
+
+        metadata = yaml.safe_load(meta_path.read_text(encoding="utf-8")) or {}
+        determinism = metadata.get("determinism", {})
+        matches_previous = determinism.get("matches_previous")
+        if matches_previous is False:
+            raise RuntimeError("Metadata reports non-deterministic output")
+        LOGGER.info("Determinism check succeeded: %s", determinism)
     finally:
-        tmp1.unlink(missing_ok=True)
-        tmp2.unlink(missing_ok=True)
+        if not args.keep_artifacts:
+            output_path.unlink(missing_ok=True)
+            meta_path.unlink(missing_ok=True)
+
+    return 0
 
 
-if __name__ == "__main__":  # pragma: no cover - manual invocation
-    main()
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/scripts/chembl_testitems_main.py
+++ b/scripts/chembl_testitems_main.py
@@ -26,7 +26,7 @@ from library.chembl_client import ChemblClient
 from library.chembl_library import get_testitems
 from library.data_profiling import analyze_table_quality
 from library.io import read_ids
-from library.io_utils import CsvConfig
+from library.io_utils import CsvConfig, serialise_cell
 from library.normalize_testitems import normalize_testitems
 from library.testitem_library import (
     PUBCHEM_BASE_URL,
@@ -75,7 +75,6 @@ def _serialise_complex_columns(df: pd.DataFrame, list_format: str) -> pd.DataFra
             lambda value: serialise_cell(value, list_format)
         )
     return result
-
 
 
 def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:

--- a/tests/test_chembl_activities_pipeline.py
+++ b/tests/test_chembl_activities_pipeline.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import requests_mock as requests_mock_lib
+import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -220,6 +221,27 @@ def test_chembl_activities_main_end_to_end(
 
     meta_file = output_csv.with_suffix(".csv.meta.yaml")
     assert meta_file.exists()
+
+    second_exit = chembl_activities_main(
+        [
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--base-url",
+            base_url,
+            "--chunk-size",
+            "1",
+            "--log-level",
+            "DEBUG",
+        ]
+    )
+    assert second_exit == 0
+
+    metadata = yaml.safe_load(meta_file.read_text(encoding="utf-8"))
+    determinism = metadata["determinism"]
+    assert determinism["matches_previous"] is True
+    assert determinism["previous_sha256"] == determinism["current_sha256"]
 
     quality_report = Path(f"{output_csv.with_suffix('')}_quality_report_table.csv")
     assert quality_report.exists()

--- a/tests/test_chembl_testitems_main.py
+++ b/tests/test_chembl_testitems_main.py
@@ -13,6 +13,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 chembl_testitems_main = importlib.import_module("scripts.chembl_testitems_main")
+prepare_cli_config = importlib.import_module("library.cli_common").prepare_cli_config
 
 
 def test_run_pipeline_passes_pubchem_http_client_config(
@@ -75,28 +76,29 @@ def test_run_pipeline_passes_pubchem_http_client_config(
         captured["errors_path"] = errors_path
         return df
 
-    def fake_write_meta_yaml(
+    def fake_write_cli_metadata(
         output_path: Path,
         *,
-        command: str,
-        config: dict[str, Any],
         row_count: int,
         column_count: int,
+        namespace: Any,
+        command_parts: Any,
         meta_path: Path | None,
-    ) -> None:
+    ) -> Path:
         captured["meta_output_path"] = output_path
-        captured["meta_command"] = command
-        captured["meta_config"] = config
+        captured["meta_command"] = command_parts
+        captured["meta_config"] = prepare_cli_config(namespace)
         captured["meta_row_count"] = row_count
         captured["meta_column_count"] = column_count
         captured["meta_path"] = meta_path
+        return output_path.with_suffix(".csv.meta.yaml")
 
     monkeypatch.setattr(module, "ChemblClient", DummyClient)
     monkeypatch.setattr(module, "get_testitems", fake_get_testitems)
     monkeypatch.setattr(module, "normalize_testitems", fake_normalize)
     monkeypatch.setattr(module, "add_pubchem_data", fake_add_pubchem_data)
     monkeypatch.setattr(module, "validate_testitems", fake_validate)
-    monkeypatch.setattr(module, "write_meta_yaml", fake_write_meta_yaml)
+    monkeypatch.setattr(module, "write_cli_metadata", fake_write_cli_metadata)
     monkeypatch.setattr(module, "analyze_table_quality", lambda *_, **__: None)
 
     argv = [

--- a/tests/test_chembl_testitems_pipeline.py
+++ b/tests/test_chembl_testitems_pipeline.py
@@ -111,12 +111,12 @@ def test_chembl_testitems_main_end_to_end(
 
     requests_mock.get(
         f"{pubchem_base}/compound/smiles/C/property/"
-        "MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
+        "CID,MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
         json=_pubchem_response(11, "CH4"),
     )
     requests_mock.get(
         f"{pubchem_base}/compound/smiles/CC/property/"
-        "MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
+        "CID,MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
         json=_pubchem_response(22, "C2H6"),
     )
     requests_mock.get(

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -111,3 +111,8 @@ def test_write_cli_metadata_produces_expected_yaml(tmp_path: Path) -> None:
     assert "output" not in payload["config"]
     assert payload["rows"] == 1
     assert payload["columns"] == 1
+    determinism = payload["determinism"]
+    assert determinism["baseline_sha256"] == payload["sha256"]
+    assert determinism["previous_sha256"] is None
+    assert determinism["matches_previous"] is None
+    assert determinism["check_count"] == 1

--- a/tests/test_testitems_library.py
+++ b/tests/test_testitems_library.py
@@ -65,12 +65,12 @@ def test_add_pubchem_data_enriches_dataframe(
 
     requests_mock.get(
         f"{PUBCHEM_BASE_URL}/compound/smiles/C/property/"
-        "MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
+        "CID,MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
         json=_pubchem_properties_response("CH4", 10),
     )
     requests_mock.get(
         f"{PUBCHEM_BASE_URL}/compound/smiles/CC/property/"
-        "MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
+        "CID,MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
         json=_pubchem_properties_response("C2H6", 20),
     )
     requests_mock.get(


### PR DESCRIPTION
## Summary
- record determinism information in metadata sidecars and extend the developer documentation on CSV export policy
- enhance `scripts/check_determinism.py` and integrate metadata writing into the unified pipeline CLI
- adjust PubChem handling and tests to exercise deterministic checks across the CLI surface

## Testing
- ruff check .
- black --check .
- mypy --config-file mypy.ini
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cae296376c8324ae20a2ca38d9f68f