### PR TITLE
Align pre-commit hooks with dependency constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist/
 # Cache directories
 .mypy_cache/
 .pytest_cache/
+.hypothesis/
 
 # VS Code etc
 .vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,22 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.8
+    rev: v0.13.0
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 25.1.0
     hooks:
       - id: black
         language_version: python3.12
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.18.1
     hooks:
       - id: mypy
         args: [--strict, --ignore-missing-imports, .]
+        additional_dependencies:
+          - types-PyYAML==6.0.12.20250915
+          - types-requests==2.32.4.20250913
         pass_filenames: false
   - repo: local
     hooks:

--- a/library/config/pipeline_targets.py
+++ b/library/config/pipeline_targets.py
@@ -393,4 +393,3 @@ class PipelineClientsConfig(BaseModel):
     hgnc: HGNCSectionConfig
     gtop: GtoPSectionConfig
     orthologs: OrthologsSectionConfig | None = None
-

--- a/library/config/uniprot.py
+++ b/library/config/uniprot.py
@@ -6,7 +6,14 @@ from pathlib import Path
 from typing import Any, Mapping
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 from library.chembl2uniprot.config import _apply_env_overrides
 

--- a/scripts/check_dependency_versions_main.py
+++ b/scripts/check_dependency_versions_main.py
@@ -1,4 +1,5 @@
 """CLI for verifying dependency declarations against pinned constraints."""
+
 from __future__ import annotations
 
 import argparse

