### PR TITLE
Add contact configuration and initialise IUPHAR session

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,9 @@
 
+contact:
+  name: "ChEMBL Data Acquisition"
+  email: "chembl-da@example.org"
+  user_agent: "chembl-data-acquisition/1.0 (mailto:chembl-da@example.org)"
+
 gtop:
   base_url: "https://www.guidetopharmacology.org/services"
   network:

--- a/library/config/__init__.py
+++ b/library/config/__init__.py
@@ -1,5 +1,6 @@
 """Configuration models for configurable scripts and utilities."""
 
+from .contact import ContactConfig, load_contact_config
 from .pipeline_targets import (
     GtoPSectionConfig,
     HGNCSectionConfig,
@@ -30,4 +31,6 @@ __all__ = [
     "UniProtScriptConfig",
     "UniProtSection",
     "load_uniprot_target_config",
+    "ContactConfig",
+    "load_contact_config",
 ]

--- a/library/config/contact.py
+++ b/library/config/contact.py
@@ -1,0 +1,134 @@
+"""Contact and user agent configuration helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+
+class ContactConfig(BaseModel):
+    """Contact details and HTTP user agent configuration.
+
+    Attributes
+    ----------
+    name:
+        Human readable name for the maintainer or organisation operating the
+        tooling. The value is used purely for documentation purposes but must
+        not be blank.
+    email:
+        Optional contact email address. When provided it must include a single
+        ``@`` separator and a domain.
+    user_agent:
+        Descriptive ``User-Agent`` header sent with outgoing HTTP requests.
+        The string should generally include the project name and a contact
+        point, for example ``"chembl-da/1.0 (mailto:team@example.org)"``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    email: str | None = None
+    user_agent: str = Field(min_length=1)
+
+    @field_validator("name", "user_agent")
+    @classmethod
+    def _strip_and_validate(cls, value: str) -> str:
+        """Return ``value`` stripped of surrounding whitespace."""
+
+        cleaned = value.strip()
+        if not cleaned:
+            msg = "Value must not be blank"
+            raise ValueError(msg)
+        return cleaned
+
+    @field_validator("email")
+    @classmethod
+    def _validate_email(cls, value: str | None) -> str | None:
+        """Ensure the optional email address is well formed."""
+
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            msg = "Email address must not be blank"
+            raise ValueError(msg)
+        if cleaned.count("@") != 1:
+            msg = "Email address must contain exactly one '@'"
+            raise ValueError(msg)
+        local_part, domain = cleaned.split("@", 1)
+        if not local_part or not domain or "." not in domain:
+            msg = "Email address must include a domain"
+            raise ValueError(msg)
+        return cleaned
+
+    def effective_user_agent(self) -> str:
+        """Return the user agent string guaranteed to be non-empty."""
+
+        return self.user_agent
+
+
+def load_contact_config(path: str | Path, *, apply_env: bool = True) -> ContactConfig:
+    """Load and validate the ``contact`` section from a YAML configuration file.
+
+    Parameters
+    ----------
+    path:
+        Path to a YAML configuration file containing a top-level ``contact``
+        mapping.
+    apply_env:
+        When ``True`` environment variable overrides following the
+        ``CHEMBL_DA__`` convention are applied before validation.
+
+    Returns
+    -------
+    ContactConfig
+        Parsed and validated contact configuration.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the provided path does not exist.
+    ValueError
+        If the YAML file does not contain a mapping or lacks the ``contact``
+        section, or when validation fails.
+    """
+
+    config_path = Path(path)
+    try:
+        content = config_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raise
+
+    try:
+        loaded = yaml.safe_load(content) or {}
+    except yaml.YAMLError as exc:  # pragma: no cover - invalid YAML exercised elsewhere
+        raise ValueError(f"Invalid YAML in {config_path}: {exc}") from exc
+
+    if not isinstance(loaded, Mapping):
+        msg = f"Configuration root must be a mapping in {config_path}"
+        raise ValueError(msg)
+
+    data = dict(loaded)
+
+    if apply_env:
+        try:
+            from library.chembl2uniprot.config import _apply_env_overrides
+        except Exception:  # pragma: no cover - defensive fallback
+            pass
+        else:
+            _apply_env_overrides(data)
+
+    contact_data: Any = data.get("contact")
+    if contact_data is None:
+        msg = f"Missing 'contact' section in {config_path}"
+        raise ValueError(msg)
+
+    try:
+        return ContactConfig.model_validate(contact_data)
+    except (
+        ValidationError
+    ) as exc:  # pragma: no cover - detailed error surfaced to caller
+        raise ValueError(str(exc)) from exc

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1,8 +1,18 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": ["io", "columns", "uniprot", "network", "batch", "logging"],
+  "required": ["contact", "io", "columns", "uniprot", "network", "batch", "logging"],
   "properties": {
+    "contact": {
+      "type": "object",
+      "required": ["name", "user_agent"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "email": { "type": "string", "format": "email" },
+        "user_agent": { "type": "string", "minLength": 1 }
+      }
+    },
     "io": {
       "type": "object",
       "required": ["input", "output", "csv"],

--- a/tests/data/config/alias.yaml
+++ b/tests/data/config/alias.yaml
@@ -1,3 +1,8 @@
+contact:
+  name: "Example Maintainer"
+  email: "maintainer@example.org"
+  user_agent: "example-tool/1.0 (mailto:maintainer@example.org)"
+
 io:
   input:
     encoding: "utf-8"

--- a/tests/data/config/config.schema.json
+++ b/tests/data/config/config.schema.json
@@ -1,8 +1,18 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": ["io", "columns", "uniprot", "network", "batch", "logging"],
+  "required": ["contact", "io", "columns", "uniprot", "network", "batch", "logging"],
   "properties": {
+    "contact": {
+      "type": "object",
+      "required": ["name", "user_agent"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "email": { "type": "string", "format": "email" },
+        "user_agent": { "type": "string", "minLength": 1 }
+      }
+    },
     "io": {
       "type": "object",
       "required": ["input", "output", "csv"],

--- a/tests/data/config/valid.yaml
+++ b/tests/data/config/valid.yaml
@@ -1,3 +1,8 @@
+contact:
+  name: "Example Maintainer"
+  email: "maintainer@example.org"
+  user_agent: "example-tool/1.0 (mailto:maintainer@example.org)"
+
 io:
   input:
     encoding: "utf-8"

--- a/tests/test_chembl2uniprot_cli.py
+++ b/tests/test_chembl2uniprot_cli.py
@@ -19,6 +19,10 @@ from chembl2uniprot.mapping import BatchMappingResult
 
 SCHEMA_SOURCE = Path(__file__).parent / "data" / "config" / "config.schema.json"
 CONFIG_TEMPLATE = """
+contact:
+  name: "Test Maintainer"
+  email: "maintainer@example.org"
+  user_agent: "test-suite/1.0 (mailto:maintainer@example.org)"
 io:
   input:
     encoding: "{input_encoding}"

--- a/tests/test_chembl2uniprot_library.py
+++ b/tests/test_chembl2uniprot_library.py
@@ -24,6 +24,10 @@ from chembl2uniprot.mapping import (  # noqa: E402
 SCHEMA_SOURCE = Path(__file__).parent / "data" / "config" / "config.schema.json"
 
 CONFIG_TEMPLATE = """
+contact:
+  name: "Test Maintainer"
+  email: "maintainer@example.org"
+  user_agent: "test-suite/1.0 (mailto:maintainer@example.org)"
 io:
   input:
     encoding: "{input_encoding}"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,16 @@ def _write_config(tmp_path: Path, text: str) -> Path:
     return cfg
 
 
+def test_contact_section_parsed() -> None:
+    """The ``contact`` section is required and parsed via Pydantic."""
+
+    loaded = load_and_validate_config(CONFIG)
+    assert loaded.contact.name == "Example Maintainer"
+    assert (
+        loaded.contact.user_agent == "example-tool/1.0 (mailto:maintainer@example.org)"
+    )
+
+
 def test_invalid_type(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     cfg_text = CONFIG.read_text().replace("rps: 1000", 'rps: "fast"')
     cfg = _write_config(tmp_path, cfg_text)

--- a/tests/test_dump_gtop_target_cli.py
+++ b/tests/test_dump_gtop_target_cli.py
@@ -16,6 +16,14 @@ if str(ROOT) not in sys.path:
 from scripts import dump_gtop_target  # noqa: E402
 
 
+CONTACT_YAML = (
+    "contact:\n"
+    "  name: Test Maintainer\n"
+    "  email: maintainer@example.org\n"
+    "  user_agent: test-suite/1.0 (mailto:maintainer@example.org)\n"
+)
+
+
 class DummyClient:
     """Minimal stub emulating ``GtoPClient`` interactions."""
 
@@ -58,7 +66,8 @@ def test_dump_gtop_target_cli_smoke(
 
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
-        "\n".join(
+        CONTACT_YAML
+        + "\n".join(
             [
                 "gtop:",
                 "  base_url: https://example.org",  # mocked HTTP interactions
@@ -159,7 +168,7 @@ def test_dump_gtop_target_cli_many_identifiers(
             yield normalise(value) if normalise is not None else value
 
     config_path = tmp_path / "config.yaml"
-    config_path.write_text("gtop: {}\n", encoding="utf-8")
+    config_path.write_text(CONTACT_YAML + "gtop: {}\n", encoding="utf-8")
 
     input_csv = tmp_path / "ids.csv"
     input_csv.write_text("hgnc_id\n", encoding="utf-8")

--- a/tests/test_iuphar.py
+++ b/tests/test_iuphar.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
 
 import pandas as pd
 
 from iuphar import IUPHARData, load_families, load_targets
+
+
+def _iuphar_test_data_path(filename: str) -> Path:
+    """Return the path to a fixture file in ``tests/data``."""
+
+    return Path("tests/data") / filename
 
 
 def test_load_functions() -> None:
@@ -24,3 +34,61 @@ def test_map_uniprot_file(tmp_path) -> None:
     assert isinstance(df, pd.DataFrame)
     assert df.loc[0, "target_id"] == "0001"
     assert df.loc[0, "IUPHAR_class"] == "Enzyme"
+
+
+def test_cli_initialises_session_with_contact_user_agent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """CLI initialises the HTTP session with the configured user agent."""
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "contact:\n"
+        "  name: Test Runner\n"
+        "  email: runner@example.org\n"
+        "  user_agent: test-runner/1.0 (mailto:runner@example.org)\n",
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "output.csv"
+
+    import scripts.iuphar_main as module
+    import library.iuphar as iuphar_module
+
+    args = SimpleNamespace(
+        target=str(_iuphar_test_data_path("iuphar_target.csv")),
+        family=str(_iuphar_test_data_path("iuphar_family.csv")),
+        input=str(_iuphar_test_data_path("iuphar_input.csv")),
+        output=str(output_path),
+        sep=",",
+        encoding="utf-8",
+        log_level="INFO",
+        log_format="human",
+        config=str(config_path),
+    )
+    monkeypatch.setattr(module, "parse_args", lambda: args)
+
+    created_sessions: list[Any] = []
+
+    class DummySession:
+        def __init__(self) -> None:
+            self.headers: dict[str, str] = {}
+
+        def get(self, *_args: Any, **_kwargs: Any) -> None:  # pragma: no cover - safety
+            raise AssertionError("Network access not expected during CLI test")
+
+    def fake_session() -> DummySession:
+        session = DummySession()
+        created_sessions.append(session)
+        return session
+
+    monkeypatch.setattr(iuphar_module.requests, "Session", fake_session)
+    monkeypatch.setattr(iuphar_module, "_session", iuphar_module._session)
+
+    module.main()
+
+    assert created_sessions, "Expected init_session to create a requests.Session"
+    assert (
+        created_sessions[0].headers.get("User-Agent")
+        == "test-runner/1.0 (mailto:runner@example.org)"
+    )
+    assert output_path.exists()

--- a/tests/test_pipeline_targets_cli.py
+++ b/tests/test_pipeline_targets_cli.py
@@ -26,6 +26,13 @@ from library.config.pipeline_targets import PipelineClientsConfig
 from library.pipeline_targets import PipelineConfig
 import scripts.pipeline_targets_main as pipeline_main
 
+CONTACT_YAML = (
+    "contact:\n"
+    "  name: Test Maintainer\n"
+    "  email: maintainer@example.org\n"
+    "  user_agent: test-suite/1.0 (mailto:maintainer@example.org)\n"
+)
+
 
 def _make_valid_clients_config() -> dict[str, Any]:
     """Return a configuration mapping accepted by ``PipelineClientsConfig``."""
@@ -140,7 +147,7 @@ def test_pipeline_targets_cli_writes_outputs(
     )
 
     config_path = tmp_path / "config.yaml"
-    config_path.write_text("{}\n", encoding="utf-8")
+    config_path.write_text(CONTACT_YAML + "pipeline: {}\n", encoding="utf-8")
 
     class DummyUniClient:
         def fetch_entry_json(self, accession: str) -> dict[str, Any]:
@@ -299,7 +306,7 @@ def test_pipeline_targets_cli_filters_invalid_ids(
         encoding="utf-8",
     )
     config_path = tmp_path / "config.yaml"
-    config_path.write_text("{}\n", encoding="utf-8")
+    config_path.write_text(CONTACT_YAML + "pipeline: {}\n", encoding="utf-8")
 
     captured: dict[str, Any] = {}
 
@@ -393,7 +400,7 @@ def test_pipeline_targets_cli_rejects_invalid_batch_size(
     input_csv = tmp_path / "input.csv"
     input_csv.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
     config_path = tmp_path / "config.yaml"
-    config_path.write_text("{}\n", encoding="utf-8")
+    config_path.write_text(CONTACT_YAML + "pipeline: {}\n", encoding="utf-8")
 
     argv = [
         "pipeline_targets_main",
@@ -456,7 +463,9 @@ def test_pipeline_targets_cli_uses_configured_list_format(
     input_csv.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
 
     config_path = tmp_path / "config.yaml"
-    config_path.write_text("pipeline:\n  list_format: pipe\n", encoding="utf-8")
+    config_path.write_text(
+        CONTACT_YAML + "pipeline:\n  list_format: pipe\n", encoding="utf-8"
+    )
 
     class DummyUniClient:
         def fetch_entry_json(self, accession: str) -> dict[str, Any]:
@@ -535,7 +544,9 @@ def test_pipeline_targets_cli_respects_yaml_defaults(
 
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
-        """
+        CONTACT_YAML
+        + (
+            """
 pipeline:
   list_format: pipe
   species_priority:
@@ -546,8 +557,9 @@ pipeline:
     primary_target_only: false
 orthologs:
   enabled: true
-        """.strip()
-        + "\n",
+            """.strip()
+            + "\n"
+        ),
         encoding="utf-8",
     )
 
@@ -640,7 +652,9 @@ def test_pipeline_targets_cli_overrides_specific_flags(
 
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
-        """
+        CONTACT_YAML
+        + (
+            """
 pipeline:
   list_format: pipe
   species_priority:
@@ -651,8 +665,9 @@ pipeline:
     primary_target_only: false
 orthologs:
   enabled: false
-        """.strip()
-        + "\n",
+            """.strip()
+            + "\n"
+        ),
         encoding="utf-8",
     )
 
@@ -754,7 +769,7 @@ def test_pipeline_targets_cli_network_overrides(
     input_csv.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
 
     config_path = tmp_path / "config.yaml"
-    config_path.write_text("{}\n", encoding="utf-8")
+    config_path.write_text(CONTACT_YAML + "pipeline: {}\n", encoding="utf-8")
 
     expected_timeout = 45.5
     expected_retries = 7
@@ -864,15 +879,18 @@ def test_pipeline_targets_cli_accepts_null_sections(
 
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
-        """
+        CONTACT_YAML
+        + (
+            """
 pipeline:
   columns: null
   iuphar: null
 orthologs: null
 chembl: null
 uniprot_enrich: null
-        """.strip()
-        + "\n",
+            """.strip()
+            + "\n"
+        ),
         encoding="utf-8",
     )
 
@@ -951,7 +969,7 @@ def test_run_pipeline_streams_identifiers_without_dataframe(
     module: Any = importlib.import_module("scripts.pipeline_targets_main")
 
     config_path = tmp_path / "config.yaml"
-    config_path.write_text("{}\n", encoding="utf-8")
+    config_path.write_text(CONTACT_YAML + "pipeline: {}\n", encoding="utf-8")
 
     input_path = tmp_path / "input.csv"
     input_path.write_text(
@@ -1170,7 +1188,7 @@ def test_pipeline_targets_cli_rejects_invalid_list_format(
     input_csv.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
 
     config_path = tmp_path / "config.yaml"
-    config_path.write_text("{}\n", encoding="utf-8")
+    config_path.write_text(CONTACT_YAML + "pipeline: {}\n", encoding="utf-8")
 
     argv = [
         "pipeline_targets_main",

--- a/tests/test_pipeline_targets_main.py
+++ b/tests/test_pipeline_targets_main.py
@@ -25,6 +25,14 @@ from pipeline_targets_main import (
 from library.pipeline_targets import PipelineConfig
 
 
+CONTACT_YAML = (
+    "contact:\n"
+    "  name: Test Maintainer\n"
+    "  email: maintainer@example.org\n"
+    "  user_agent: test-suite/1.0 (mailto:maintainer@example.org)\n"
+)
+
+
 def test_merge_chembl_fields_adds_columns():
     pipeline_df = pd.DataFrame(
         {
@@ -385,7 +393,9 @@ def test_parse_args_with_orthologs_flag(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     config_path = tmp_path / "config.yaml"
-    config_path.write_text("orthologs:\n  enabled: true\n", encoding="utf-8")
+    config_path.write_text(
+        CONTACT_YAML + "orthologs:\n  enabled: true\n", encoding="utf-8"
+    )
 
     monkeypatch.setattr(
         sys,


### PR DESCRIPTION
## Summary
- add a shared contact configuration section and expose helpers for loading it
- require the new contact section in config validation and update fixtures to provide it
- load the contact user agent in iuphar_main and initialise the HTTP session
- extend tests to cover the new configuration and session behaviour

## Testing
- ruff check library/config/contact.py library/chembl2uniprot/config.py scripts/iuphar_main.py tests/test_iuphar.py tests/test_config.py tests/test_chembl2uniprot_cli.py tests/test_chembl2uniprot_library.py tests/test_pipeline_targets_cli.py tests/test_pipeline_targets_main.py tests/test_dump_gtop_target_cli.py tests/scripts/test_cli_error_handling.py
- mypy --config-file mypy.ini library/config/contact.py scripts/iuphar_main.py library/chembl2uniprot/config.py
- pytest tests/test_config.py tests/test_iuphar.py tests/test_chembl2uniprot_cli.py tests/test_chembl2uniprot_library.py tests/test_pipeline_targets_cli.py tests/test_pipeline_targets_main.py tests/test_dump_gtop_target_cli.py tests/scripts/test_cli_error_handling.py

------
https://chatgpt.com/codex/tasks/task_e_68cdc577b7b88324b51a7fc69f0fb3e9