### PR TITLE
Respect Retry-After headers in UniProt clients

### DIFF
--- a/tests/test_uniprot_client.py
+++ b/tests/test_uniprot_client.py
@@ -1,7 +1,10 @@
 from typing import Dict
 from pathlib import Path
+import logging
+from unittest import mock
 import sys
 
+import pytest
 import requests_mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -28,3 +31,55 @@ def test_fetch_entries_json_batches(requests_mock: requests_mock.Mocker) -> None
     res: Dict[str, Dict[str, str]] = client.fetch_entries_json(["P1", "P2"])
     assert requests_mock.call_count == 1
     assert set(res.keys()) == {"P1", "P2"}
+
+
+def test_fetch_respects_retry_after(
+    requests_mock: requests_mock.Mocker,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """HTTP 429 responses should trigger retries honouring Retry-After."""
+
+    monkeypatch.setattr("tenacity.nap.sleep", lambda _: None)
+    monkeypatch.setattr("library.http_client.time.sleep", lambda _: None)
+
+    client = UniProtClient(
+        base_url="https://rest.uniprot.org/uniprotkb",
+        fields="",
+        network=NetworkConfig(timeout_sec=1, max_retries=3, backoff_sec=0.1),
+        rate_limit=RateLimitConfig(rps=1000),
+    )
+    url = "https://rest.uniprot.org/uniprotkb/search"
+    requests_mock.get(
+        url,
+        [
+            {
+                "status_code": 429,
+                "headers": {"Retry-After": "0.2"},
+                "json": {"error": "rate limit"},
+            },
+            {
+                "status_code": 200,
+                "json": {"results": [{"primaryAccession": "P12345"}]},
+            },
+        ],
+    )
+
+    with (
+        mock.patch.object(
+            client._rate_limiter,  # type: ignore[attr-defined]
+            "apply_penalty",
+            wraps=client._rate_limiter.apply_penalty,  # type: ignore[attr-defined]
+        ) as penalty_mock,
+        caplog.at_level(logging.WARNING),
+    ):
+        result = client.fetch("P12345")
+
+    assert result == {"primaryAccession": "P12345"}
+    assert requests_mock.call_count == 2
+    assert penalty_mock.call_count >= 1
+    assert any(
+        call.args and pytest.approx(0.2, rel=0.05) == call.args[0]
+        for call in penalty_mock.call_args_list
+    )
+    assert any("attempt" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- expose `retry_after_from_response` alongside `RetryAfterWaitStrategy` in the shared HTTP helper module
- update the UniProt client to use the shared wait strategy, status forcelist and rate limiter penalties while logging retry attempts
- align the ChEMBL to UniProt mapper with the same retry handling and add regression tests for Retry-After flows

## Testing
- `pytest tests/test_uniprot_client.py tests/test_chembl2uniprot_mapping.py`


------
https://chatgpt.com/codex/tasks/task_e_68cbc796137c83249aa4cbe10fb80539