--- a/scripts/chembl_activities_main.py
+++ b/scripts/chembl_activities_main.py
@@ -210,9 +210,7 @@ def run_pipeline(
     if sort_columns:
         validated = validated.sort_values(sort_columns).reset_index(drop=True)
 
-    serialised = serialise_dataframe(
-        validated, args.list_format, inplace=True
-    )
+    serialised = serialise_dataframe(validated, args.list_format, inplace=True)
     ensure_output_dir(output_path)
     serialised.to_csv(output_path, index=False, sep=args.sep, encoding=args.encoding)
 

--- a/scripts/chembl_testitems_main.py
+++ b/scripts/chembl_testitems_main.py
@@ -341,9 +341,7 @@ def run_pipeline(
             drop=True
         )
 
-    serialised = serialise_dataframe(
-        validated, args.list_format, inplace=True
-    )
+    serialised = serialise_dataframe(validated, args.list_format, inplace=True)
     ensure_output_dir(output_path)
     serialised.to_csv(output_path, index=False, sep=args.sep, encoding=args.encoding)
 

--- a/scripts/data_profiling_main.py
+++ b/scripts/data_profiling_main.py
@@ -73,7 +73,9 @@ def main(argv: Sequence[str] | None = None) -> None:
     configure_logging(args.log_level, log_format=args.log_format)
 
     input_path = Path(args.input)
-    base_path = input_path.with_name(input_path.stem) if input_path.suffix else input_path
+    base_path = (
+        input_path.with_name(input_path.stem) if input_path.suffix else input_path
+    )
     table_name = args.output_prefix or str(base_path)
     analyze_table_quality(
         args.input,

--- a/scripts/dump_gtop_target.py
+++ b/scripts/dump_gtop_target.py
@@ -64,7 +64,10 @@ def _normalise_identifiers(values: List[str], column: str) -> List[str]:
 
     filtered = [value for value in values if value.lower() != "nan"]
     if column == "hgnc_id":
-        return [value if value.startswith("HGNC:") else f"HGNC:{value}" for value in filtered]
+        return [
+            value if value.startswith("HGNC:") else f"HGNC:{value}"
+            for value in filtered
+        ]
     return filtered
 
 
@@ -272,7 +275,9 @@ def main(argv: Sequence[str] | None = None) -> None:
     )
 
     targets_path = ensure_output_dir(output_dir / "targets.csv")
-    _serialise_and_write(targets_df, targets_path, csv_cfg, list_format=csv_cfg.list_format)
+    _serialise_and_write(
+        targets_df, targets_path, csv_cfg, list_format=csv_cfg.list_format
+    )
     targets_meta, _, targets_quality = resolve_cli_sidecar_paths(
         targets_path,
         meta_output=args.meta_output,

--- a/scripts/get_target_data_main.py
+++ b/scripts/get_target_data_main.py
@@ -31,6 +31,7 @@ DEFAULT_LOG_FORMAT = "human"
 DEFAULT_INPUT = "input.csv"
 DEFAULT_COLUMN = "target_chembl_id"
 
+
 def _default_output_name(input_path: str) -> str:
     """Derive the default output file name from ``input_path``."""
 
@@ -41,7 +42,6 @@ def _default_output_name(input_path: str) -> str:
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Create an argument parser and return parsed ``argv``."""
-
 
     parser = argparse.ArgumentParser(description="Download ChEMBL target data")
     parser.add_argument(

--- a/scripts/get_uniprot_target_data.py
+++ b/scripts/get_uniprot_target_data.py
@@ -305,9 +305,7 @@ def main(argv: Sequence[str] | None = None) -> None:
                         "parent_uniprot_id": acc,
                         "isoform_uniprot_id": iso["isoform_uniprot_id"],
                         "isoform_name": iso["isoform_name"],
-
                         "isoform_synonyms": list(iso["isoform_synonyms"]),
-
                         "is_canonical": iso["is_canonical"],
                     }
                 )

--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -6,11 +6,11 @@ import argparse
 import logging
 import os
 import sys
- 
+
 from functools import partial
- 
+
 from dataclasses import dataclass
- 
+
 from pathlib import Path
 
 from collections.abc import Iterable, Mapping, Sequence
@@ -1264,10 +1264,7 @@ def main() -> None:
 
     # Fetch comprehensive ChEMBL data once and reuse it in the pipeline
 
-    chembl_df: pd.DataFrame = fetch_targets(
-        ids, chembl_cfg, batch_size=args.batch_size
-    )
-
+    chembl_df: pd.DataFrame = fetch_targets(ids, chembl_cfg, batch_size=args.batch_size)
 
     def _cached_chembl_fetch(
         _: Sequence[str], __: TargetConfig

--- a/scripts/update_constraints_main.py
+++ b/scripts/update_constraints_main.py
@@ -83,7 +83,9 @@ def main(argv: Sequence[str] | None = None) -> None:
         logger.error("Lock file '%s' could not be found", exc.filename)
         raise SystemExit(1) from exc
     except OSError as exc:
-        logger.error("Failed to write constraints file '%s': %s", args.constraints_file, exc)
+        logger.error(
+            "Failed to write constraints file '%s': %s", args.constraints_file, exc
+        )
         raise SystemExit(1) from exc
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -42,10 +42,14 @@ def pubmed_xml_factory() -> Callable[[Sequence[tuple[str, str, str | None]]], st
     </PubmedData>
   </PubmedArticle>
 """.strip().format(
-                pmid=pmid, title=title, publication_type=publication_type
+                    pmid=pmid, title=title, publication_type=publication_type
+                )
             )
-            )
-        return "<?xml version='1.0'?>\n<PubmedArticleSet>\n" + "\n".join(articles) + "\n</PubmedArticleSet>"
+        return (
+            "<?xml version='1.0'?>\n<PubmedArticleSet>\n"
+            + "\n".join(articles)
+            + "\n</PubmedArticleSet>"
+        )
 
     return _build
 

