### PR TITLE
Add shared UniProt field resolver and tests

### DIFF
--- a/scripts/get_uniprot_target_data.py
+++ b/scripts/get_uniprot_target_data.py
@@ -22,6 +22,8 @@ if __package__ in {None, ""}:
 
     _ensure_project_root()
 
+from pipeline_targets_main import _resolve_uniprot_fields
+
 if TYPE_CHECKING:  # pragma: no cover - imported for typing only
     from library.orthologs import EnsemblHomologyClient, OmaClient
     from library.uniprot_normalize import Isoform
@@ -174,9 +176,7 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     client = UniProtClient(
         base_url=uniprot_cfg.get("base_url", "https://rest.uniprot.org/uniprotkb"),
-        fields=(
-            ",".join(uniprot_cfg.get("fields", [])) if uniprot_cfg.get("fields") else ""
-        ),
+        fields=_resolve_uniprot_fields(uniprot_cfg),
         network=NetworkConfig(
             timeout_sec=uniprot_cfg.get("timeout_sec", 30),
             max_retries=uniprot_cfg.get("retries", 3),

--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -7,7 +7,8 @@ import logging
 import sys
 from pathlib import Path
 
-from typing import Any, Callable, Dict, Iterable, List, Sequence
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any, Callable, Dict, List
 
 import pandas as pd
 import requests
@@ -101,6 +102,87 @@ def merge_chembl_fields(
             how="left",
         )
     return pipeline_df
+
+
+def _normalise_field_names(value: Any, *, source: str) -> list[str]:
+    """Return ``value`` as a list of stripped field names.
+
+    Parameters
+    ----------
+    value:
+        Configuration value representing UniProt field names.
+    source:
+        Human-readable label used in error messages to indicate the origin of
+        the data.
+
+    Returns
+    -------
+    list[str]
+        Field names stripped of surrounding whitespace. Empty strings are
+        discarded to avoid passing blank field names to the UniProt API.
+
+    Raises
+    ------
+    TypeError
+        If ``value`` is neither a string nor an iterable of strings.
+    """
+
+    if value is None:
+        return []
+    if isinstance(value, str):
+        candidate = value.strip()
+        return [candidate] if candidate else []
+    if isinstance(value, Mapping):
+        msg = f"Expected '{source}' to be a sequence of strings, not a mapping"
+        raise TypeError(msg)
+    if not isinstance(value, Iterable):
+        msg = f"Expected '{source}' to be a string or iterable of strings"
+        raise TypeError(msg)
+    names: list[str] = []
+    for entry in value:
+        if entry is None:
+            continue
+        if not isinstance(entry, str):
+            msg = (
+                f"Expected all values in '{source}' to be strings, received "
+                f"{type(entry).__name__}"
+            )
+            raise TypeError(msg)
+        candidate = entry.strip()
+        if candidate:
+            names.append(candidate)
+    return names
+
+
+def _resolve_uniprot_fields(uni_cfg: Mapping[str, Any]) -> str:
+    """Return the UniProt ``fields`` parameter derived from ``uni_cfg``.
+
+    The configuration may specify the desired UniProt fields explicitly via the
+    ``fields`` key. When omitted, the helper falls back to the ``columns``
+    configuration so existing deployments that only list output columns continue
+    to function without modification.
+
+    Parameters
+    ----------
+    uni_cfg:
+        Mapping containing UniProt configuration options loaded from the YAML
+        file.
+
+    Returns
+    -------
+    str
+        Comma separated string suitable for the UniProt REST API ``fields``
+        parameter. The string is empty when neither ``fields`` nor ``columns``
+        are configured.
+    """
+
+    field_names = _normalise_field_names(uni_cfg.get("fields"), source="uniprot.fields")
+    if field_names:
+        return ",".join(field_names)
+    column_names = _normalise_field_names(
+        uni_cfg.get("columns"), source="uniprot.columns"
+    )
+    return ",".join(column_names)
 
 
 def add_iuphar_classification(
@@ -608,7 +690,7 @@ def build_clients(
         data = yaml.safe_load(fh) or {}
     global_cache = default_cache or CacheConfig.from_dict(data.get("http_cache"))
     uni_cfg = data["uniprot"]
-    fields = ",".join(uni_cfg.get("fields", []))
+    fields = _resolve_uniprot_fields(uni_cfg)
     uni_cache = CacheConfig.from_dict(uni_cfg.get("cache")) or global_cache
     uni = UniProtClient(
         base_url=uni_cfg["base_url"],

--- a/tests/test_pipeline_targets_main.py
+++ b/tests/test_pipeline_targets_main.py
@@ -1,11 +1,11 @@
+import json
+import sys
 from pathlib import Path
 from typing import Dict, Iterable
 
-import json
-import sys
-
 import pandas as pd
-
+import yaml
+ 
 sys.path.insert(0, str(Path("scripts")))
 from pipeline_targets_main import (
     add_iuphar_classification,
@@ -13,10 +13,12 @@ from pipeline_targets_main import (
     add_activity_fields,
     add_isoform_fields,
     add_uniprot_fields,
+    build_clients,
     extract_activity,
     extract_isoform,
     merge_chembl_fields,
 )
+from library.pipeline_targets import PipelineConfig
 
 
 def test_merge_chembl_fields_adds_columns():
@@ -196,3 +198,15 @@ def test_add_isoform_fields() -> None:
     assert row["isoform_names"] == "Isoform 1"
     assert row["isoform_ids"] == "P1-1"
     assert row["isoform_synonyms"] == "Alpha"
+
+
+def test_build_clients_infers_uniprot_fields() -> None:
+    pipeline_cfg = PipelineConfig()
+    uni_client, *_ = build_clients("config.yaml", pipeline_cfg)
+
+    config = yaml.safe_load(Path("config.yaml").read_text())
+    uniprot_columns = config["uniprot"]["columns"]
+    field_set = {field for field in uni_client.fields.split(",") if field}
+
+    assert set(uniprot_columns).issubset(field_set)
+


### PR DESCRIPTION
## Summary
- add a reusable `_resolve_uniprot_fields` helper to derive UniProt field lists from the configuration
- update the UniProt target data script to share the same field resolution logic
- extend the pipeline tests to ensure the resolved UniProt fields include the configured columns

## Testing
- `pytest tests/test_pipeline_targets_main.py`
- `ruff check scripts/pipeline_targets_main.py scripts/get_uniprot_target_data.py tests/test_pipeline_targets_main.py`
- `mypy scripts/pipeline_targets_main.py scripts/get_uniprot_target_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68cbb806eee48324b68f6362a2a6000d