### PR TITLE
Stream target metadata export in batches

### DIFF
--- a/scripts/get_target_data_main.py
+++ b/scripts/get_target_data_main.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import csv
 from datetime import datetime
 from pathlib import Path
-from typing import Sequence
+from typing import Iterable, Iterator, Sequence
 
 if __package__ in {None, ""}:
     from _path_utils import ensure_project_root as _ensure_project_root
@@ -21,7 +22,7 @@ from library.cli_common import (  # noqa: E402
     write_cli_metadata,
 )
 from library.io import read_ids  # noqa: E402
-from library.io_utils import CsvConfig, write_rows  # noqa: E402
+from library.io_utils import CsvConfig  # noqa: E402
 from library.logging_utils import configure_logging  # noqa: E402
 
 DEFAULT_LOG_LEVEL = "INFO"
@@ -30,6 +31,7 @@ DEFAULT_ENCODING = "utf-8-sig"
 DEFAULT_LOG_FORMAT = "human"
 DEFAULT_INPUT = "input.csv"
 DEFAULT_COLUMN = "target_chembl_id"
+STREAM_BATCH_SIZE = 200
 
 
 def _default_output_name(input_path: str) -> str:
@@ -38,6 +40,51 @@ def _default_output_name(input_path: str) -> str:
     stem = Path(input_path).stem or "input"
     date_suffix = datetime.utcnow().strftime("%Y%m%d")
     return f"output_{stem}_{date_suffix}.csv"
+
+
+def _chunked(iterable: Iterable[str], size: int) -> Iterator[list[str]]:
+    """Yield fixed-size chunks from ``iterable``.
+
+    Parameters
+    ----------
+    iterable:
+        The source iterable providing identifier values.
+    size:
+        Maximum number of identifiers to include in a single chunk. Must be a
+        positive integer.
+
+    Yields
+    ------
+    list[str]
+        Lists containing up to ``size`` identifiers, preserving the original
+        order.
+
+    Raises
+    ------
+    ValueError
+        If ``size`` is not a positive integer.
+    """
+
+    if size <= 0:
+        msg = "size must be a positive integer"
+        raise ValueError(msg)
+
+    batch: list[str] = []
+    for item in iterable:
+        batch.append(item)
+        if len(batch) == size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def _write_header(path: Path, columns: Sequence[str], cfg: CsvConfig) -> None:
+    """Write only the CSV header to ``path`` using ``columns`` order."""
+
+    with path.open("w", encoding=cfg.encoding, newline="") as handle:
+        writer = csv.writer(handle, delimiter=cfg.sep)
+        writer.writerow(columns)
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -112,29 +159,57 @@ def main(argv: Sequence[str] | None = None) -> None:
     csv_cfg = CsvConfig(
         sep=args.sep, encoding=args.encoding, list_format=args.list_format
     )
-    identifiers = list(read_ids(input_path, args.column, csv_cfg))
+    identifiers = read_ids(input_path, args.column, csv_cfg)
 
     target_cfg = TargetConfig(
         output_sep=args.sep,
         output_encoding=args.encoding,
         list_format=args.list_format,
     )
-    result = fetch_targets(identifiers, target_cfg)
-    serialised = serialise_dataframe(result, args.list_format, inplace=True)
+    row_count = 0
+    wrote_header = False
+    columns: list[str] | None = None
 
-    columns = list(serialised.columns) or list(target_cfg.columns)
-    rows = serialised.to_dict(orient="records")
-    write_rows(output_path, rows, columns, csv_cfg)
+    for batch in _chunked(identifiers, STREAM_BATCH_SIZE):
+        batch_frame = fetch_targets(batch, target_cfg)
+        serialised = serialise_dataframe(batch_frame, args.list_format, inplace=True)
+
+        if columns is None:
+            columns = list(serialised.columns) or list(target_cfg.columns)
+        serialised = serialised.loc[:, columns]
+
+        mode = "w" if not wrote_header else "a"
+        serialised.to_csv(
+            output_path,
+            sep=args.sep,
+            encoding=args.encoding,
+            index=False,
+            mode=mode,
+            header=not wrote_header,
+        )
+        wrote_header = True
+        row_count += int(serialised.shape[0])
+
+    if columns is None:
+        columns = list(target_cfg.columns)
+
+    if not wrote_header:
+        _write_header(output_path, columns, csv_cfg)
 
     meta_path, _, quality_base = resolve_cli_sidecar_paths(
         output_path,
         meta_output=args.meta_output,
     )
