### PR TITLE
Improve ChEMBL target error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,10 @@ The `scripts/` directory contains several other scripts for performing specific 
 
 *   `chembl2uniprot_main.py`: Map ChEMBL IDs to UniProt accessions.
 *   `chembl_tissue_main.py`: Download tissue metadata directly from ChEMBL.
-*   `get_target_data_main.py`: Download target metadata from ChEMBL.
+*   `get_target_data_main.py`: Download target metadata from ChEMBL. The CLI
+    aborts when any chunk fails and writes a detailed
+    `<output>.errors.json` report next to the main file so missing records are
+    never silently ignored.
 *   `get_cell_line_main.py`: Download metadata for specific ChEMBL cell lines and
     serialise the records as JSON lines.
 *   `get_uniprot_target_data.py`: Retrieve and normalize detailed information about UniProt targets.

--- a/scripts/get_target_data_main.py
+++ b/scripts/get_target_data_main.py
@@ -57,13 +57,14 @@ def main(argv: Sequence[str] | None = None) -> None:
     ids = df[args.column].dropna().astype(str).tolist()
 
     cfg = TargetConfig(output_sep=args.sep, output_encoding=args.encoding)
-    result = fetch_targets(ids, cfg)
+    output_path = Path(args.output).expanduser()
+    result = fetch_targets(ids, cfg, output_path=output_path)
     result.to_csv(
-        args.output, index=False, sep=cfg.output_sep, encoding=cfg.output_encoding
+        output_path, index=False, sep=cfg.output_sep, encoding=cfg.output_encoding
     )
-    analyze_table_quality(result, table_name=str(Path(args.output).with_suffix("")))
+    analyze_table_quality(result, table_name=str(output_path.with_suffix("")))
 
-    print(args.output)
+    print(str(output_path))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -6,11 +6,11 @@ import argparse
 import logging
 import os
 import sys
- 
+
 from functools import partial
- 
+
 from dataclasses import dataclass
- 
+
 from pathlib import Path
 
 from collections.abc import Iterable, Mapping, Sequence
@@ -1276,6 +1276,7 @@ def main() -> None:
         )
     pipeline_cfg.include_isoforms = pipeline_cfg.include_isoforms or args.with_isoforms
     use_isoforms = pipeline_cfg.include_isoforms
+    output_path = Path(args.output).expanduser().resolve()
 
     # Load optional ChEMBL column configuration and ensure required fields
     data = _load_yaml_mapping(args.config)
@@ -1360,9 +1361,11 @@ def main() -> None:
     # Fetch comprehensive ChEMBL data once and reuse it in the pipeline
 
     chembl_df: pd.DataFrame = fetch_targets(
-        ids, chembl_cfg, batch_size=args.batch_size
+        ids,
+        chembl_cfg,
+        batch_size=args.batch_size,
+        output_path=output_path,
     )
-
 
     def _cached_chembl_fetch(
         _: Sequence[str], __: TargetConfig
@@ -1433,7 +1436,7 @@ def main() -> None:
     if sort_columns:
         out_df = out_df.sort_values(sort_columns).reset_index(drop=True)
 
-    output_path = ensure_output_dir(Path(args.output).expanduser().resolve())
+    output_path = ensure_output_dir(output_path)
     serialised_df = serialise_dataframe(out_df, list_format=pipeline_cfg.list_format)
     serialised_df.to_csv(
         output_path,

--- a/tests/test_chembl_targets.py
+++ b/tests/test_chembl_targets.py
@@ -1,15 +1,25 @@
 from pathlib import Path
 import sys
+import json
+import logging
+from typing import Any
 
+import pytest
 import requests_mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import library.chembl_targets as chembl_targets
 from library.chembl_targets import TargetConfig, fetch_targets
 
 
 def test_fetch_targets_batches(requests_mock: requests_mock.Mocker) -> None:
     cfg = TargetConfig(base_url="https://example.org")
     url = "https://example.org/target"
+
+    def _first_chunk_matcher(request: Any) -> bool:
+        url = request.url
+        return "CHEMBL1%2CCHEMBL2" in url or "CHEMBL1,CHEMBL2" in url
+
     requests_mock.get(
         url,
         json={
@@ -26,7 +36,7 @@ def test_fetch_targets_batches(requests_mock: requests_mock.Mocker) -> None:
                 },
             ]
         },
-        additional_matcher=lambda r: "CHEMBL1,CHEMBL2" in r.url,
+        additional_matcher=_first_chunk_matcher,
     )
     requests_mock.get(
         url,
@@ -52,3 +62,52 @@ def test_fetch_targets_batches(requests_mock: requests_mock.Mocker) -> None:
     )
     assert requests_mock.call_count == 2
     assert set(df["target_chembl_id"]) == {"CHEMBL1", "CHEMBL2", "CHEMBL3"}
