### PR TITLE
Optimize protein classification fetch usage

### DIFF
--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -217,16 +217,22 @@ def add_protein_classification(
     unique_ids = [acc for acc in dict.fromkeys(ids) if acc]
     logger = logging.getLogger(__name__)
     entry_map: Dict[str, Any] = {}
-    for acc in unique_ids:
+    fetched_entries: Dict[str, Any] = {}
+    if unique_ids:
         try:
-            fetched = fetch_entries([acc])
+            fetched_entries = fetch_entries(unique_ids) or {}
         except requests.RequestException as exc:
-            msg = f"Network error while fetching UniProt entry for {acc}"
+            msg = (
+                "Network error while fetching UniProt entries "
+                f"for {len(unique_ids)} accessions"
+            )
             raise RuntimeError(msg) from exc
         except Exception as exc:  # pragma: no cover - logging side effect
-            logger.warning("Failed to fetch UniProt entry for %s: %s", acc, exc)
-            continue
-        entry = (fetched or {}).get(acc)
+            logger.warning("Failed to fetch UniProt entries: %s", exc)
+            fetched_entries = {}
+
+    for acc in unique_ids:
+        entry = fetched_entries.get(acc)
         if entry is not None:
             entry_map[acc] = entry
 

--- a/tests/test_pipeline_targets_main.py
+++ b/tests/test_pipeline_targets_main.py
@@ -75,6 +75,21 @@ def test_add_protein_classification():
     assert row["protein_class_pred_confidence"] == "high"
 
 
+def test_add_protein_classification_fetches_once() -> None:
+    samples = json.loads((Path("tests/data/protein_samples.json").read_text()))
+    calls: list[list[str]] = []
+
+    def fetcher(accessions: Iterable[str]) -> Dict[str, dict]:
+        collected = list(accessions)
+        calls.append(collected)
+        return {acc: samples["gpcr"] for acc in collected}
+
+    df = pd.DataFrame({"uniprot_id_primary": ["P00000", "", "P00000"]})
+    add_protein_classification(df, fetcher)
+    assert len(calls) == 1
+    assert calls[0] == ["P00000"]
+
+
 def test_add_uniprot_fields() -> None:
     df = pd.DataFrame({"uniprot_id_primary": ["P12345"]})
 


### PR DESCRIPTION
## Summary
- fetch UniProt entries for protein classification in a single batched call
- populate the classification entry cache from the batched response while handling errors gracefully
- add a regression test confirming the fetcher is invoked only once per set of accessions

## Testing
- black scripts/pipeline_targets_main.py tests/test_pipeline_targets_main.py
- ruff check scripts/pipeline_targets_main.py tests/test_pipeline_targets_main.py
- mypy scripts/pipeline_targets_main.py tests/test_pipeline_targets_main.py
- pytest tests/test_pipeline_targets_main.py -k protein

------
https://chatgpt.com/codex/tasks/task_e_68cbb87f55a883249936ef1d96ed5080