### PR TITLE
Refine target and GtoP CLIs with streaming IO and metadata

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -181,11 +181,16 @@ python scripts/get_target_data_main.py \
     --input targets.csv \
     --output targets_dump.csv \
     --column target_chembl_id \
-    --log-level INFO
+    --sep , \
+    --encoding utf-8-sig \
+    --list-format json \
+    --log-level INFO \
+    --meta-output targets_dump.csv.meta.yaml
 ```
 
-Nested fields in the output are encoded as JSON strings to ensure
-deterministic, machine-readable results.
+Nested fields in the output are encoded deterministically according to
+``--list-format``. The CLI writes both ``targets_dump.csv`` and a metadata
+sidecar capturing the command invocation, file checksum, and table dimensions.
 
 The set of columns retrieved from ChEMBL can be customised in
 ``config.yaml`` under the ``chembl.columns`` section.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -11,13 +11,18 @@ python scripts/get_target_data_main.py \
     --input data/targets.csv \
     --output out/targets_dump.csv \
     --column target_chembl_id \
+    --sep , \
+    --encoding utf-8-sig \
+    --list-format json \
     --log-level INFO \
-    --log-format json
+    --meta-output out/targets_dump.csv.meta.yaml
 ```
 
 The input file must contain a column with ChEMBL target identifiers. Duplicate
 and empty values are ignored. The resulting CSV contains one row per unique
-identifier with nested fields serialised as JSON strings.
+identifier with nested fields serialised deterministically via
+``--list-format``. A companion ``.meta.yaml`` file captures the CLI invocation,
+row/column counts, and output checksum.
 
 ## dump_gtop_target.py
 
@@ -31,14 +36,18 @@ python scripts/dump_gtop_target.py \
     --id-column uniprot_id \
     --affinity-parameter pKi \
     --affinity-ge 7 \
+    --sep , \
+    --encoding utf-8-sig \
     --log-level INFO \
