### PR TITLE
Ensure HGNC client uses thread-local HTTP sessions

### DIFF
--- a/library/hgnc_client.py
+++ b/library/hgnc_client.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, asdict
 from pathlib import Path
+from types import TracebackType
 from typing import Dict, List
 import logging
 
@@ -162,6 +163,26 @@ class HGNCClient:
             rps=cfg.rate_limit.rps,
             cache_config=cfg.cache,
         )
+
+    def close(self) -> None:
+        """Release HTTP resources associated with the client."""
+
+        self.http.close()
+
+    def __enter__(self) -> "HGNCClient":
+        """Enter the managed context, returning ``self``."""
+
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Ensure resources are released when leaving a context manager block."""
+
+        self.close()
 
     def _request(self, url: str) -> requests.Response:
         """Perform a GET request with retry and rate limiting.
@@ -329,11 +350,16 @@ def map_uniprot_to_hgnc(
     raw_ids: List[str] = [str(v) for v in df[column]]
     unique_ids = list(dict.fromkeys(filter(None, raw_ids)))
 
-    client = HGNCClient(cfg)
-    max_workers = int(cfg.rate_limit.rps) or 1
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        results = executor.map(client.fetch, unique_ids)
-        mapping: Dict[str, HGNCRecord] = dict(zip(unique_ids, results))
+    max_workers = max(1, int(cfg.rate_limit.rps))
+    with HGNCClient(cfg) as client:
+        if not unique_ids:
+            mapping: Dict[str, HGNCRecord] = {}
+        elif max_workers == 1 or len(unique_ids) == 1:
+            mapping = {uid: client.fetch(uid) for uid in unique_ids}
+        else:
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                results = executor.map(client.fetch, unique_ids)
+                mapping = dict(zip(unique_ids, results))
 
     rows = [
         asdict(mapping.get(uid, HGNCRecord(uid, "", "", "", ""))) for uid in raw_ids

--- a/tests/library/test_hgnc_client.py
+++ b/tests/library/test_hgnc_client.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import threading
+from typing import Any
+
+from library.hgnc_client import (
+    Config,
+    HGNCClient,
+    HGNCServiceConfig,
+    NetworkConfig,
+    OutputConfig,
+    RateLimitConfig,
+)
+
+
+class FakeResponse:
+    """Minimal stub implementing the subset of ``requests.Response`` used in tests."""
+
+    def __init__(self, url: str) -> None:
+        self.url = url
+        self.status_code = 200
+        self.headers: dict[str, str] = {}
+
+    def json(self) -> dict[str, Any]:
+        accession = self.url.rsplit("/", 1)[-1]
+        if accession.endswith(".json"):
+            accession = accession[:-5]
+        if "rest.uniprot.org" in self.url:
+            return {
+                "proteinDescription": {
+                    "recommendedName": {"fullName": {"value": f"Protein {accession}"}}
+                }
+            }
+        return {
+            "response": {
+                "docs": [
+                    {
+                        "symbol": f"SYM_{accession}",
+                        "name": f"Gene {accession}",
+                        "hgnc_id": f"HGNC:{accession}",
+                    }
+                ]
+            }
+        }
+
+    def raise_for_status(self) -> None:  # pragma: no cover - compatibility shim
+        return None
+
+
+class FakeSession:
+    """Thread-bound HTTP session tracking the worker that created it."""
+
+    def __init__(self) -> None:
+        self.creator = threading.get_ident()
+        self.closed = False
+        self.request_threads: list[int] = []
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        timeout: float | tuple[float, float] | None = None,
+        **_: Any,
+    ) -> FakeResponse:
+        thread_id = threading.get_ident()
+        self.request_threads.append(thread_id)
+        if thread_id != self.creator:
+            raise AssertionError("Session used across threads")
+        return FakeResponse(url)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_parallel_fetch_uses_thread_local_sessions(monkeypatch) -> None:
+    """Ensure HGNCClient creates one HTTP session per worker thread."""
+
+    created_sessions: list[FakeSession] = []
+
+    def fake_create_http_session(_cache_config):
+        session = FakeSession()
+        created_sessions.append(session)
+        return session
+
+    monkeypatch.setattr(
+        "library.http_client.create_http_session", fake_create_http_session
+    )
+
+    cfg = Config(
+        hgnc=HGNCServiceConfig(base_url="https://example.org/hgnc"),
+        network=NetworkConfig(timeout_sec=1.0, max_retries=1),
+        rate_limit=RateLimitConfig(rps=3.0),
+        output=OutputConfig(sep=",", encoding="utf-8"),
+        cache=None,
+    )
+
+    accessions = ["P1", "P2", "P3", "P4"]
+
+    with HGNCClient(cfg) as client:
+        with ThreadPoolExecutor(max_workers=3) as executor:
+            results = list(executor.map(client.fetch, accessions))
+
+    assert {record.uniprot_id for record in results} == set(accessions)
+    assert all(session.closed for session in created_sessions)
+    assert len(created_sessions) >= 2
+    for session in created_sessions:
+        assert all(
+            thread_id == session.creator for thread_id in session.request_threads
+        )
+        assert session.request_threads, "Session was created but never used"


### PR DESCRIPTION
## Summary
- update the shared HttpClient to create and manage thread-local requests sessions while supporting context management
- make HGNCClient close its HTTP resources and fall back to sequential processing when concurrency is unnecessary
- add a concurrency-focused HGNC client test suite that mocks thread-local HTTP usage and update existing tests to use the new context manager

## Testing
- `poetry run black library/hgnc_client.py library/http_client.py tests/test_hgnc_client.py tests/library/test_hgnc_client.py`
- `poetry run ruff check library/hgnc_client.py library/http_client.py tests/test_hgnc_client.py tests/library/test_hgnc_client.py`
- `poetry run mypy library/hgnc_client.py library/http_client.py tests/library/test_hgnc_client.py`
- `poetry run pytest tests/test_hgnc_client.py tests/library/test_hgnc_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68cd2974aee48324b7db01210248ecbc