### PR TITLE
Fix Ensembl dog species alias to avoid 400 errors

### DIFF
--- a/library/orthologs.py
+++ b/library/orthologs.py
@@ -104,7 +104,14 @@ _SPECIES_MAP = {
     "human": "homo_sapiens",
     "mouse": "mus_musculus",
     "rat": "rattus_norvegicus",
-    "dog": "canis_familiaris",
+    # The Ensembl API expects the full species name ``canis_lupus_familiaris``
+    # for dog ortholog queries.  The previously used alias
+    # ``canis_familiaris`` triggered HTTP 400 errors and prevented the pipeline
+    # from retrieving ortholog data for genes when dog was included in the
+    # target species list.  Normalise both the friendly ``dog`` alias and the
+    # shortened scientific name to the canonical value accepted by the API.
+    "dog": "canis_lupus_familiaris",
+    "canis_familiaris": "canis_lupus_familiaris",
     "macaque": "macaca_mulatta",
     "zebrafish": "danio_rerio",
 }

--- a/tests/test_orthologs.py
+++ b/tests/test_orthologs.py
@@ -11,7 +11,10 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from library.orthologs import EnsemblHomologyClient  # type: ignore  # noqa: E402
+from library.orthologs import (  # type: ignore  # noqa: E402
+    EnsemblHomologyClient,
+    _map_species,
+)
 from library.uniprot_normalize import extract_ensembl_gene_ids  # type: ignore  # noqa: E402
 from library.uniprot_client import NetworkConfig, RateLimitConfig  # type: ignore  # noqa: E402
 
@@ -57,6 +60,13 @@ def make_response(
     else:
         response._content = b""
     return response
+
+
+def test_species_mapping_handles_dog_aliases() -> None:
+    """Ensure dog aliases resolve to the Ensembl canonical species name."""
+
+    assert _map_species("dog") == "canis_lupus_familiaris"
+    assert _map_species("canis_familiaris") == "canis_lupus_familiaris"
 
 
 def test_extract_ensembl_gene_ids() -> None:


### PR DESCRIPTION
## Summary
- normalize dog alias and `canis_familiaris` species names to `canis_lupus_familiaris` so Ensembl ortholog lookups succeed
- add a regression test covering the new species mapping behaviour

## Testing
- black library/orthologs.py tests/test_orthologs.py
- ruff check library/orthologs.py tests/test_orthologs.py
- mypy library/orthologs.py tests/test_orthologs.py
- pytest tests/test_orthologs.py

------
https://chatgpt.com/codex/tasks/task_e_68cd0cc95bc4832485afe59f99d55fe9