### PR TITLE
Improve CSV parsing robustness for Crossref CLI

### DIFF
--- a/library/crossref_client.py
+++ b/library/crossref_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
-from typing import Any, Dict, List, Mapping, Sequence
+from typing import Any, Dict, Iterable, List, Mapping, Sequence
 from urllib.parse import quote
 
 import requests
@@ -24,22 +24,57 @@ def _clean_string(value: Any) -> str | None:
     return None
 
 
+def _dedupe_preserve_order(values: Iterable[str]) -> List[str]:
+    """Return ``values`` without duplicates while preserving the input order."""
+
+    seen: set[str] = set()
+    ordered: List[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
+
+
+def _coerce_sequence(value: Any) -> List[Any]:
+    """Return ``value`` as a list while preserving the original ordering."""
+
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]
+
+
+def _normalise_strings(value: Any) -> List[str]:
+    """Extract cleaned string values from ``value`` preserving order."""
+
+    strings: List[str] = []
+    for item in _coerce_sequence(value):
+        if isinstance(item, str):
+            candidate = _clean_string(item)
+            if candidate:
+                strings.append(candidate)
+    return strings
+
+
 def _normalise_subject(subject: Any) -> List[str]:
-    if isinstance(subject, list):
-        values: List[str] = []
-        for item in subject:
-            if isinstance(item, Mapping):
-                name = _clean_string(item.get("name"))
+    values: List[str] = []
+    for item in _coerce_sequence(subject):
+        if isinstance(item, Mapping):
+            for key in ("name", "value"):
+                name = _clean_string(item.get(key))
                 if name:
                     values.append(name)
-                    continue
-            text = _clean_string(item)
-            if text:
-                values.append(text)
-        return values
-    if isinstance(subject, str) and subject.strip():
-        return [subject.strip()]
-    return []
+                    break
+            continue
+        text = _clean_string(item)
+        if text:
+            values.append(text)
+    return _dedupe_preserve_order(values)
 
 
 @dataclass
