### PR TITLE
Handle missing input file in UniProt CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,9 @@ The `scripts/` directory contains several other scripts for performing specific 
     serialise the records as JSON lines.
 *   `get_uniprot_target_data.py`: Retrieve and normalize detailed information about UniProt targets.
     The input CSV must expose a `uniprot_id` column unless `--column` is used to
-    point at an alternative header.
+    point at an alternative header. When the provided input path does not
+    reference an existing file, the CLI logs a clear error message and exits with
+    a status code of `1` so that automation can detect the failure immediately.
 *   `get_hgnc_by_uniprot.py`: Map UniProt accessions to HGNC identifiers.
 *   `dump_gtop_target.py`: Download comprehensive GtoPdb target information.
 *   `protein_classify_main.py`: Classify proteins based on UniProt data.

--- a/scripts/get_uniprot_target_data.py
+++ b/scripts/get_uniprot_target_data.py
@@ -225,6 +225,16 @@ def main(argv: Sequence[str] | None = None) -> None:
     )
 
     input_path = Path(args.input)
+
+    if not input_path.exists():
+        message = f"Input file {input_path} does not exist"
+        LOGGER.error(message)
+        raise SystemExit(1) from None
+    if not input_path.is_file():
+        message = f"Input path {input_path} is not a file"
+        LOGGER.error(message)
+        raise SystemExit(1) from None
+
     output_path = Path(args.output) if args.output else _default_output(input_path)
 
     orthologs_path = (

--- a/tests/test_get_uniprot_target_data.py
+++ b/tests/test_get_uniprot_target_data.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -40,3 +41,43 @@ def test_missing_column_exits_cleanly(tmp_path: Path) -> None:
     assert metadata["status"] == "error"
     assert "does not contain the required" in metadata["error"]
     assert metadata["sha256"] is None
+
+
+def test_missing_input_file_exits_with_error(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    """The CLI should report when the input file cannot be located."""
+
+    import scripts.get_uniprot_target_data as cli
+
+    real_path = cli.Path
+
+    class MissingPathStub:
+        """Stand-in path reporting that the referenced file is absent."""
+
+        def __init__(self, raw: str):
+            self._raw = raw
+
+        def exists(self) -> bool:
+            return False
+
+        def is_file(self) -> bool:
+            return False
+
+        def __str__(self) -> str:
+            return self._raw
+
+        def __fspath__(self) -> str:
+            return self._raw
+
+    def fake_path(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        if args and args[0] == "missing.csv" and len(args) == 1:
+            return MissingPathStub("missing.csv")
+        return real_path(*args, **kwargs)
+
+    monkeypatch.setattr(cli, "Path", fake_path)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["--input", "missing.csv", "--output", str(tmp_path / "output.csv")])
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "Input file missing.csv does not exist" in captured.err


### PR DESCRIPTION
## Summary
- log a clear error and exit when the UniProt CLI input path is missing or not a file
- add regression coverage that mocks Path to ensure the CLI aborts with SystemExit(1)
- document the new behaviour in the README usage description

## Testing
- pytest tests/test_get_uniprot_target_data.py

------
https://chatgpt.com/codex/tasks/task_e_68cd729abea08324851d6b9000b1544b