### PR TITLE
Apply environment overrides to HGNC config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,33 @@
+# Configuration overrides
+
+The applications bundled with this repository load their defaults from
+`config.yaml`.  Every configuration block can be tuned without editing the file
+by setting environment variables before invoking a script or library function.
+Variables prefixed with `CHEMBL_DA__` take precedence; the legacy `CHEMBL_`
+prefix is still honoured for backwards compatibility.  Component names are
+separated by double underscores and are case-insensitive.  For example, setting
+`CHEMBL_DA__HGNC__NETWORK__TIMEOUT_SEC=45` overrides the timeout in the HGNC
+section.
+
+## HGNC mapping variables
+
+The HGNC utilities consume the `hgnc` section of `config.yaml`.  The following
+variables are recognised by :func:`library.hgnc_client.load_config` and can be
+used to adjust runtime behaviour without editing configuration files.
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `CHEMBL_DA__HGNC__HGNC__BASE_URL` | Base URL for the HGNC REST API endpoint. | `https://rest.genenames.org/fetch/uniprot_ids` |
+| `CHEMBL_DA__HGNC__NETWORK__TIMEOUT_SEC` | Timeout for HTTP requests in seconds. | `30` |
+| `CHEMBL_DA__HGNC__NETWORK__MAX_RETRIES` | Maximum number of retry attempts for HGNC calls. | `3` |
+| `CHEMBL_DA__HGNC__RATE_LIMIT__RPS` | Allowed request rate in requests per second. | `3` |
+| `CHEMBL_DA__HGNC__OUTPUT__SEP` | Delimiter used when writing output CSV files. | `,` |
+| `CHEMBL_DA__HGNC__OUTPUT__ENCODING` | Text encoding for generated CSV files. | `utf-8` |
+| `CHEMBL_DA__HGNC__CACHE__ENABLED` | Enable (`true`) or disable (`false`) the shared HTTP cache. | `false` |
+| `CHEMBL_DA__HGNC__CACHE__PATH` | Filesystem location for the HTTP cache database. | `None` |
+| `CHEMBL_DA__HGNC__CACHE__TTL_SEC` | Cache expiry time in seconds (set to `0` to disable persistence). | `0` |
+
+Boolean values accept YAML semantics, so `true`/`false`, `yes`/`no` and `1`/`0`
+are all valid inputs.  Numeric values may be provided as integers or floats.  The
+values are parsed using `yaml.safe_load`, matching the behaviour of other
+configuration loaders in the project.

--- a/library/hgnc_client.py
+++ b/library/hgnc_client.py
@@ -11,11 +11,11 @@ Algorithm Notes
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass, asdict
-from pathlib import Path
-from typing import Dict, List
 import logging
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, List
 
 import pandas as pd
 import requests
@@ -30,6 +30,11 @@ try:  # pragma: no cover - support package and script imports
     from .http_client import CacheConfig, HttpClient
 except ImportError:  # pragma: no cover
     from http_client import CacheConfig, HttpClient  # type: ignore[no-redef]
+
+try:  # pragma: no cover - support package and script imports
+    from .chembl2uniprot.config import _apply_env_overrides
+except ImportError:  # pragma: no cover
+    from chembl2uniprot.config import _apply_env_overrides  # type: ignore[no-redef]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -105,12 +110,23 @@ def load_config(path: str | Path, *, section: str | None = None) -> Config:
     """
 
     with Path(path).open("r", encoding="utf-8") as fh:
-        data = yaml.safe_load(fh) or {}
+        loaded = yaml.safe_load(fh) or {}
+    if not isinstance(loaded, dict):
+        msg = f"Root of {path} must be a mapping"
+        raise TypeError(msg)
+    data: Dict[str, Any]
     if section:
         try:
-            data = data[section]
+            section_payload = loaded[section]
         except KeyError as exc:  # pragma: no cover - defensive
             raise KeyError(f"Section '{section}' not found in {path}") from exc
+        if not isinstance(section_payload, dict):
+            msg = f"Section '{section}' in {path} must be a mapping"
+            raise TypeError(msg)
+        data = dict(section_payload)
+    else:
+        data = dict(loaded)
+    _apply_env_overrides(data, section=section)
     return Config(
         hgnc=HGNCServiceConfig(**data["hgnc"]),
         network=NetworkConfig(**data["network"]),

--- a/tests/config/test_hgnc_config.py
+++ b/tests/config/test_hgnc_config.py
@@ -1,0 +1,21 @@
+"""Tests for environment overrides in the HGNC configuration loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hgnc_client import load_config
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = ROOT / "config.yaml"
+
+
+def test_hgnc_config_env_override(monkeypatch) -> None:
+    """Environment variables should override network settings."""
+
+    monkeypatch.setenv("CHEMBL_DA__HGNC__NETWORK__TIMEOUT_SEC", "45")
+
+    cfg = load_config(CONFIG_PATH, section="hgnc")
+
+    assert cfg.network.timeout_sec == 45
+    assert cfg.rate_limit.rps == 3


### PR DESCRIPTION
## Summary
- apply environment variable overrides while loading HGNC configuration data
- document the supported HGNC-related environment variables for operators
- add a regression test covering the HGNC configuration override path

## Testing
- black library/hgnc_client.py tests/config/test_hgnc_config.py
- ruff check library/hgnc_client.py tests/config/test_hgnc_config.py
- mypy library/hgnc_client.py
- pytest tests/config/test_hgnc_config.py

------
https://chatgpt.com/codex/tasks/task_e_68cd299f5e488324abdc50fd2f3c4bb4