### PR TITLE
Fix streaming mapping loop and expand CLI tests

### DIFF
--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -24,6 +24,7 @@ CONFIG = CONFIG_DIR / "valid.yaml"
 SCHEMA = CONFIG_DIR / "config.schema.json"
 INPUT = CSV_DIR / "input.csv"
 INPUT_SINGLE = CSV_DIR / "input_single.csv"
+INPUT_EMPTY = CSV_DIR / "empty.csv"
 
 
 @pytest.fixture
@@ -64,6 +65,17 @@ def test_success_mapping_single_batch(
     out = tmp_path / "out.csv"
     map_chembl_to_uniprot(INPUT, out, config_path)
     assert read_output(out) == ["P1", "P2"]
+
+
+def test_empty_input_skips_requests(
+    requests_mock, tmp_path: Path, config_path: Path
+) -> None:
+    out = tmp_path / "out.csv"
+    result = map_chembl_to_uniprot(INPUT_EMPTY, out, config_path)
+
+    assert result == out
+    assert read_output(out) == []
+    assert not requests_mock.called
 
 
 def test_success_mapping_redirect(


### PR DESCRIPTION
## Summary
- fix `map_chembl_to_uniprot` to stream unique ChEMBL identifiers once while tracking failed IDs
- add regression coverage for empty CSV inputs and CLI success execution paths
- adjust CLI batch-mapping stubs to use `BatchMappingResult`

## Testing
- pytest -k chembl2uniprot

------
https://chatgpt.com/codex/tasks/task_e_68cbaba3960c8324acb1a32bc70233b3