-    analyze_table_quality(serialised, table_name=str(quality_base))
+    analyze_table_quality(
+        output_path,
+        table_name=str(quality_base),
+        separator=args.sep,
+        encoding=args.encoding,
+    )
 
     write_cli_metadata(
         output_path,
-        row_count=int(serialised.shape[0]),
+        row_count=row_count,
         column_count=int(len(columns)),
         namespace=args,
         meta_path=meta_path,

--- a/tests/test_get_target_data_cli.py
+++ b/tests/test_get_target_data_cli.py
@@ -49,6 +49,18 @@ def test_get_target_data_cli_writes_csv_and_meta(
 
     monkeypatch.setattr("scripts.get_target_data_main.fetch_targets", fake_fetch)
 
+    quality_calls: list[tuple[object, str, str, str]] = []
+
+    def fake_quality(
+        table: object, *, table_name: str, separator: str, encoding: str
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        quality_calls.append((table, table_name, separator, encoding))
+        return pd.DataFrame(), pd.DataFrame()
+
+    monkeypatch.setattr(
+        "scripts.get_target_data_main.analyze_table_quality", fake_quality
+    )
+
     main(
         [
             "--input",
@@ -78,5 +90,91 @@ def test_get_target_data_cli_writes_csv_and_meta(
     meta_path = output_csv.with_name(f"{output_csv.name}.meta.yaml")
     meta = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
     assert meta["rows"] == 2
+    assert meta["columns"] == 3
+    assert meta["output"] == str(output_csv)
+
+    assert quality_calls == [
+        (output_csv, str(output_csv.with_suffix("")), ",", "utf-8")
+    ]
+
+
+def test_get_target_data_cli_streams_in_batches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure the CLI processes identifiers in fixed-size batches."""
+
+    input_csv = tmp_path / "targets.csv"
+    input_csv.write_text(
+        "target_chembl_id\nchembl001\nchembl002\nchembl003\nchembl004\n",
+        encoding="utf-8",
+    )
+    output_csv = tmp_path / "dump.csv"
+
+    calls: list[list[str]] = []
+
+    def fake_fetch(ids: list[str], _cfg: object) -> pd.DataFrame:
+        calls.append(list(ids))
+        rows = [
+            {
+                "target_chembl_id": chembl_id,
+                "pref_name": f"Target {chembl_id[-3:]}",
+                "cross_references": [{"source": "UniProt", "xref_id": f"P{index:05d}"}],
+            }
+            for index, chembl_id in enumerate(ids, start=1)
+        ]
+        return pd.DataFrame(rows)
+
+    monkeypatch.setattr("scripts.get_target_data_main.fetch_targets", fake_fetch)
+    monkeypatch.setattr("scripts.get_target_data_main.STREAM_BATCH_SIZE", 2)
+
+    def fake_quality(
+        table: object, *, table_name: str, separator: str, encoding: str
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        assert Path(table) == output_csv
+        assert table_name == str(output_csv.with_suffix(""))
+        assert separator == ","
+        assert encoding == "utf-8"
+        return pd.DataFrame(), pd.DataFrame()
+
+    monkeypatch.setattr(
+        "scripts.get_target_data_main.analyze_table_quality", fake_quality
+    )
+
+    main(
+        [
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--column",
+            "target_chembl_id",
+            "--encoding",
+            "utf-8",
+            "--sep",
+            ",",
+            "--list-format",
+            "json",
+        ]
+    )
+
+    assert calls == [["CHEMBL001", "CHEMBL002"], ["CHEMBL003", "CHEMBL004"]]
+
+    with output_csv.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+
+    assert [row["target_chembl_id"] for row in rows] == [
+        "CHEMBL001",
+        "CHEMBL002",
+        "CHEMBL003",
+        "CHEMBL004",
+    ]
+    assert rows[0]["cross_references"] == json.dumps(
+        [{"source": "UniProt", "xref_id": "P00001"}], separators=(",", ":")
+    )
+
+    meta_path = output_csv.with_name(f"{output_csv.name}.meta.yaml")
+    meta = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+    assert meta["rows"] == 4
     assert meta["columns"] == 3
     assert meta["output"] == str(output_csv)


### PR DESCRIPTION
## Summary
- stream `get_target_data_main.py` by chunking identifiers and appending serialised batches to CSV output while reusing the quality report on-disk export
- track written row counts for metadata and keep deterministic column ordering during incremental writes
- extend CLI tests to assert chunked fetching behaviour and metadata invariants when streaming

## Testing
- black --check scripts/get_target_data_main.py tests/test_get_target_data_cli.py
- ruff check scripts/get_target_data_main.py tests/test_get_target_data_cli.py
- mypy scripts/get_target_data_main.py
- pytest tests/test_get_target_data_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cd2994514083248f17268c06c1354a