### PR TITLE
Add Pydantic-backed pipeline configuration validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ export CHEMBL_BATCH__SIZE=10  # Equivalent to CHEMBL_DA__BATCH__SIZE
 python scripts/chembl2uniprot_main.py --config my_config.yaml
 ```
 
+The unified target pipeline honours the same convention. For instance, to switch the serialisation format without editing `config.yaml` use:
+
+```bash
+export CHEMBL_DA__PIPELINE__LIST_FORMAT=pipe
+export CHEMBL_DA__PIPELINE__IUPHAR__APPROVED_ONLY=true
+python scripts/pipeline_targets_main.py --input data/input/targets.csv --output data/output/final_targets.csv
+```
+
 Always define the environment variables in the shell session before launching the CLI so that the overrides are visible to the Python process.
 
 #### HTTP retry configuration

--- a/docs/README.md
+++ b/docs/README.md
@@ -213,6 +213,12 @@ enrichment follows the ``orthologs.enabled`` setting unless either
 ``--with-orthologs`` or ``--no-with-orthologs`` is supplied, providing an easy
 way to enable or disable the feature without editing YAML files.
 
+Environment variables prefixed with ``CHEMBL_DA__PIPELINE__`` offer an
+alternative override mechanism when editing configuration files is not
+practical. For instance ``CHEMBL_DA__PIPELINE__LIST_FORMAT=pipe`` switches list
+serialisation globally, while ``CHEMBL_DA__PIPELINE__IUPHAR__APPROVED_ONLY=true``
+enables the corresponding IUPHAR filter.
+
 Optional sections such as ``orthologs``, ``chembl`` or ``uniprot_enrich`` can be
 set to ``null`` in the configuration file when they are not required. The
 pipeline falls back to sensible defaults in this case while still allowing the

--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -1116,7 +1116,7 @@ def main() -> None:
     ids: List[str] = list(unique_ids)
 
     # Fetch comprehensive ChEMBL data once and reuse it in the pipeline
-    chembl_df = fetch_targets(ids, chembl_cfg, batch_size=args.batch_size)
+    chembl_df: pd.DataFrame = fetch_targets(ids, chembl_cfg, batch_size=args.batch_size)
 
     def _cached_chembl_fetch(
         _: Sequence[str], __: TargetConfig

--- a/tests/test_chembl_testitems_pipeline.py
+++ b/tests/test_chembl_testitems_pipeline.py
@@ -109,14 +109,16 @@ def test_chembl_testitems_main_end_to_end(
             }
         }
 
+    property_suffix = (
+        "MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,"
+        "HBondAcceptorCount,RotatableBondCount/JSON"
+    )
     requests_mock.get(
-        f"{pubchem_base}/compound/smiles/C/property/"
-        "CID,MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
+        f"{pubchem_base}/compound/smiles/C/property/{property_suffix}",
         json=_pubchem_response(11, "CH4"),
     )
     requests_mock.get(
-        f"{pubchem_base}/compound/smiles/CC/property/"
-        "CID,MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
+        f"{pubchem_base}/compound/smiles/CC/property/{property_suffix}",
         json=_pubchem_response(22, "C2H6"),
     )
     requests_mock.get(

--- a/tests/test_pipeline_targets.py
+++ b/tests/test_pipeline_targets.py
@@ -140,8 +140,22 @@ pipeline:
         + "\n",
         encoding="utf-8",
     )
-    with pytest.raises(TypeError, match="pipeline.retries"):
+    with pytest.raises(ValueError, match="retries"):
         load_pipeline_config(str(cfg_path))
+
+
+def test_load_pipeline_config_env_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg_path = tmp_path / "config_env.yaml"
+    cfg_path.write_text("pipeline:\n  list_format: json\n", encoding="utf-8")
+    monkeypatch.setenv("CHEMBL_DA__PIPELINE__LIST_FORMAT", "pipe")
+    monkeypatch.setenv("CHEMBL_DA__PIPELINE__IUPHAR__APPROVED_ONLY", "true")
+    monkeypatch.setenv(
+        "CHEMBL_DA__PIPELINE__SPECIES_PRIORITY", "[\"Mouse\", \"Rat\"]"
+    )
+    cfg = load_pipeline_config(str(cfg_path))
+    assert cfg.list_format == "pipe"
+    assert cfg.iuphar.approved_only is True
+    assert cfg.species_priority == ["Mouse", "Rat"]
 
 
 def test_pipeline_single_target(monkeypatch):


### PR DESCRIPTION
## Summary
- replace the dataclass-based pipeline configuration with a pydantic model that provides validation, defaults, and timestamp normalisation
- honour CHEMBL_DA__PIPELINE__* environment variables when loading the YAML configuration and add coverage for the new override behaviour
- document the new override mechanism and update the PubChem fixture to reflect the properties endpoint that is actually requested

## Testing
- ruff check .
- mypy --strict --ignore-missing-imports .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc64dfa2f4832497c11e1372b876ec