### PR TITLE
Improve ortholog configuration defaults and validation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -206,6 +206,18 @@ covering identifiers, taxonomy, sequence features, cross-references and a brief
 IUPHAR summary.  Lists are serialised as JSON arrays and sorted to guarantee
 reproducible files.  See the source for the full column list.
 
+The CLI honours defaults from ``config.yaml`` but command line switches always
+take precedence. For example ``--list-format`` overrides ``pipeline.list_format``
+and ``--species`` prepends values to ``pipeline.species_priority``. Ortholog
+enrichment follows the ``orthologs.enabled`` setting unless either
+``--with-orthologs`` or ``--no-with-orthologs`` is supplied, providing an easy
+way to enable or disable the feature without editing YAML files.
+
+Optional sections such as ``orthologs``, ``chembl`` or ``uniprot_enrich`` can be
+set to ``null`` in the configuration file when they are not required. The
+pipeline falls back to sensible defaults in this case while still allowing the
+sections to be re-enabled later without removing placeholder keys.
+
 
 ## CSV output conventions
 

--- a/tests/test_pipeline_targets_main.py
+++ b/tests/test_pipeline_targets_main.py
@@ -242,7 +242,7 @@ def test_merge_species_lists_prioritises_cli_values() -> None:
 
 def test_parse_args_with_orthologs_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     config_path = tmp_path / "config.yaml"
-    config_path.write_text("{}\n", encoding="utf-8")
+    config_path.write_text("orthologs:\n  enabled: true\n", encoding="utf-8")
 
     monkeypatch.setattr(
         sys,
@@ -258,7 +258,7 @@ def test_parse_args_with_orthologs_flag(monkeypatch: pytest.MonkeyPatch, tmp_pat
         ],
     )
     args = parse_args()
-    assert args.with_orthologs is None
+    assert args.with_orthologs is True
 
     monkeypatch.setattr(
         sys,
@@ -276,4 +276,21 @@ def test_parse_args_with_orthologs_flag(monkeypatch: pytest.MonkeyPatch, tmp_pat
     )
     args_with_flag = parse_args()
     assert args_with_flag.with_orthologs is True
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pipeline_targets_main",
+            "--input",
+            "input.csv",
+            "--output",
+            "output.csv",
+            "--config",
+            str(config_path),
+            "--no-with-orthologs",
+        ],
+    )
+    args_without_flag = parse_args()
+    assert args_without_flag.with_orthologs is False
 


### PR DESCRIPTION
## Summary
- derive the `--with-orthologs` CLI default from `orthologs.enabled` and add robust YAML parsing helpers
- harden `PipelineConfig` loading with explicit type validation for mappings, booleans, numerics and column lists
- extend CLI and pipeline unit tests to cover YAML-driven ortholog toggles and null configuration sections, and document CLI precedence over YAML

## Testing
- black scripts/pipeline_targets_main.py library/pipeline_targets.py tests/test_pipeline_targets_cli.py tests/test_pipeline_targets.py
- ruff check scripts/pipeline_targets_main.py library/pipeline_targets.py tests/test_pipeline_targets_cli.py tests/test_pipeline_targets.py
- mypy scripts/pipeline_targets_main.py library/pipeline_targets.py
- pytest tests/test_pipeline_targets_cli.py tests/test_pipeline_targets.py

------
https://chatgpt.com/codex/tasks/task_e_68cc0d62aa3c8324a48fa7d257b2050f