### PR TITLE
Stream target ID input only once

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ The repository is organized as follows:
 
 The pipeline is primarily driven by the scripts in the `scripts/` directory. Each script provides a command-line interface for a specific task.
 
+### Memory considerations
+
+`scripts/get_target_data_main.py` streams the identifier column directly from disk using `library.io.read_ids`. The generator is consumed once by the batching helper, which means the CLI never materialises the full list of target identifiers in memory. Only a single chunk of identifiers—200 rows by default via `STREAM_BATCH_SIZE`—and the current response DataFrame are resident at any given time. Workflows that need to iterate over the identifiers repeatedly must reopen the input file or explicitly cache the values to avoid exhausting memory on large datasets.
+
 ## Output Artefacts and Determinism
 
 Every CLI produces a primary CSV file together with deterministic companion

--- a/scripts/get_target_data_main.py
+++ b/scripts/get_target_data_main.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
- 
- 
+
+import argparse
 import csv
- 
+
 import logging
- 
+
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable, Iterator, Sequence
@@ -170,14 +170,11 @@ def _run(args: argparse.Namespace) -> None:
     csv_cfg = CsvConfig(
         sep=args.sep, encoding=args.encoding, list_format=args.list_format
     )
- 
-    identifiers = read_ids(input_path, args.column, csv_cfg)
- 
+
     try:
-        identifiers = list(read_ids(input_path, args.column, csv_cfg))
+        identifiers = read_ids(input_path, args.column, csv_cfg)
     except KeyError as exc:
         raise ValueError(str(exc)) from exc
- 
 
     target_cfg = TargetConfig(
         output_sep=args.sep,


### PR DESCRIPTION
## Summary
- catch missing column errors around a single read_ids call and keep the generator streaming for batching
- extend the CLI smoke tests to ensure read_ids is invoked once while keeping type checking happy
- document the streaming behaviour and memory footprint of the target metadata CLI in the README

## Testing
- ruff check scripts/get_target_data_main.py tests/test_get_target_data_cli.py
- mypy scripts/get_target_data_main.py tests/test_get_target_data_cli.py
- pytest tests/test_get_target_data_cli.py


------
https://chatgpt.com/codex/tasks/task_e_68cd729170d88324bdfdfdc53d1ae0a1