### PR TITLE
Update tooling targets to Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,11 @@ where = ["library"]
 
 [tool.black]
 line-length = 88
-target-version = ["py310"]
+target-version = ["py312"]
 
 [tool.ruff]
 line-length = 88
-target-version = "py310"
+target-version = "py312"
 
 [tool.ruff.format]
 quote-style = "double"

--- a/tests/test_pipeline_targets_cli.py
+++ b/tests/test_pipeline_targets_cli.py
@@ -1,5 +1,7 @@
 """Integration tests for the pipeline targets CLI entry point."""
 
+# ruff: noqa: E402  # Module imports follow a runtime path mutation necessary for tests.
+
 from __future__ import annotations
 
 import hashlib


### PR DESCRIPTION
## Summary
- update the Black configuration to target Python 3.12 syntax
- align Ruff's target version with Python 3.12 and document the required test import ordering override

## Testing
- black --version
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68cd1cab8390832480ed0dde7eb732d2