### PR TITLE
Default pubmed pipeline to all command

### DIFF
--- a/scripts/pubmed_main.py
+++ b/scripts/pubmed_main.py
@@ -46,6 +46,7 @@ from library.logging_utils import configure_logging
 
 LOGGER = logging.getLogger("pubmed_main")
 DEFAULT_LOG_FORMAT = "human"
+DEFAULT_COMMAND = "all"
 
 DEFAULT_CONFIG: Dict[str, Any] = {
     "io": {"sep": ",", "encoding": "utf-8"},
@@ -939,7 +940,20 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Override the Semantic Scholar timeout",
     )
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers = parser.add_subparsers(dest="command")
+    parser.set_defaults(
+        command=DEFAULT_COMMAND,
+        batch_size=None,
+        sleep=None,
+        workers=None,
+        openalex_rps=None,
+        crossref_rps=None,
+        chunk_size=None,
+        timeout=None,
+        semantic_scholar_rps=None,
+        semantic_scholar_chunk_size=None,
+        semantic_scholar_timeout=None,
+    )
 
     pubmed_parser = subparsers.add_parser(
         "pubmed",

--- a/tests/test_pubmed_main.py
+++ b/tests/test_pubmed_main.py
@@ -360,6 +360,16 @@ def test_output_argument_after_command() -> None:
     assert args.output == "results.csv"
 
 
+def test_default_command_when_omitted() -> None:
+    """Omitting the command should fall back to the default 'all' command."""
+
+    parser = pm.build_parser()
+    args = parser.parse_args(["--input", "input.csv"])
+
+    assert args.command == pm.DEFAULT_COMMAND
+    assert args.workers is None
+
+
 def test_run_semantic_scholar_command(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- default the PubMed CLI to the `all` command when no subcommand is supplied
- ensure command-specific attributes exist for the default path and document behaviour with a regression test

## Testing
- pytest tests/test_pubmed_main.py
- ruff check scripts/pubmed_main.py tests/test_pubmed_main.py
- mypy scripts/pubmed_main.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1a2a4d008324a97c755f82a0a4da