### PR TITLE
Document chembl activities performance smoke check

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,3 +263,54 @@ python scripts/chembl_activities_main.py \
 Validation errors are persisted to `<output>.errors.json` while dataset metadata
 is written to `<output>.meta.yaml`. Quality and correlation reports are produced
 alongside the main CSV file.
+
+### Performance smoke testing
+
+`chembl_activities_main.py` is the preferred entry point for quick performance
+smoke checks because it supports both `--dry-run` and `--limit` arguments. The
+snippet below exercises the CLI against the bundled
+`tests/data/activities_input.csv` file without making network calls while
+capturing the runtime via `time.perf_counter`:
+
+```bash
+python - <<'PY'
+import pathlib
+import runpy
+import sys
+import time
+
+sys.path.insert(0, str(pathlib.Path('scripts').resolve()))
+sys.argv = [
+    'chembl_activities_main.py',
+    '--input',
+    'tests/data/activities_input.csv',
+    '--dry-run',
+    '--limit',
+    '50',
+]
+start = time.perf_counter()
+try:
+    runpy.run_path('scripts/chembl_activities_main.py', run_name='__main__')
+except SystemExit as exc:
+    if exc.code not in (0, None):
+        raise
+elapsed = time.perf_counter() - start
+print(f"Dry-run completed in {elapsed:.3f}s")
+PY
+```
+
+Engineers can drop the `--dry-run` flag and keep a small `--limit` (for example
+`--limit 5`) to perform a short end-to-end request against the live API:
+
+```bash
+python scripts/chembl_activities_main.py \
+    --input tests/data/activities_input.csv \
+    --output output/activities_smoke.csv \
+    --column activity_chembl_id \
+    --limit 5 \
+    --chunk-size 5 \
+    --log-level INFO
+```
+
+Add the first command to the CI smoke test job to guard against regressions in
+argument parsing and input handling without depending on external services.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -39,3 +39,50 @@ This command creates ``targets.csv`` together with related tables such as
 ``targets_synonyms.csv`` and ``targets_interactions.csv`` in the specified output
 directory. Only unique identifiers are queried and results are written in a
 deterministic order.
+
+## Performance smoke testing
+
+Use ``chembl_activities_main.py`` for quick performance smoke checks. The
+following snippet measures how long the CLI takes to parse a realistic input
+file without contacting external APIs:
+
+```bash
+python - <<'PY'
+import pathlib
+import runpy
+import sys
+import time
+
+sys.path.insert(0, str(pathlib.Path('scripts').resolve()))
+sys.argv = [
+    'chembl_activities_main.py',
+    '--input',
+    'tests/data/activities_input.csv',
+    '--dry-run',
+    '--limit',
+    '50',
+]
+start = time.perf_counter()
+try:
+    runpy.run_path('scripts/chembl_activities_main.py', run_name='__main__')
+except SystemExit as exc:
+    if exc.code not in (0, None):
+        raise
+elapsed = time.perf_counter() - start
+print(f"Dry-run completed in {elapsed:.3f}s")
+PY
+```
+
+This command is suitable for a CI smoke test step because it exercises argument
+parsing and input validation without relying on the ChEMBL API. For a short
+end-to-end measurement, remove ``--dry-run`` and keep a conservative limit:
+
+```bash
+python scripts/chembl_activities_main.py \
+    --input tests/data/activities_input.csv \
+    --output output/activities_smoke.csv \
+    --column activity_chembl_id \
+    --limit 5 \
+    --chunk-size 5 \
+    --log-level INFO
+```


### PR DESCRIPTION
## Summary
- document chembl_activities_main.py as the preferred performance smoke CLI
- add built-in timer snippet and limit examples to README and docs/USAGE.md
- describe how to integrate the dry-run smoke command into CI

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cbabacebe88324932360b0178d7228