+
+
+def test_fetch_targets_error_reporting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    class DummyResponse:
+        def __init__(self, url: str) -> None:
+            self.status_code = 500
+            self.url = url
+
+        def json(self) -> dict[str, str]:
+            return {}
+
+    class DummyClient:
+        def request(
+            self, method: str, url: str, params: dict[str, str]
+        ) -> DummyResponse:
+            return DummyResponse(url)
+
+    monkeypatch.setattr(chembl_targets, "HttpClient", lambda **_: DummyClient())
+
+    cfg = TargetConfig(base_url="https://example.org")
+    output_path = tmp_path / "targets.csv"
+    caplog.set_level(logging.WARNING, logger=chembl_targets.__name__)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        fetch_targets(
+            [
+                "CHEMBL1",
+            ],
+            cfg,
+            batch_size=1,
+            output_path=output_path,
+        )
+
+    assert "Failed to fetch 1 chunk" in str(excinfo.value)
+
+    error_path = output_path.with_suffix(f"{output_path.suffix}.errors.json")
+    assert error_path.exists()
+    payload = json.loads(error_path.read_text(encoding="utf-8"))
+    assert len(payload) == 1
+    entry = payload[0]
+    assert entry["chunk_index"] == 0
+    assert entry["identifiers"] == ["CHEMBL1"]
+    assert entry["status_code"] == 500
+    assert any(
+        "Chunk 0" in record.getMessage() and "500" in record.getMessage()
+        for record in caplog.records
+    )

--- a/tests/test_pipeline_targets_cli.py
+++ b/tests/test_pipeline_targets_cli.py
@@ -74,7 +74,9 @@ def test_pipeline_targets_cli_writes_outputs(
         cfg = module.PipelineConfig()
         return cfg
 
-    def fake_fetch_targets(ids: list[str], _: Any, batch_size: int) -> pd.DataFrame:
+    def fake_fetch_targets(
+        ids: list[str], _: Any, batch_size: int, **_kwargs: Any
+    ) -> pd.DataFrame:
         return pd.DataFrame(
             {
                 "target_chembl_id": ids,
@@ -211,7 +213,9 @@ def test_pipeline_targets_cli_filters_invalid_ids(
 
     captured: dict[str, Any] = {}
 
-    def fake_fetch_targets(ids: list[str], cfg: Any, batch_size: int) -> pd.DataFrame:
+    def fake_fetch_targets(
+        ids: list[str], cfg: Any, batch_size: int, **_kwargs: Any
+    ) -> pd.DataFrame:
         captured["ids"] = list(ids)
         return pd.DataFrame({"target_chembl_id": ids})
 
@@ -226,10 +230,14 @@ def test_pipeline_targets_cli_filters_invalid_ids(
         )
 
     class DummyEnrichClient:
-        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - simple
+        def __init__(
+            self, *args: Any, **kwargs: Any
+        ) -> None:  # pragma: no cover - simple
             pass
 
-        def fetch_all(self, accessions: list[str]) -> dict[str, dict[str, str]]:  # pragma: no cover - simple
+        def fetch_all(
+            self, accessions: list[str]
+        ) -> dict[str, dict[str, str]]:  # pragma: no cover - simple
             return {acc: {} for acc in accessions}
 
     def fake_build_clients(*_args: Any, **_kwargs: Any) -> tuple[Any, ...]:
@@ -249,7 +257,10 @@ def test_pipeline_targets_cli_filters_invalid_ids(
     monkeypatch.setattr(module, "merge_chembl_fields", lambda df, _: df)
     monkeypatch.setattr(module, "add_activity_fields", _identity_frame)
     monkeypatch.setattr(module, "add_isoform_fields", _identity_frame)
-    def _ensure_iuphar_columns(df: pd.DataFrame, *args: Any, **kwargs: Any) -> pd.DataFrame:
+
+    def _ensure_iuphar_columns(
+        df: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> pd.DataFrame:
         frame = df.copy()
         for column in module.IUPHAR_CLASS_COLUMNS:
             if column not in frame.columns:
@@ -799,7 +810,9 @@ uniprot_enrich: null
 
     monkeypatch.setattr(module, "build_clients", fake_build_clients)
 
-    def fake_fetch_targets(ids: list[str], cfg: Any, batch_size: int) -> pd.DataFrame:
+    def fake_fetch_targets(
+        ids: list[str], cfg: Any, batch_size: int, **_kwargs: Any
+    ) -> pd.DataFrame:
         captured["chembl_columns"] = list(cfg.columns)
         return pd.DataFrame({"target_chembl_id": ids})
 

--- a/tests/test_pipeline_targets_main.py
+++ b/tests/test_pipeline_targets_main.py
@@ -16,6 +16,7 @@ from pipeline_targets_main import (
     add_isoform_fields,
     add_protein_classification,
     add_uniprot_fields,
+    build_clients,
     extract_activity,
     extract_isoform,
     merge_chembl_fields,
@@ -368,5 +369,3 @@ def test_parse_args_rejects_non_positive_batch_size(
     )
     with pytest.raises(SystemExit):
         parse_args()
-
-


### PR DESCRIPTION
## Summary
- capture per-chunk failures in `fetch_targets`, write optional `<output>.errors.json` sidecars, and raise with detailed logging context
- propagate output paths from the target CLI and pipeline so fetch failures are reported, and document the behaviour in the README
- add a regression test for error reporting and adjust pipeline test doubles for the new signature

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cc811e68fc8324893719ef40fd4df3