### PR TITLE
Use DataFrame serialisation for UniProt output

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,11 @@ example isoform or ortholog exports) receive their own diagnostics. For an
 output named `targets.csv` the following files are created in the same
 directory:
 
-*   `targets.csv`: The canonical dataset written by :func:`library.io_utils.write_rows`.
+*   `targets.csv`: The canonical dataset produced from a serialised DataFrame
+    via :meth:`pandas.DataFrame.to_csv`. Secondary lookup tables such as
+    isoform or ortholog exports continue to rely on
+    :func:`library.io_utils.write_rows` until they are migrated to the
+    DataFrame-based path.
 *   `targets.csv.meta.yaml`: Metadata produced by
     :func:`library.cli_common.write_cli_metadata` capturing the command line,
     resolved configuration, row/column counts, and SHA-256 checksum.

--- a/docs/README.md
+++ b/docs/README.md
@@ -170,6 +170,13 @@ output name (for example ``targets_dump.tar.gz``).  Basic data quality metrics
 are calculated via ``library.data_profiling.analyze_table_quality`` which saves
 reports using the same base filename.
 
+The main table is always derived from the :func:`library.cli_common.serialise_dataframe`
+result and written with :meth:`pandas.DataFrame.to_csv`. Metadata generation and
+quality analysis therefore inspect the same payload that ultimately lands on
+disk. Secondary exports such as ortholog or isoform tables continue to use
+:func:`library.io_utils.write_rows` until they are migrated to the DataFrame
+pipeline.
+
 
 ### Including orthologs
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -21,9 +21,12 @@ python scripts/get_target_data_main.py \
 The input file must contain a column with ChEMBL target identifiers. Duplicate
 and empty values are ignored. The resulting CSV contains one row per unique
 identifier with nested fields serialised deterministically via
-``--list-format``. A companion ``<output_filename>.meta.yaml`` file captures the
-CLI invocation, row/column counts, and output checksum.  The suffix is appended
-to the entire output filename to support multi-extension artefacts such as
+``--list-format``. The CLI persists the :func:`library.cli_common.serialise_dataframe`
+result directly through :meth:`pandas.DataFrame.to_csv`, which means metadata
+and quality analysis routines observe the exact payload stored on disk. A
+companion ``<output_filename>.meta.yaml`` file captures the CLI invocation,
+row/column counts, and output checksum.  The suffix is appended to the entire
+output filename to support multi-extension artefacts such as
 ``.tar.gz``.
 
 Network and API failures are surfaced as ``requests`` exceptions. The downloader

--- a/tests/test_pipeline_targets_cli.py
+++ b/tests/test_pipeline_targets_cli.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
+from pandas.testing import assert_frame_equal
 import pytest
 import yaml  # type: ignore[import-untyped]
 
@@ -256,6 +257,12 @@ def test_pipeline_targets_cli_writes_outputs(
     assert metadata["rows"] == 3
     assert metadata["columns"] == len(result_df.columns)
     assert metadata["config"]["input"] == str(input_csv)
+    normalised_result = result_df.fillna("")
+    assert_frame_equal(
+        captured["table"].reset_index(drop=True),
+        normalised_result,
+        check_dtype=False,
+    )
 
     expected_hash = hashlib.sha256(output_path.read_bytes()).hexdigest()
     assert metadata["sha256"] == expected_hash

--- a/tests/test_uniprot_cli.py
+++ b/tests/test_uniprot_cli.py
@@ -123,7 +123,9 @@ def test_get_uniprot_target_data_batches_requests(
             tmp_path / "quality",
         ),
     )
-    monkeypatch.setattr("library.io.read_ids", lambda *_args, **_kwargs: accessions)
+    monkeypatch.setattr(
+        "library.io.read_ids", lambda *_args, **_kwargs: iter(accessions)
+    )
     monkeypatch.setattr("library.io_utils.write_rows", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         "library.uniprot_normalize.extract_ensembl_gene_ids",


### PR DESCRIPTION
## Summary
- write the UniProt target export from the serialised DataFrame via `to_csv` so metadata and profiling operate on the same payload
- update `_batched` to iterate over generic iterables and extend the pipeline integration test to compare the written file with the serialised frame
- refresh CLI documentation to describe the unified serialisation path and adjust the UniProt test fixture to yield iterators

## Testing
- `pytest tests/test_pipeline_targets_cli.py::test_pipeline_targets_cli_writes_outputs`
- `pytest tests/test_uniprot_cli.py::test_get_uniprot_target_data_batches_requests`


------
https://chatgpt.com/codex/tasks/task_e_68cd728b1ca88324aa52ec67b61d6619