### PR TITLE
Improve ChEMBL target error handling

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -24,6 +24,12 @@ identifier with nested fields serialised deterministically via
 ``--list-format``. A companion ``.meta.yaml`` file captures the CLI invocation,
 row/column counts, and output checksum.
 
+Network and API failures are surfaced as ``requests`` exceptions. The downloader
+raises :class:`requests.HTTPError` for non-success HTTP statuses (for example,
+``404`` or ``500`` responses) and propagates other
+:class:`requests.RequestException` instances so that automation can fail fast
+instead of silently producing partial outputs.
+
 ## dump_gtop_target.py
 
 Resolve identifiers against the IUPHAR/BPS Guide to PHARMACOLOGY and download

--- a/library/chembl_targets.py
+++ b/library/chembl_targets.py
@@ -16,11 +16,12 @@ Algorithm Notes
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import logging
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Sequence
 
 import pandas as pd
+import requests
 
 # ``chembl_targets`` can be imported either as part of the ``library`` package or
 # as a standalone module during testing. We therefore try a relative import
@@ -331,6 +332,12 @@ def fetch_targets(
 
     Returns:
         A pandas DataFrame containing the normalized target data.
+
+    Raises:
+        requests.HTTPError: If the ChEMBL API responds with a non-success status.
+        requests.RequestException: If a network-level failure occurs while
+            contacting the ChEMBL API.
+        ValueError: If the response payload cannot be decoded as JSON.
     """
 
     norm_ids = normalise_ids(ids)
@@ -350,21 +357,40 @@ def fetch_targets(
             "limit": str(len(chunk)),
         }
         url = f"{base}/target"
+        chunk_label = ",".join(chunk)
         try:
             resp = client.request("get", url, params=params)
-            if resp.status_code == 200:
+            if resp.status_code != 200:
+                LOGGER.error("Unexpected HTTP %s for %s", resp.status_code, chunk_label)
+                resp.raise_for_status()
+            try:
                 data = resp.json()
-                payload_map = {
-                    t.get("target_chembl_id"): t for t in data.get("targets", []) or []
-                }
-            else:
-                LOGGER.warning(
-                    "Non-200 response for %s: %s", ",".join(chunk), resp.status_code
-                )
+            except ValueError as exc:
+                LOGGER.error("Invalid JSON payload for %s: %s", chunk_label, exc)
+                raise
+            targets_payload: list[Any] = []
+            if isinstance(data, dict):
+                raw_targets = data.get("targets")
+                if isinstance(raw_targets, list):
+                    targets_payload = raw_targets
+            if not targets_payload:
+                LOGGER.warning("Empty target payload received for %s", chunk_label)
                 payload_map = {}
-        except Exception as exc:  # noqa: BLE001 - we log and continue
-            LOGGER.warning("Failed to fetch %s: %s", ",".join(chunk), exc)
-            payload_map = {}
+            else:
+                payload_map = {
+                    t.get("target_chembl_id"): t
+                    for t in targets_payload
+                    if isinstance(t, dict)
+                }
+        except requests.HTTPError as exc:
+            status = exc.response.status_code if exc.response is not None else "?"
+            LOGGER.error(
+                "HTTP error while fetching %s (status %s): %s", chunk_label, status, exc
+            )
+            raise
+        except requests.RequestException as exc:
+            LOGGER.error("Request error while fetching %s: %s", chunk_label, exc)
+            raise
         for chembl_id in chunk:
             payload = payload_map.get(chembl_id, {})
             genes = _extract_gene_symbols(payload)

--- a/tests/test_chembl_targets.py
+++ b/tests/test_chembl_targets.py
@@ -1,6 +1,10 @@
+import logging
 from pathlib import Path
 import sys
+from urllib.parse import parse_qs, urlsplit
 
+import pytest
+import requests
 import requests_mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -26,7 +30,10 @@ def test_fetch_targets_batches(requests_mock: requests_mock.Mocker) -> None:
                 },
             ]
         },
-        additional_matcher=lambda r: "CHEMBL1,CHEMBL2" in r.url,
+        additional_matcher=lambda r: parse_qs(urlsplit(r.url).query).get(
+            "target_chembl_id__in"
+        )
+        == ["CHEMBL1,CHEMBL2"],
     )
     requests_mock.get(
         url,
@@ -39,7 +46,10 @@ def test_fetch_targets_batches(requests_mock: requests_mock.Mocker) -> None:
                 }
             ]
         },
-        additional_matcher=lambda r: "CHEMBL3" in r.url and "CHEMBL1" not in r.url,
+        additional_matcher=lambda r: parse_qs(urlsplit(r.url).query).get(
+            "target_chembl_id__in"
+        )
+        == ["CHEMBL3"],
     )
     df = fetch_targets(
         [
@@ -52,3 +62,35 @@ def test_fetch_targets_batches(requests_mock: requests_mock.Mocker) -> None:
     )
     assert requests_mock.call_count == 2
     assert set(df["target_chembl_id"]) == {"CHEMBL1", "CHEMBL2", "CHEMBL3"}
+
+
+def test_fetch_targets_raises_on_server_error(
+    requests_mock: requests_mock.Mocker,
+) -> None:
+    cfg = TargetConfig(base_url="https://example.org", max_retries=1)
+    url = "https://example.org/target"
+    requests_mock.get(url, status_code=500, text="server error")
+    with pytest.raises(requests.HTTPError):
+        fetch_targets(["CHEMBL1"], cfg, batch_size=1)
+
+
+def test_fetch_targets_raises_on_not_found(
+    requests_mock: requests_mock.Mocker,
+) -> None:
+    cfg = TargetConfig(base_url="https://example.org")
+    url = "https://example.org/target"
+    requests_mock.get(url, status_code=404, json={"detail": "missing"})
+    with pytest.raises(requests.HTTPError):
+        fetch_targets(["CHEMBL1"], cfg, batch_size=1)
+
+
+def test_fetch_targets_warns_on_empty_response(
+    requests_mock: requests_mock.Mocker, caplog: pytest.LogCaptureFixture
+) -> None:
+    cfg = TargetConfig(base_url="https://example.org")
+    url = "https://example.org/target"
+    requests_mock.get(url, status_code=200, json={"targets": []})
+    with caplog.at_level(logging.WARNING):
+        df = fetch_targets(["CHEMBL1"], cfg, batch_size=1)
+    assert "Empty target payload" in caplog.text
+    assert df.shape[0] == 1


### PR DESCRIPTION
## Summary
- raise and log explicit HTTP/requests errors in `fetch_targets`, guard JSON parsing, and warn on empty payloads
- extend the ChEMBL target tests to cover server/not-found errors and empty responses while fixing request matchers
- document the CLI behaviour on API failures

## Testing
- `pytest tests/test_chembl_targets.py`
- `pytest` *(fails: known issues in scripts.dump_gtop_target and scripts.get_uniprot_target_data unrelated to these changes)*
- `ruff check library/chembl_targets.py tests/test_chembl_targets.py`
- `mypy --config-file mypy.ini library/chembl_targets.py`


------
https://chatgpt.com/codex/tasks/task_e_68ccfcc0c99c8324b493fbf4fb77cc6d