-    --log-format json
+    --meta-output out/gtop/targets_overview.meta.yaml
 ```
 
 This command creates ``targets.csv`` together with related tables such as
 ``targets_synonyms.csv`` and ``targets_interactions.csv`` in the specified output
 directory. Only unique identifiers are queried and results are written in a
-deterministic order.
+deterministic order. The main table is accompanied by a metadata sidecar (set
+to a custom path above via ``--meta-output``) that records runtime parameters
+and checksums.
 
 ## Performance smoke testing
 

--- a/library/io.py
+++ b/library/io.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import csv
 import logging
 from pathlib import Path
+from collections.abc import Callable
 from typing import Iterator, Set
 
 from .io_utils import CsvConfig
@@ -28,7 +29,12 @@ LOGGER = logging.getLogger(__name__)
 
 
 def read_ids(
-    path: Path, column: str, cfg: CsvConfig, *, limit: int | None = None
+    path: Path,
+    column: str,
+    cfg: CsvConfig,
+    *,
+    limit: int | None = None,
+    normalise: Callable[[str], str] | None = str.upper,
 ) -> Iterator[str]:
     """Yield unique identifiers from ``column`` of ``path`` lazily.
 
@@ -43,6 +49,10 @@ def read_ids(
     limit:
         Optional maximum number of **unique** identifiers to yield. ``None``
         disables limiting and streams the entire file.
+    normalise:
+        Callable applied to each non-empty cell before deduplication and
+        yielding. The default converts values to upper case. Pass ``None`` to
+        preserve the original casing while still trimming whitespace.
 
     Yields
     ------
@@ -68,7 +78,7 @@ def read_ids(
             raw_value = (row.get(column) or "").strip()
             if not raw_value:
                 continue
-            normalised = raw_value.upper()
+            normalised = normalise(raw_value) if normalise is not None else raw_value
             if normalised in seen:
                 continue
             seen.add(normalised)

--- a/scripts/get_target_data_main.py
+++ b/scripts/get_target_data_main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from datetime import datetime
 from pathlib import Path
 from typing import Sequence
 
@@ -12,58 +13,130 @@ if __package__ in {None, ""}:
     _ensure_project_root()
 
 from chembl_targets import TargetConfig, fetch_targets  # noqa: E402
-from data_profiling import analyze_table_quality  # noqa: E402
+from library.cli_common import (  # noqa: E402
+    analyze_table_quality,
+    ensure_output_dir,
+    serialise_dataframe,
+    write_cli_metadata,
+)
+from library.io import read_ids  # noqa: E402
+from library.io_utils import CsvConfig, write_rows  # noqa: E402
 from library.logging_utils import configure_logging  # noqa: E402
 
 DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_SEP = ","
 DEFAULT_ENCODING = "utf-8-sig"
 DEFAULT_LOG_FORMAT = "human"
+DEFAULT_INPUT = "input.csv"
+DEFAULT_COLUMN = "target_chembl_id"
 
 
-def main(argv: Sequence[str] | None = None) -> None:
-    """Parse command-line arguments and run the target data download.
+def _default_output_name(input_path: str) -> str:
+    """Derive the default output file name from ``input_path``."""
 
-    Parameters
-    ----------
-    argv:
-        Optional list of command line arguments. When ``None`` the CLI values
-        provided by the user are used.
-    """
+    stem = Path(input_path).stem or "input"
+    date_suffix = datetime.utcnow().strftime("%Y%m%d")
+    return f"output_{stem}_{date_suffix}.csv"
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Create an argument parser and return parsed ``argv``."""
+
     parser = argparse.ArgumentParser(description="Download ChEMBL target data")
-    parser.add_argument("--input", required=True, help="Input CSV file")
-    parser.add_argument("--output", required=True, help="Output CSV file")
     parser.add_argument(
-        "--column", default="target_chembl_id", help="Column with target IDs"
+        "--input", default=DEFAULT_INPUT, help="Input CSV file containing identifiers"
     )
-    parser.add_argument("--log-level", default=DEFAULT_LOG_LEVEL)
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output CSV file. Defaults to output_<input>_<YYYYMMDD>.csv",
+    )
+    parser.add_argument(
+        "--column",
+        default=DEFAULT_COLUMN,
+        help="Name of the column providing ChEMBL target identifiers",
+    )
+    parser.add_argument(
+        "--log-level",
+        default=DEFAULT_LOG_LEVEL,
+        help="Logging level (e.g. DEBUG, INFO)",
+    )
     parser.add_argument(
         "--log-format",
         default=DEFAULT_LOG_FORMAT,
         choices=("human", "json"),
-        help="Logging output format (human or json)",
+        help="Logging output format",
     )
-    parser.add_argument("--sep", default=DEFAULT_SEP)
-    parser.add_argument("--encoding", default=DEFAULT_ENCODING)
-    args = parser.parse_args(argv)
+    parser.add_argument(
+        "--sep",
+        default=DEFAULT_SEP,
+        help="CSV delimiter used for reading input and writing output",
+    )
+    parser.add_argument(
+        "--encoding",
+        default=DEFAULT_ENCODING,
+        help="Text encoding for input and output CSV files",
+    )
+    parser.add_argument(
+        "--list-format",
+        choices=("json", "pipe"),
+        default="json",
+        help="Serialisation format for list-like columns",
+    )
+    parser.add_argument(
+        "--meta-output",
+        default=None,
+        help="Optional path for the generated .meta.yaml file",
+    )
+    return parser.parse_args(argv)
 
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Parse command-line arguments and run the target data download."""
+
+    args = parse_args(argv)
     configure_logging(args.log_level, log_format=args.log_format)
 
-    import pandas as pd
+    input_path = Path(args.input).expanduser().resolve()
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input file {input_path} does not exist")
 
-    df = pd.read_csv(args.input, sep=args.sep, encoding=args.encoding)
-    if args.column not in df.columns:
-        raise ValueError(f"missing column {args.column}")
-    ids = df[args.column].dropna().astype(str).tolist()
-
-    cfg = TargetConfig(output_sep=args.sep, output_encoding=args.encoding)
-    result = fetch_targets(ids, cfg)
-    result.to_csv(
-        args.output, index=False, sep=cfg.output_sep, encoding=cfg.output_encoding
+    output_candidate = (
+        Path(args.output).expanduser().resolve()
+        if args.output
+        else input_path.with_name(_default_output_name(args.input))
     )
-    analyze_table_quality(result, table_name=str(Path(args.output).with_suffix("")))
+    output_path = ensure_output_dir(output_candidate)
 
-    print(args.output)
+    csv_cfg = CsvConfig(
+        sep=args.sep, encoding=args.encoding, list_format=args.list_format
+    )
+    identifiers = list(read_ids(input_path, args.column, csv_cfg))
+
+    target_cfg = TargetConfig(
+        output_sep=args.sep,
+        output_encoding=args.encoding,
+        list_format=args.list_format,
+    )
+    result = fetch_targets(identifiers, target_cfg)
+    serialised = serialise_dataframe(result, args.list_format)
+
+    columns = list(serialised.columns) or list(target_cfg.columns)
+    rows = serialised.to_dict(orient="records")
+    write_rows(output_path, rows, columns, csv_cfg)
+
+    analyze_table_quality(serialised, table_name=str(output_path.with_suffix("")))
+
+    meta_path = Path(args.meta_output).expanduser().resolve() if args.meta_output else None
+    write_cli_metadata(
+        output_path,
+        row_count=int(serialised.shape[0]),
+        column_count=int(len(columns)),
+        namespace=args,
+        meta_path=meta_path,
+    )
+
+    print(output_path)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_dump_gtop_target_cli.py
+++ b/tests/test_dump_gtop_target_cli.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+import sys
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import dump_gtop_target  # noqa: E402
+
+
+class DummyClient:
+    """Minimal stub emulating ``GtoPClient`` interactions."""
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        self.synonym_calls: list[int] = []
+        self.interaction_calls: list[int] = []
+
+    def fetch_target_endpoint(
+        self, target_id: int, endpoint: str, params: dict[str, object] | None = None
+    ) -> list[dict[str, object]]:
+        if endpoint == "synonyms":
+            self.synonym_calls.append(target_id)
+            return [{"synonym": "Example", "synonymType": "Preferred"}]
+        if endpoint == "interactions":
+            self.interaction_calls.append(target_id)
+            return [
+                {
+                    "ligandId": 42,
+                    "type": "Inhibition",
+                    "action": "antagonist",
+                    "affinity": 8.7,
+                    "affinityParameter": params.get("affinityType") if params else None,
+                    "species": "Human",
+                    "ligandType": "Small molecule",
+                    "approved": True,
+                    "primaryTarget": True,
+                }
+            ]
+        msg = f"Unexpected endpoint: {endpoint}"
+        raise AssertionError(msg)
+
+
+def test_dump_gtop_target_cli_smoke(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure the GtoP dump CLI writes CSV tables and metadata."""
+
+    input_csv = tmp_path / "ids.csv"
+    input_csv.write_text("uniprot_id\np12345\n", encoding="utf-8")
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "gtop:",
+                "  base_url: https://example.org",  # mocked HTTP interactions
+                "output:",
+                "  encoding: utf-8",
+                "  sep: ','",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    dummy_client = DummyClient()
+    monkeypatch.setattr(dump_gtop_target, "GtoPClient", lambda *_args, **_kwargs: dummy_client)
+    monkeypatch.setattr(
+        dump_gtop_target,
+        "resolve_target",
+        lambda _client, identifier, _column: {
+            "targetId": 101,
+            "name": f"Target {identifier.upper()}",
+            "targetType": "Protein",
+            "family": "GPCR",
+            "species": "Human",
+            "description": "Mock target",
+        },
+    )
+
+    output_dir = tmp_path / "gtop"
+    meta_file = output_dir / "targets_overview.meta.yaml"
+
+    dump_gtop_target.main(
+        [
+            "--input",
+            str(input_csv),
+            "--output-dir",
+            str(output_dir),
+            "--config",
+            str(config_path),
+            "--id-column",
+            "uniprot_id",
+            "--encoding",
+            "utf-8",
+            "--sep",
+            ",",
+            "--meta-output",
+            str(meta_file),
+        ]
+    )
+
+    targets_csv = output_dir / "targets.csv"
+    assert targets_csv.exists()
+
+    with targets_csv.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+
+    assert rows == [
+        {
+            "targetId": "101",
+            "name": "Target P12345",
+            "targetType": "Protein",
+            "family": "GPCR",
+            "species": "Human",
+            "description": "Mock target",
+        }
+    ]
+
+    assert dummy_client.synonym_calls == [101]
+    assert dummy_client.interaction_calls == [101]
+
+    assert meta_file.exists()
+    meta = yaml.safe_load(meta_file.read_text(encoding="utf-8"))
+    assert meta["rows"] == 1
+    assert meta["columns"] == 6
+    assert meta["output"] == str(targets_csv)

--- a/tests/test_get_target_data_cli.py
+++ b/tests/test_get_target_data_cli.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+import sys
+
+import pandas as pd
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.get_target_data_main import main  # noqa: E402
+
+
+def test_get_target_data_cli_writes_csv_and_meta(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Smoke-test the target metadata CLI output and metadata sidecar."""
+
+    input_csv = tmp_path / "targets.csv"
+    input_csv.write_text(
+        "target_chembl_id\nchembl123\nCHEMBL123\nchembl999\n",
+        encoding="utf-8",
+    )
+    output_csv = tmp_path / "dump.csv"
+
+    sample = pd.DataFrame(
+        [
+            {
+                "target_chembl_id": "CHEMBL123",
+                "pref_name": "Example target",
+                "cross_references": [{"source": "UniProt", "xref_id": "P12345"}],
+            },
+            {
+                "target_chembl_id": "CHEMBL999",
+                "pref_name": "Fallback",
+                "cross_references": [],
+            },
+        ]
+    )
+
+    def fake_fetch(ids: list[str], _cfg: object) -> pd.DataFrame:
+        assert ids == ["CHEMBL123", "CHEMBL999"]
+        return sample
+
+    monkeypatch.setattr("scripts.get_target_data_main.fetch_targets", fake_fetch)
+
+    main(
+        [
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--column",
+            "target_chembl_id",
+            "--encoding",
+            "utf-8",
+            "--sep",
+            ",",
+            "--list-format",
+            "json",
+        ]
+    )
+
+    with output_csv.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+
+    assert [row["target_chembl_id"] for row in rows] == ["CHEMBL123", "CHEMBL999"]
+    assert rows[0]["pref_name"] == "Example target"
+    cross_refs = json.loads(rows[0]["cross_references"])
+    assert cross_refs == [{"xref_id": "P12345", "source": "UniProt"}]
+
+    meta_path = output_csv.with_suffix(f"{output_csv.suffix}.meta.yaml")
+    meta = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+    assert meta["rows"] == 2
+    assert meta["columns"] == 3
+    assert meta["output"] == str(output_csv)


### PR DESCRIPTION
## Summary
- switch get_target_data_main.py to the streaming CSV helpers, reuse cli_common utilities, and add metadata/list-format controls
- refactor dump_gtop_target.py to share the same IO pipeline, extend CLI options, and emit metadata alongside auxiliary tables
- extend documentation and add smoke tests covering CSV and .meta.yaml generation for both CLIs

## Testing
- pytest tests/test_get_target_data_cli.py tests/test_dump_gtop_target_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cc810e4e3483248807e8ddeedf8c0b