### PR TITLE
Improve UniProt client session reuse and retry penalties

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -137,6 +137,7 @@ chembl2uniprot:
     retry:
       max_attempts: 5
       backoff_sec: 1
+      penalty_sec: 1
   network:
     timeout_sec: 30
   batch:

--- a/library/chembl2uniprot/config.py
+++ b/library/chembl2uniprot/config.py
@@ -79,6 +79,7 @@ class RetryConfig(BaseModel):
 
     max_attempts: int = Field(gt=0)
     backoff_sec: float = Field(ge=0)
+    penalty_sec: float | None = Field(default=None, ge=0)
 
 
 class UniprotConfig(BaseModel):

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -83,7 +83,8 @@
           "required": ["max_attempts", "backoff_sec"],
           "properties": {
             "max_attempts": { "type": "integer", "minimum": 0 },
-            "backoff_sec": { "type": "number", "minimum": 0 }
+            "backoff_sec": { "type": "number", "minimum": 0 },
+            "penalty_sec": { "type": "number", "minimum": 0 }
           }
         }
       }

--- a/tests/data/config/alias.yaml
+++ b/tests/data/config/alias.yaml
@@ -24,6 +24,7 @@ uniprot:
   retry:
     max_attempts: 2
     backoff_sec: 0
+    penalty_sec: 0
 network:
   timeout_sec: 30
 batch:

--- a/tests/data/config/config.schema.json
+++ b/tests/data/config/config.schema.json
@@ -71,7 +71,8 @@
           "required": ["max_attempts", "backoff_sec"],
           "properties": {
             "max_attempts": { "type": "integer", "minimum": 0 },
-            "backoff_sec": { "type": "number", "minimum": 0 }
+            "backoff_sec": { "type": "number", "minimum": 0 },
+            "penalty_sec": { "type": "number", "minimum": 0 }
           }
         }
       }

--- a/tests/data/config/valid.yaml
+++ b/tests/data/config/valid.yaml
@@ -24,6 +24,7 @@ uniprot:
   retry:
     max_attempts: 2
     backoff_sec: 0
+    penalty_sec: 0
 network:
   timeout_sec: 30
 batch:

--- a/tests/test_chembl2uniprot_mapping.py
+++ b/tests/test_chembl2uniprot_mapping.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, Iterable, Iterator, List
 from unittest import mock
 
 import pytest
@@ -19,9 +19,11 @@ from chembl2uniprot.config import (
     UniprotConfig,
 )
 from chembl2uniprot.mapping import (
+    DEFAULT_USER_AGENT,
     RateLimiter,
     _fetch_results,
     _map_batch,
+    _SESSION,
     _request_with_retry,
 )
 
@@ -38,6 +40,69 @@ class _DummyResponse:
 
     def json(self) -> Dict[str, Any]:
         return self.payload