--- a/tests/test_chembl_activities_pipeline.py
+++ b/tests/test_chembl_activities_pipeline.py
@@ -246,7 +246,5 @@ def test_chembl_activities_main_end_to_end(
     base_path = output_csv.with_name(output_csv.stem)
     quality_report = Path(f"{base_path}_quality_report_table.csv")
     assert quality_report.exists()
-    corr_report = Path(
-        f"{base_path}_data_correlation_report_table.csv"
-    )
+    corr_report = Path(f"{base_path}_data_correlation_report_table.csv")
     assert corr_report.exists()

--- a/tests/test_chembl_assays_pipeline.py
+++ b/tests/test_chembl_assays_pipeline.py
@@ -221,7 +221,5 @@ def test_chembl_assays_main_end_to_end(
     base_path = output_csv.with_name(output_csv.stem)
     quality_report = Path(f"{base_path}_quality_report_table.csv")
     assert quality_report.exists()
-    corr_report = Path(
-        f"{base_path}_data_correlation_report_table.csv"
-    )
+    corr_report = Path(f"{base_path}_data_correlation_report_table.csv")
     assert corr_report.exists()

--- a/tests/test_chembl_testitems_pipeline.py
+++ b/tests/test_chembl_testitems_pipeline.py
@@ -14,7 +14,9 @@ if str(ROOT) not in sys.path:
 read_ids = importlib.import_module("library.io").read_ids
 CsvConfig = importlib.import_module("library.io_utils").CsvConfig
 chembl_testitems_main = importlib.import_module("scripts.chembl_testitems_main").main
-PUBCHEM_PROPERTIES = importlib.import_module("library.testitem_library").PUBCHEM_PROPERTIES
+PUBCHEM_PROPERTIES = importlib.import_module(
+    "library.testitem_library"
+).PUBCHEM_PROPERTIES
 
 
 def test_read_ids_limit(tmp_path: Path) -> None:
@@ -111,7 +113,6 @@ def test_chembl_testitems_main_end_to_end(
         }
 
     requests_mock.get(
-
         f"{pubchem_base}/compound/smiles/C/property/"
         "MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
         json=_pubchem_response(11, "CH4"),
@@ -119,7 +120,6 @@ def test_chembl_testitems_main_end_to_end(
     requests_mock.get(
         f"{pubchem_base}/compound/smiles/CC/property/"
         "MolecularFormula,MolecularWeight,TPSA,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount/JSON",
-
         json=_pubchem_response(22, "C2H6"),
     )
     requests_mock.get(
@@ -170,7 +170,5 @@ def test_chembl_testitems_main_end_to_end(
     base_path = output_csv.with_name(output_csv.stem)
     quality_report = Path(f"{base_path}_quality_report_table.csv")
     assert quality_report.exists()
-    corr_report = Path(
-        f"{base_path}_data_correlation_report_table.csv"
-    )
+    corr_report = Path(f"{base_path}_data_correlation_report_table.csv")
     assert corr_report.exists()

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -59,7 +59,9 @@ def _baseline_serialise(df: pd.DataFrame, list_format: str) -> pd.DataFrame:
     return result
 
 
-def _time_execution(func: Callable[[], pd.DataFrame | None], *, repeats: int = 3) -> float:
+def _time_execution(
+    func: Callable[[], pd.DataFrame | None], *, repeats: int = 3
+) -> float:
     """Measure the execution time of a callable and return the best duration."""
 
     durations: list[float] = []
@@ -224,7 +226,6 @@ def test_write_cli_metadata_produces_expected_yaml(tmp_path: Path) -> None:
     assert "output" not in payload["config"]
     assert payload["rows"] == 1
     assert payload["columns"] == 1
- 
 
 
 def test_write_cli_metadata_defaults_to_sys_argv(
@@ -254,7 +255,7 @@ def test_write_cli_metadata_defaults_to_sys_argv(
 
     payload = yaml.safe_load(meta_file.read_text(encoding="utf-8"))
     assert payload["command"] == "chembl-cli --flag value"
- 
+
     determinism = payload["determinism"]
     assert determinism["baseline_sha256"] == payload["sha256"]
     assert determinism["previous_sha256"] is None
@@ -288,4 +289,3 @@ def test_resolve_cli_sidecar_paths_defaults(tmp_path: Path) -> None:
     assert plain_meta == plain_output.with_name("dataset.meta.yaml")
     assert plain_errors == plain_output.with_name("dataset.errors.json")
     assert plain_quality == plain_output
- 

--- a/tests/test_dump_gtop_target_cli.py
+++ b/tests/test_dump_gtop_target_cli.py
@@ -46,7 +46,9 @@ class DummyClient:
         raise AssertionError(msg)
 
 
-def test_dump_gtop_target_cli_smoke(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_dump_gtop_target_cli_smoke(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Ensure the GtoP dump CLI writes CSV tables and metadata."""
 
     input_csv = tmp_path / "ids.csv"
@@ -67,7 +69,9 @@ def test_dump_gtop_target_cli_smoke(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     )
 
     dummy_client = DummyClient()
-    monkeypatch.setattr(dump_gtop_target, "GtoPClient", lambda *_args, **_kwargs: dummy_client)
+    monkeypatch.setattr(
+        dump_gtop_target, "GtoPClient", lambda *_args, **_kwargs: dummy_client
+    )
     monkeypatch.setattr(
         dump_gtop_target,
         "resolve_target",

--- a/tests/test_hgnc_client.py
+++ b/tests/test_hgnc_client.py
@@ -250,7 +250,9 @@ def test_hgnc_client_recovers_after_retry_after(
         uniprot_url,
         json={
             "proteinDescription": {
-                "recommendedName": {"fullName": {"value": "Alpha-1A adrenergic receptor"}}
+                "recommendedName": {
+                    "fullName": {"value": "Alpha-1A adrenergic receptor"}
+                }
             }
         },
     )
@@ -259,7 +261,9 @@ def test_hgnc_client_recovers_after_retry_after(
 
     assert record.hgnc_id == "HGNC:277"
     assert record.gene_symbol == "ADRA1A"
-    hgnc_calls = [call for call in requests_mock.request_history if call.url == hgnc_url]
+    hgnc_calls = [
+        call for call in requests_mock.request_history if call.url == hgnc_url
+    ]
     assert len(hgnc_calls) == 2
     assert any(pytest.approx(delay, rel=1e-3) == 1.5 for delay in clock.sleeps)
     assert "retrying after 1.50 seconds" in caplog.text

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -105,6 +105,9 @@ def test_write_meta_yaml_updates_determinism_on_repeat(metadata_csv: Path) -> No
 
     assert determinism["current_sha256"] == payload["sha256"]
     assert determinism["previous_sha256"] == first_payload["sha256"]
-    assert determinism["baseline_sha256"] == first_payload["determinism"]["baseline_sha256"]
+    assert (
+        determinism["baseline_sha256"]
+        == first_payload["determinism"]["baseline_sha256"]
+    )
     assert determinism["matches_previous"] is True
     assert determinism["check_count"] >= 2

--- a/tests/test_pipeline_targets.py
+++ b/tests/test_pipeline_targets.py
@@ -144,14 +144,14 @@ pipeline:
         load_pipeline_config(str(cfg_path))
 
 
-def test_load_pipeline_config_env_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_pipeline_config_env_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     cfg_path = tmp_path / "config_env.yaml"
     cfg_path.write_text("pipeline:\n  list_format: json\n", encoding="utf-8")
     monkeypatch.setenv("CHEMBL_DA__PIPELINE__LIST_FORMAT", "pipe")
     monkeypatch.setenv("CHEMBL_DA__PIPELINE__IUPHAR__APPROVED_ONLY", "true")
-    monkeypatch.setenv(
-        "CHEMBL_DA__PIPELINE__SPECIES_PRIORITY", "[\"Mouse\", \"Rat\"]"
-    )
+    monkeypatch.setenv("CHEMBL_DA__PIPELINE__SPECIES_PRIORITY", '["Mouse", "Rat"]')
     cfg = load_pipeline_config(str(cfg_path))
     assert cfg.list_format == "pipe"
     assert cfg.iuphar.approved_only is True

--- a/tests/test_pipeline_targets_cli.py
+++ b/tests/test_pipeline_targets_cli.py
@@ -16,6 +16,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+# ruff: noqa: E402
 from pydantic import ValidationError
 
 from library.config.pipeline_targets import PipelineClientsConfig
@@ -308,10 +309,14 @@ def test_pipeline_targets_cli_filters_invalid_ids(
         )
 
     class DummyEnrichClient:
-        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - simple
+        def __init__(
+            self, *args: Any, **kwargs: Any
+        ) -> None:  # pragma: no cover - simple
             pass
 
-        def fetch_all(self, accessions: list[str]) -> dict[str, dict[str, str]]:  # pragma: no cover - simple
+        def fetch_all(
+            self, accessions: list[str]
+        ) -> dict[str, dict[str, str]]:  # pragma: no cover - simple
             return {acc: {} for acc in accessions}
 
     def fake_build_clients(*_args: Any, **_kwargs: Any) -> tuple[Any, ...]:
@@ -331,7 +336,10 @@ def test_pipeline_targets_cli_filters_invalid_ids(
     monkeypatch.setattr(module, "merge_chembl_fields", lambda df, _: df)
     monkeypatch.setattr(module, "add_activity_fields", _identity_frame)
     monkeypatch.setattr(module, "add_isoform_fields", _identity_frame)
-    def _ensure_iuphar_columns(df: pd.DataFrame, *args: Any, **kwargs: Any) -> pd.DataFrame:
+
+    def _ensure_iuphar_columns(
+        df: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> pd.DataFrame:
         frame = df.copy()
         for column in module.IUPHAR_CLASS_COLUMNS:
             if column not in frame.columns:

--- a/tests/test_pipeline_targets_main.py
+++ b/tests/test_pipeline_targets_main.py
@@ -369,5 +369,3 @@ def test_parse_args_rejects_non_positive_batch_size(
     )
     with pytest.raises(SystemExit):
         parse_args()
-
-

--- a/tests/test_pubmed_client.py
+++ b/tests/test_pubmed_client.py
@@ -18,7 +18,7 @@ from library.http_client import HttpClient  # type: ignore  # noqa: E402
 
 
 def test_fetch_pubmed_records_parses_fields(
-    pubmed_xml_factory: Callable[[Sequence[tuple[str, str, str | None]]], str]
+    pubmed_xml_factory: Callable[[Sequence[tuple[str, str, str | None]]], str],
 ) -> None:
     """Basic parsing should surface the expected bibliographic fields."""
 
@@ -43,7 +43,7 @@ def test_fetch_pubmed_records_parses_fields(
 
 
 def test_fetch_pubmed_records_batches_requests(
-    pubmed_xml_factory: Callable[[Sequence[tuple[str, str, str | None]]], str]
+    pubmed_xml_factory: Callable[[Sequence[tuple[str, str, str | None]]], str],
 ) -> None:
     """The downloader should honour the requested batch size for pagination."""
 
@@ -63,9 +63,7 @@ def test_fetch_pubmed_records_batches_requests(
         m.get(pc.API_URL, text=xml_chunk_one, additional_matcher=_match("1,2"))
         m.get(pc.API_URL, text=xml_chunk_two, additional_matcher=_match("3"))
         client = HttpClient(timeout=1.0, max_retries=1, rps=0)
-        records = pc.fetch_pubmed_records(
-            ["1", "2", "3"], client=client, batch_size=2
-        )
+        records = pc.fetch_pubmed_records(["1", "2", "3"], client=client, batch_size=2)
         history = list(m.request_history)
 
     assert [req.qs["id"][0] for req in history] == ["1,2", "3"]
@@ -85,7 +83,7 @@ def test_fetch_pubmed_records_reports_http_error() -> None:
 
 
 def test_fetch_pubmed_records_marks_missing_pmids(
-    pubmed_xml_factory: Callable[[Sequence[tuple[str, str, str | None]]], str]
+    pubmed_xml_factory: Callable[[Sequence[tuple[str, str, str | None]]], str],
 ) -> None:
     """Missing identifiers must surface descriptive error messages."""
 

--- a/tests/test_pubmed_main.py
+++ b/tests/test_pubmed_main.py
@@ -206,7 +206,6 @@ def test_run_openalex_command_exports_openalex_only(
     assert df.loc[0, "crossref.Subject"] == "Biology|Chemistry"
 
 
-
 def test_run_crossref_command_exports_crossref_only(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- update the pre-commit hooks to match the ruff, black, and mypy versions pinned in constraints.txt/pyproject.toml
- install the required stub packages for the mypy hook and add an inline suppression for the CLI pipeline test import layout
- ignore Hypothesis artifacts and reformat the repository with Black 25.1.0 so the new hooks pass cleanly

## Testing
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68cd1cc69a148324ac8811fbcdd181ed