### PR TITLE
Refactor pipeline config loading and client setup

### DIFF
--- a/tests/test_cli_logging_redaction.py
+++ b/tests/test_cli_logging_redaction.py
@@ -165,7 +165,9 @@ CLI_SPECS: list[CliSpec] = [
         expect_exit=True,
         exit_code=0,
         prepare=lambda module, monkeypatch, tmp_path: monkeypatch.setattr(
-            module, "load_pipeline_config", _make_stub(module, exit_code=0)
+            module,
+            "load_pipeline_config_with_sections",
+            _make_stub(module, exit_code=0),
         ),
     ),
     CliSpec(


### PR DESCRIPTION
## Summary
- extend `library.pipeline_targets.load_pipeline_config` to return a bundle exposing the parsed sections with environment-variable overrides applied
- update the pipeline CLI to use the parsed configuration directly when building service clients and honour UniProt rate-limit overrides
- refresh CLI tests and add coverage ensuring the UniProt client picks up the overridden rate limit

## Testing
- pytest
- ruff check
- mypy .

------
https://chatgpt.com/codex/tasks/task_e_68cbb8475d3083248168d92878306abf