### PR TITLE
Stream pipeline targets identifiers

### DIFF
--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -1212,18 +1212,14 @@ def _run_pipeline(args: argparse.Namespace) -> None:
         raise ValueError("--encoding must be provided")
 
     config_path = Path(args.config).expanduser()
+    pipeline_cfg = load_pipeline_config(str(config_path))
+    config_path = config_path.resolve()
     if not config_path.exists() or not config_path.is_file():
         raise FileNotFoundError(
             f"Configuration file {config_path.resolve()} does not exist"
         )
-    config_path = config_path.resolve()
 
     input_path = Path(args.input).expanduser()
-    if not input_path.exists() or not input_path.is_file():
-        raise FileNotFoundError(f"Input file {input_path.resolve()} does not exist")
-    input_path = input_path.resolve()
-
-    pipeline_cfg = load_pipeline_config(str(config_path))
     if args.timeout_sec is not None:
         pipeline_cfg.timeout_sec = args.timeout_sec
     if args.retries is not None:
@@ -1248,6 +1244,9 @@ def _run_pipeline(args: argparse.Namespace) -> None:
             args.primary_target_only.lower() == "true"
         )
     pipeline_cfg.include_isoforms = pipeline_cfg.include_isoforms or args.with_isoforms
+    if not input_path.exists() or not input_path.is_file():
+        raise FileNotFoundError(f"Input file {input_path.resolve()} does not exist")
+    input_path = input_path.resolve()
     use_isoforms = pipeline_cfg.include_isoforms
 
     data = _load_yaml_mapping(str(config_path))
@@ -1320,30 +1319,28 @@ def _run_pipeline(args: argparse.Namespace) -> None:
 
     csv_cfg = CsvConfig(sep=args.sep, encoding=args.encoding)
     try:
-        identifier_iter = (
-            identifier
-            for identifier in read_ids(
-                input_path,
-                args.id_column,
-                csv_cfg,
-                normalise=_normalise_identifier_series,
-            )
+        identifiers = read_ids(
+            input_path,
+            args.id_column,
+            csv_cfg,
+            normalise=_normalise_identifier_series,
         )
     except KeyError as exc:
         raise ValueError(exc.args[0]) from exc
-    ids: list[str] = [identifier for identifier in identifier_iter if identifier]
-
-    chembl_df: pd.DataFrame = fetch_targets(ids, chembl_cfg, batch_size=args.batch_size)
-
-    def _cached_chembl_fetch(
-        _: Sequence[str], __: TargetConfig
-    ) -> pd.DataFrame:  # pragma: no cover - simple wrapper
-        return chembl_df
 
     entry_cache: Dict[str, Any] = {}
-    with tqdm(total=len(ids), desc="targets") as pbar:
+    chembl_df_holder: dict[str, pd.DataFrame] = {}
+
+    def _cached_chembl_fetch(
+        raw_ids: Iterable[str], config: TargetConfig
+    ) -> pd.DataFrame:
+        df = fetch_targets(raw_ids, config, batch_size=args.batch_size)
+        chembl_df_holder["value"] = df
+        return df
+
+    with tqdm(desc="targets", unit="target") as pbar:
         out_df = run_pipeline(
-            ids,
+            identifiers,
             pipeline_cfg,
             chembl_fetcher=_cached_chembl_fetch,
             chembl_config=chembl_cfg,
@@ -1356,6 +1353,7 @@ def _run_pipeline(args: argparse.Namespace) -> None:
             progress_callback=pbar.update,
             entry_cache=entry_cache,
         )
+    chembl_df = chembl_df_holder.get("value", pd.DataFrame(columns=chembl_cfg.columns))
     enrich_client = enrich_client_factory(cache_config=enrich_cache)
     out_df = add_uniprot_fields(out_df, enrich_client.fetch_all)
     out_df = merge_chembl_fields(out_df, chembl_df)

--- a/tests/test_get_target_data_cli.py
+++ b/tests/test_get_target_data_cli.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import csv
 import json
 import sys
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 
 import pandas as pd
@@ -46,8 +46,8 @@ def test_get_target_data_cli_writes_csv_and_meta(
         ]
     )
 
-    def fake_fetch(ids: list[str], _cfg: object) -> pd.DataFrame:
-        assert ids == ["CHEMBL123", "CHEMBL999"]
+    def fake_fetch(ids: Iterable[str], _cfg: object) -> pd.DataFrame:
+        assert list(ids) == ["CHEMBL123", "CHEMBL999"]
         return sample
 
     monkeypatch.setattr("scripts.get_target_data_main.fetch_targets", fake_fetch)
@@ -128,15 +128,16 @@ def test_get_target_data_cli_streams_in_batches(
 
     calls: list[list[str]] = []
 
-    def fake_fetch(ids: list[str], _cfg: object) -> pd.DataFrame:
-        calls.append(list(ids))
+    def fake_fetch(ids: Iterable[str], _cfg: object) -> pd.DataFrame:
+        batch_ids = list(ids)
+        calls.append(batch_ids)
         rows = [
             {
                 "target_chembl_id": chembl_id,
                 "pref_name": f"Target {chembl_id[-3:]}",
                 "cross_references": [{"source": "UniProt", "xref_id": f"P{index:05d}"}],
             }
-            for index, chembl_id in enumerate(ids, start=1)
+            for index, chembl_id in enumerate(batch_ids, start=1)
         ]
         return pd.DataFrame(rows)
 


### PR DESCRIPTION
## Summary
- keep `library.chembl_targets.fetch_targets` streaming by accepting iterables and batching lazily
- stream identifiers through `library.pipeline_targets.run_pipeline` and the pipeline CLI without materialising lists while updating progress dynamically
- extend CLI tests to cover the streaming behaviour and adapt existing stubs to the iterable-based API

## Testing
- `pytest tests/test_pipeline_targets_cli.py`
- `pytest tests/test_cli_logging_redaction.py -k pipeline_targets_main -q`


------
https://chatgpt.com/codex/tasks/task_e_68cdc586e94c83248d0c5b8cba2eaf48