### PR TITLE
Add cache-aware UniProt enrich client and tests

### DIFF
--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -694,6 +694,10 @@ def main() -> None:
     with open(args.config, "r", encoding="utf-8") as fh:
         data = yaml.safe_load(fh) or {}
     global_cache = CacheConfig.from_dict(data.get("http_cache"))
+    enrich_cache = (
+        CacheConfig.from_dict(data.get("uniprot_enrich", {}).get("cache"))
+        or global_cache
+    )
     chembl_cols = list(data.get("chembl", {}).get("columns", []))
     required_cols = [
         "target_chembl_id",
@@ -777,7 +781,7 @@ def main() -> None:
             target_species=target_species,
             progress_callback=pbar.update,
         )
-    enrich_client = UniProtEnrichClient()
+    enrich_client = UniProtEnrichClient(cache_config=enrich_cache)
     out_df = add_uniprot_fields(out_df, enrich_client.fetch_all)
     out_df = merge_chembl_fields(out_df, chembl_df)
     entry_cache: Dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- extend the UniProt enrichment client to accept an HttpClient and optional cache configuration so the HTTP layer can use shared caching
- propagate the global or uniprot_enrich cache settings when instantiating the enrichment client in the pipeline CLI
- cover the caching behaviour with a dedicated unit test and update the pipeline CLI test to verify cache propagation

## Testing
- pytest -q
- ruff check .
- black library/uniprot_enrich/enrich.py scripts/pipeline_targets_main.py tests/test_pipeline_targets_cli.py tests/test_uniprot_enrich.py
- mypy --config-file mypy.ini library/uniprot_enrich/enrich.py

------
https://chatgpt.com/codex/tasks/task_e_68cbb88b338c8324b170322e9e72e90a