+
+
+class _RecordingSession(requests.Session):
+    """Session stub that records calls and yields pre-seeded responses."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: List[tuple[str, str, float | None]] = []
+        self._responses: Iterator[Any] | None = None
+        self.closed_flag = False
+
+    def queue_responses(self, responses: Iterable[Any]) -> None:
+        """Prime the session with an iterable of responses."""
+
+        self._responses = iter(responses)
+
+    def request(self, method: str, url: str, **kwargs: Any) -> Any:  # type: ignore[override]
+        self.calls.append((method, url, kwargs.get("timeout")))
+        if self._responses is None:
+            raise AssertionError("Responses have not been queued")
+        try:
+            return next(self._responses)
+        except StopIteration as exc:  # pragma: no cover - defensive guard
+            raise AssertionError("Unexpected extra request") from exc
+
+    def close(self) -> None:  # pragma: no cover - exercised via fixture assertions
+        super().close()
+        self.closed_flag = True
+
+
+class _RetryableResponse:
+    """Response stub supporting :meth:`raise_for_status`."""
+
+    def __init__(
+        self,
+        status_code: int,
+        *,
+        headers: Dict[str, str] | None = None,
+        payload: Dict[str, Any] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._payload = payload or {}
+        self.text = json.dumps(self._payload)
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            err = requests.HTTPError(f"HTTP {self.status_code}")
+            err.response = self  # type: ignore[attr-defined]
+            raise err
+
+
+@pytest.fixture
+def recording_session() -> Iterator[_RecordingSession]:
+    """Provide a session stub that ensures cleanup after each test."""
+
+    session = _RecordingSession()
+    yield session
+    session.close()
+    assert session.closed_flag
 
 
 @pytest.fixture
@@ -204,52 +269,19 @@ def test_map_batch_returns_failed_ids(
 def test_request_with_retry_honours_retry_after(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
+    recording_session: _RecordingSession,
 ) -> None:
     """429 responses should trigger retries and rate limiter penalties."""
 
     monkeypatch.setattr("tenacity.nap.sleep", lambda _: None)
     monkeypatch.setattr("library.http_client.time.sleep", lambda _: None)
 
-    class _StubResponse:
-        def __init__(
-            self,
-            status_code: int,
-            *,
-            headers: Dict[str, str] | None = None,
-            payload: Dict[str, Any] | None = None,
-        ) -> None:
-            self.status_code = status_code
-            self.headers = headers or {}
-            self._payload = payload or {}
-            self.text = json.dumps(self._payload)
-
-        def json(self) -> Dict[str, Any]:
-            return self._payload
-
-        def raise_for_status(self) -> None:
-            if self.status_code >= 400:
-                err = requests.HTTPError(f"HTTP {self.status_code}")
-                err.response = self
-                raise err
-
-    responses = iter(
+    recording_session.queue_responses(
         [
-            _StubResponse(429, headers={"Retry-After": "0.2"}),
-            _StubResponse(200, payload={"ok": True}),
+            _RetryableResponse(429, headers={"Retry-After": "0.2"}),
+            _RetryableResponse(200, payload={"ok": True}),
         ]
     )
-    call_log: List[str] = []
-
-    def _request_stub(
-        method: str, url: str, *, timeout: float, **kwargs: Any
-    ) -> _StubResponse:
-        call_log.append(f"{method}:{url}:{timeout}")
-        try:
-            return next(responses)
-        except StopIteration:  # pragma: no cover - defensive guard
-            raise AssertionError("Unexpected extra request") from None
-
-    monkeypatch.setattr("chembl2uniprot.mapping.requests.request", _request_stub)
 
     rate_limiter = RateLimiter(1000.0)
 
@@ -268,13 +300,68 @@ def test_request_with_retry_honours_retry_after(
             rate_limiter=rate_limiter,
             max_attempts=3,
             backoff=0.1,
+            penalty_seconds=0.1,
+            session=recording_session,
         )
 
     assert response.json() == {"ok": True}
-    assert len(call_log) == 2
+    assert len(recording_session.calls) == 2
     assert penalty_mock.call_count >= 1
     assert any(
         call.args and pytest.approx(0.2, rel=0.05) == call.args[0]
         for call in penalty_mock.call_args_list
     )
     assert any("attempt" in record.message for record in caplog.records)
+
+
+def test_request_with_retry_applies_fallback_penalty(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    recording_session: _RecordingSession,
+) -> None:
+    """Fallback penalties should guard against missing ``Retry-After`` headers."""
+
+    monkeypatch.setattr("tenacity.nap.sleep", lambda _: None)
+    monkeypatch.setattr("library.http_client.time.sleep", lambda _: None)
+
+    recording_session.queue_responses(
+        [
+            _RetryableResponse(503),
+            _RetryableResponse(200, payload={"ok": True}),
+        ]
+    )
+
+    rate_limiter = RateLimiter(1000.0)
+
+    with (
+        mock.patch.object(
+            rate_limiter,
+            "apply_penalty",
+            wraps=rate_limiter.apply_penalty,
+        ) as penalty_mock,
+        caplog.at_level(logging.WARNING),
+    ):
+        response = _request_with_retry(
+            "get",
+            "https://rest.uniprot.org/test",
+            timeout=1.0,
+            rate_limiter=rate_limiter,
+            max_attempts=3,
+            backoff=0.1,
+            penalty_seconds=0.5,
+            session=recording_session,
+        )
+
+    assert response.json() == {"ok": True}
+    assert len(recording_session.calls) == 2
+    assert any(
+        call.args and pytest.approx(0.5, rel=0.1) == call.args[0]
+        for call in penalty_mock.call_args_list
+    )
+    assert any("penalty" in record.message for record in caplog.records)
+
+
+def test_default_session_has_descriptive_user_agent() -> None:
+    """Module level session advertises a descriptive User-Agent string."""
+
+    assert _SESSION.headers.get("User-Agent") == DEFAULT_USER_AGENT

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -22,3 +22,4 @@ def test_bundled_config_matches_schema() -> None:
     assert config.uniprot.polling.interval_sec == 2
     assert config.uniprot.retry.max_attempts == 5
     assert config.uniprot.retry.backoff_sec == 1
+    assert config.uniprot.retry.penalty_sec == 1


### PR DESCRIPTION
## Summary
- add a shared requests session with a descriptive User-Agent and optional injection point so retries reuse the same connection pool
- apply configurable fallback penalties when UniProt retry responses lack Retry-After headers and thread the new setting through the mapping helpers
- extend configuration/schema defaults and unit tests to cover the penalty option, session reuse, and cleanup expectations

## Testing
- pytest
- black library/chembl2uniprot/mapping.py library/chembl2uniprot/config.py tests/test_chembl2uniprot_mapping.py
- ruff check library/chembl2uniprot/mapping.py library/chembl2uniprot/config.py tests/test_chembl2uniprot_mapping.py
- mypy library/chembl2uniprot/mapping.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1cb7e53083248f12ddcf06568a6b