### PR TITLE
Refine UniProt serialisation handling

### DIFF
--- a/scripts/get_uniprot_target_data.py
+++ b/scripts/get_uniprot_target_data.py
@@ -8,11 +8,10 @@ Examples
 from __future__ import annotations
 
 import argparse
-import json
 import logging
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
-from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 import yaml
@@ -274,7 +273,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             row: dict[str, Any] = {c: "" for c in cols}
             row["uniprot_id"] = acc
             if ensembl_client:
-                row["orthologs_json"] = "[]"
+                row["orthologs_json"] = []
                 row["orthologs_count"] = 0
             rows.append(row)
             continue
@@ -294,29 +293,21 @@ def main(argv: Sequence[str] | None = None) -> None:
                         "parent_uniprot_id": acc,
                         "isoform_uniprot_id": iso["isoform_uniprot_id"],
                         "isoform_name": iso["isoform_name"],
-                        "isoform_synonyms": json.dumps(
-                            iso["isoform_synonyms"],
-                            ensure_ascii=False,
-                            sort_keys=True,
-                        ),
-                        "is_canonical": str(iso["is_canonical"]).lower(),
+                        "isoform_synonyms": iso["isoform_synonyms"],
+                        "is_canonical": iso["is_canonical"],
                     }
                 )
 
         row = normalize_entry(data, include_seq, isoforms)
 
-        orthologs_json = "[]"
+        orthologs_json: list[dict[str, Any]] = []
         orthologs_count = 0
         if ensembl_client and gene_ids:
             gene_id = gene_ids[0]
             orthologs = ensembl_client.get_orthologs(gene_id, target_species)
             if not orthologs and oma_client:
                 orthologs = oma_client.get_orthologs_by_uniprot(acc)
-            orthologs_json = json.dumps(
-                [o.to_ordered_dict() for o in orthologs],
-                separators=(",", ":"),
-                sort_keys=True,
-            )
+            orthologs_json = [o.to_ordered_dict() for o in orthologs]
             orthologs_count = len(orthologs)
             for o in orthologs:
                 orth_rows.append(
@@ -345,11 +336,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             )
             if oma_client:
                 orthologs = oma_client.get_orthologs_by_uniprot(acc)
-                orthologs_json = json.dumps(
-                    [o.to_ordered_dict() for o in orthologs],
-                    separators=(",", ":"),
-                    sort_keys=True,
-                )
+                orthologs_json = [o.to_ordered_dict() for o in orthologs]
                 orthologs_count = len(orthologs)
                 for o in orthologs:
                     orth_rows.append(

--- a/tests/test_uniprot_serialisation.py
+++ b/tests/test_uniprot_serialisation.py
@@ -1,0 +1,74 @@
+"""Ensure UniProt exports rely on native Python collections for serialisation."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from library.io_utils import CsvConfig, write_rows
+
+
+@pytest.mark.parametrize("list_format", ["json", "pipe"])
+def test_uniprot_serialisation_formats(tmp_path: Path, list_format: str) -> None:
+    """Verify serialisation of isoform and ortholog payloads across formats."""
+
+    cfg = CsvConfig(sep=",", encoding="utf-8", list_format=list_format)
+    ortholog_entry = {
+        "dn": 0.1,
+        "ds": None,
+        "homology_type": "ortholog",
+        "is_high_confidence": False,
+        "perc_id": 55.5,
+        "perc_pos": 60.0,
+        "source_db": "Ensembl",
+        "target_ensembl_gene_id": "ENSR1",
+        "target_gene_symbol": "GeneR",
+        "target_species": "rat",
+        "target_uniprot_id": "Q1",
+    }
+    rows = [
+        {
+            "parent_uniprot_id": "P12345",
+            "isoform_uniprot_id": "P12345-1",
+            "isoform_name": "Isoform 1",
+            "isoform_synonyms": ["Alpha", "Beta"],
+            "is_canonical": True,
+            "orthologs_json": [ortholog_entry],
+            "orthologs_count": 1,
+        }
+    ]
+    columns: list[str] = [
+        "parent_uniprot_id",
+        "isoform_uniprot_id",
+        "isoform_name",
+        "isoform_synonyms",
+        "is_canonical",
+        "orthologs_json",
+        "orthologs_count",
+    ]
+
+    output_path = tmp_path / f"serialised_{list_format}.csv"
+    write_rows(output_path, rows, columns, cfg)
+
+    with output_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter=cfg.sep)
+        result = next(reader)
+
+    if list_format == "json":
+        assert json.loads(result["isoform_synonyms"]) == ["Alpha", "Beta"]
+        ortholog_payload = json.loads(result["orthologs_json"])
+        assert isinstance(ortholog_payload, list)
+        assert ortholog_payload[0]["is_high_confidence"] is False
+        assert ortholog_payload[0]["perc_id"] == pytest.approx(55.5)
+    else:
+        assert result["isoform_synonyms"] == "Alpha|Beta"
+        fragments = result["orthologs_json"].split("|")
+        parsed = [json.loads(fragment.replace("\\|", "|")) for fragment in fragments]
+        assert parsed[0]["target_species"] == "rat"
+        assert parsed[0]["perc_id"] == pytest.approx(55.5)
+
+    assert result["is_canonical"] == "True"
+    assert result["orthologs_count"] == "1"


### PR DESCRIPTION
## Summary
- ensure the UniProt export script passes native Python collections to the CSV writer so list formatting happens centrally
- keep ortholog aggregates as lists of dictionaries so boolean and numeric values serialise correctly for both JSON and pipe outputs
- add a parametrised unit test that verifies the emitted values for json and pipe list formats

## Testing
- black scripts/get_uniprot_target_data.py tests/test_uniprot_serialisation.py
- ruff check scripts/get_uniprot_target_data.py tests/test_uniprot_serialisation.py
- mypy scripts/get_uniprot_target_data.py
- pytest tests/test_uniprot_serialisation.py
- pytest tests/test_uniprot_dump.py


------
https://chatgpt.com/codex/tasks/task_e_68cc812c57bc8324b5b4aa9d1f30b7ad