### PR TITLE
Improve validation of pipeline target identifiers

### DIFF
--- a/tests/test_pipeline_targets_main.py
+++ b/tests/test_pipeline_targets_main.py
@@ -90,7 +90,20 @@ def test_add_protein_classification_fetches_once() -> None:
         calls.append(collected)
         return {acc: samples["gpcr"] for acc in collected}
 
-    df = pd.DataFrame({"uniprot_id_primary": ["P00000", "", "P00000"]})
+    df = pd.DataFrame(
+        {
+            "uniprot_id_primary": [
+                "P00000",
+                "",
+                None,
+                float("nan"),
+                "nan",
+                "None",
+                "  ",
+                "P00000",
+            ]
+        }
+    )
     add_protein_classification(df, fetcher)
     assert len(calls) == 1
     assert calls[0] == ["P00000"]
@@ -293,4 +306,24 @@ def test_parse_args_with_orthologs_flag(monkeypatch: pytest.MonkeyPatch, tmp_pat
     )
     args_without_flag = parse_args()
     assert args_without_flag.with_orthologs is False
+
+
+def test_parse_args_rejects_non_positive_batch_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pipeline_targets_main",
+            "--input",
+            "input.csv",
+            "--output",
+            "output.csv",
+            "--batch-size",
+            "0",
+        ],
+    )
+    with pytest.raises(SystemExit):
+        parse_args()
 


### PR DESCRIPTION
## Summary
- normalise identifier handling across the CLI helpers so blank, NaN or sentinel values are stripped before downstream fetches
- validate batch size arguments and reuse the identifier cleaning inside the library pipeline orchestration
- extend CLI and unit tests to cover invalid identifiers and non-positive batch sizes

## Testing
- pytest tests/test_pipeline_targets_main.py tests/test_pipeline_targets_cli.py tests/test_pipeline_targets.py

------
https://chatgpt.com/codex/tasks/task_e_68cc28f0a8c48324b7374d8bdb841b2a