### PR TITLE
Ensure UniProt target export writes metadata and uses CLI helpers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -125,6 +125,12 @@ python scripts/get_uniprot_target_data.py \
 The behaviour is configured via ``config.yaml``.  Lists are serialised either as
 JSON (default) or as ``|``-delimited strings depending on the configuration.
 
+Every run also emits a companion ``.meta.yaml`` file next to the main CSV.  The
+metadata captures the executed command line, normalised CLI arguments and
+summary statistics such as row and column counts.  Basic data quality metrics
+are calculated via ``library.data_profiling.analyze_table_quality`` for
+downstream validation.
+
 
 ### Including orthologs
 


### PR DESCRIPTION
## Summary
- switch the UniProt target export script to the streaming ID reader and CLI helpers for output directories, metadata, and profiling
- remove ad-hoc JSON handling so isoform and ortholog payloads use the shared serialization utilities
- extend the integration test to assert CSV/meta generation and document the new sidecar file in the UniProt CLI docs

## Testing
- pytest tests/test_uniprot_dump.py


------
https://chatgpt.com/codex/tasks/task_e_68cc812e5d1c83248d2efdf8d4ae4fda