@@ -132,22 +167,21 @@ def fetch_crossref_records(
             records[doi] = CrossrefRecord.from_error(doi, msg)
             continue
 
-        titles = message.get("title") or []
-        title = (
-            _clean_string(titles[0]) if titles and isinstance(titles[0], str) else None
-        )
-        subtitles = message.get("subtitle") or []
-        subtitle = (
-            _clean_string(subtitles[0])
-            if subtitles and isinstance(subtitles[0], str)
-            else None
-        )
+        titles = _normalise_strings(message.get("title"))
+        title = titles[0] if titles else None
+
+        subtitle_values = _normalise_strings(message.get("subtitle"))
+        subtitle = "|".join(subtitle_values) if subtitle_values else None
+
+        subtype_values = _normalise_strings(message.get("subtype"))
+        subtype = subtype_values[0] if subtype_values else None
+
         subject = _normalise_subject(message.get("subject"))
 
         records[doi] = CrossrefRecord(
             doi=doi,
             type=_clean_string(message.get("type")),
-            subtype=_clean_string(message.get("subtype")),
+            subtype=subtype,
             title=title,
             subtitle=subtitle,
             subject=subject,

--- a/tests/test_pubmed_main.py
+++ b/tests/test_pubmed_main.py
@@ -34,6 +34,36 @@ def _make_args(
     )
 
 
+def test_read_identifier_column_detects_separator(tmp_path: Path) -> None:
+    """_read_identifier_column should retry with an inferred separator."""
+
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("DOI;other\n10.1/doi1;value\n", encoding="utf-8")
+
+    values = pm._read_identifier_column(input_csv, "DOI", sep=",", encoding="utf-8")
+
+    assert values == ["10.1/doi1"]
+
+
+def test_read_identifier_column_missing_column(tmp_path: Path) -> None:
+    """_read_identifier_column should raise SystemExit when column is absent."""
+
+    input_csv = tmp_path / "input.csv"
+    pd.DataFrame({"PMID": ["1"]}).to_csv(input_csv, index=False)
+
+    with pytest.raises(SystemExit, match="Column 'DOI' not found in input"):
+        pm._read_identifier_column(input_csv, "DOI", sep=",", encoding="utf-8")
+
+
+def test_normalise_crossref_doi() -> None:
+    """_normalise_crossref_doi should strip prefixes and normalise case."""
+
+    assert pm._normalise_crossref_doi(" HTTPS://doi.org/10.1/DOI1 ") == "10.1/doi1"
+    assert pm._normalise_crossref_doi("doi:10.1/DOI2") == "10.1/doi2"
+    assert pm._normalise_crossref_doi("urn:doi:10.1/DOI3") == "10.1/doi3"
+    assert pm._normalise_crossref_doi(None) is None
+
+
 def test_run_pubmed_creates_output_directory(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -90,10 +120,10 @@ def test_run_pubmed_creates_output_directory(
     crossref_record = CrossrefRecord(
         doi="10.1/doi1",
         type="journal-article",
-        subtype=None,
+        subtype="clinical-trial",
         title="Title",
-        subtitle=None,
-        subject=["Biology"],
+        subtitle="Part A|Part B",
+        subject=["Biology", "Chemistry"],
         error=None,
     )
 
@@ -113,6 +143,10 @@ def test_run_pubmed_creates_output_directory(
     pm.run_pubmed_command(args, config)
 
     assert output_path.exists()
+    df = pd.read_csv(output_path)
+    assert df.loc[0, "crossref.Subtype"] == "clinical-trial"
+    assert df.loc[0, "crossref.Subtitle"] == "Part A|Part B"
+    assert df.loc[0, "crossref.Subject"] == "Biology|Chemistry"
 
 
 def test_run_openalex_command_exports_openalex_only(
@@ -138,10 +172,10 @@ def test_run_openalex_command_exports_openalex_only(
     crossref_record = CrossrefRecord(
         doi="10.1/doi1",
         type="journal-article",
-        subtype=None,
+        subtype="clinical-trial",
         title="Title",
-        subtitle=None,
-        subject=["Biology"],
+        subtitle="Part A|Part B",
+        subject=["Biology", "Chemistry"],
         error=None,
     )
 
@@ -167,6 +201,51 @@ def test_run_openalex_command_exports_openalex_only(
     assert df.loc[0, "OpenAlex.DOI"] == "10.1/doi1"
     assert df.loc[0, "crossref.DOI"] == "10.1/doi1"
     assert df.loc[0, "PubMed.Error"] == pm.OPENALEX_ONLY_PLACEHOLDER_ERROR
+    assert df.loc[0, "crossref.Subtype"] == "clinical-trial"
+    assert df.loc[0, "crossref.Subtitle"] == "Part A|Part B"
+    assert df.loc[0, "crossref.Subject"] == "Biology|Chemistry"
+
+
+def test_run_crossref_command_exports_crossref_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run_crossref_command should export Crossref-only metadata."""
+
+    input_csv = tmp_path / "input.csv"
+    pd.DataFrame({"DOI": [" https://doi.org/10.1/doi1 ", "10.1/doi1"]}).to_csv(
+        input_csv, index=False
+    )
+
+    crossref_record = CrossrefRecord(
+        doi="10.1/doi1",
+        type="journal-article",
+        subtype="clinical-trial",
+        title="Title",
+        subtitle="Part A|Part B",
+        subject=["Biology", "Chemistry"],
+        error=None,
+    )
+
+    def fake_fetch(dois: Sequence[str], *, client: Any) -> list[CrossrefRecord]:
+        assert dois == ["10.1/doi1"]
+        return [crossref_record]
+
+    monkeypatch.setattr(pm, "fetch_crossref_records", fake_fetch)
+
+    output_path = tmp_path / "out" / "crossref.csv"
+    args = _make_args(
+        "crossref", input_path=input_csv, output_path=output_path, column="DOI"
+    )
+    config = deepcopy(pm.DEFAULT_CONFIG)
+
+    pm.run_crossref_command(args, config)
+
+    df = pd.read_csv(output_path)
+    assert list(df.columns) == pm.CROSSREF_COLUMNS
+    assert df.loc[0, "crossref.DOI"] == "10.1/doi1"
+    assert df.loc[0, "crossref.Subtype"] == "clinical-trial"
+    assert df.loc[0, "crossref.Subtitle"] == "Part A|Part B"
+    assert df.loc[0, "crossref.Subject"] == "Biology|Chemistry"
 
 
 def test_run_all_merges_chembl(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- add a CSV delimiter detection helper and reuse it in `_read_identifier_column` so Crossref runs can recover from misconfigured separators
- surface clearer error messages when the requested identifier column is absent
- cover the new behaviour with unit tests for `_read_identifier_column`

## Testing
- python -m black scripts/pubmed_main.py tests/test_pubmed_main.py
- ruff check scripts/pubmed_main.py tests/test_pubmed_main.py
- mypy scripts/pubmed_main.py library/crossref_client.py tests/test_pubmed_main.py
- pytest tests/test_pubmed_main.py tests/test_metadata_clients.py

------
https://chatgpt.com/codex/tasks/task_e_68cb9b61a33c8324bca90a66c83d2116