### PR TITLE
Add ortholog override warnings and metadata support

### DIFF
--- a/library/cli_common.py
+++ b/library/cli_common.py
@@ -240,6 +240,7 @@ def write_cli_metadata(
     meta_path: Path | None = None,
     status: Literal["success", "error"] = "success",
     error: str | None = None,
+    warnings: Sequence[str] | None = None,
 ) -> Path:
     """Persists a `.meta.yaml` companion file next to the output file.
 
@@ -258,6 +259,9 @@ def write_cli_metadata(
             prevented the output from being written.
         error: Optional human-readable description of the failure when
             ``status`` is ``"error"``.
+        warnings: Optional sequence of warning messages to persist alongside the
+            core metadata. Use this to surface non-fatal issues to downstream
+            consumers.
 
     Returns:
         The path to the written metadata file.
@@ -277,4 +281,5 @@ def write_cli_metadata(
         status=status,
         error=error,
         include_hash=include_hash,
+        warnings=warnings,
     )

--- a/library/metadata.py
+++ b/library/metadata.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
@@ -109,6 +109,7 @@ def write_meta_yaml(
     status: Literal["success", "error"] = "success",
     error: str | None = None,
     include_hash: bool = True,
+    warnings: Sequence[str] | None = None,
 ) -> Path:
     """Writes dataset metadata to a YAML file next to the output file.
 
@@ -134,6 +135,10 @@ def write_meta_yaml(
     include_hash:
         When :data:`True`, compute and persist the SHA-256 digest alongside a
         determinism record. Disable when the output file was not produced.
+    warnings:
+        Optional collection of warning messages emitted during execution. The
+        sequence is preserved as provided and intended for non-fatal issues that
+        should be visible to downstream consumers of the metadata.
     """
 
     default_meta_path = output_path.with_name(f"{output_path.name}.meta.yaml")
@@ -153,6 +158,9 @@ def write_meta_yaml(
 
     if error:
         metadata["error"] = error
+
+    if warnings:
+        metadata["warnings"] = list(warnings)
 
     if include_hash:
         metadata["sha256"] = _file_sha256(output_path)

--- a/tests/test_get_uniprot_target_data.py
+++ b/tests/test_get_uniprot_target_data.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from importlib.machinery import SourceFileLoader
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -43,7 +45,9 @@ def test_missing_column_exits_cleanly(tmp_path: Path) -> None:
     assert metadata["sha256"] is None
 
 
-def test_missing_input_file_exits_with_error(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+def test_missing_input_file_exits_with_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
     """The CLI should report when the input file cannot be located."""
 
     import scripts.get_uniprot_target_data as cli
@@ -81,3 +85,124 @@ def test_missing_input_file_exits_with_error(monkeypatch: pytest.MonkeyPatch, ca
     assert excinfo.value.code == 1
     captured = capsys.readouterr()
     assert "Input file missing.csv does not exist" in captured.err
+
+
+def test_cli_records_warning_when_ortholog_flags_conflict(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Ensure the metadata captures ortholog preference conflicts."""
+
+    loader = SourceFileLoader("get_uniprot_target_data_conflict", str(SCRIPT))
+    module = loader.load_module()
+
+    input_path = tmp_path / "input.csv"
+    input_path.write_text("uniprot_id\nP12345\n", encoding="utf-8")
+    output_path = tmp_path / "output.csv"
+
+    class DummyOutputConfig:
+        list_format = "json"
+        include_sequence = False
+        sep = ","
+        encoding = "utf-8"
+
+    class DummyUniProtConfig:
+        def __init__(self) -> None:
+            self.include_isoforms = False
+            self.use_fasta_stream_for_isoform_ids = False
+            self.cache = None
+            self.base_url = "https://example.uniprot"
+            self.timeout_sec = 1.0
+            self.retries = 0
+            self.rps = 5.0
+            self.fields: list[str] = []
+            self.columns: list[str] = []
+
+        def model_dump(self) -> dict[str, list[str]]:
+            return {"fields": self.fields, "columns": self.columns}
+
+    class DummyOrthologsConfig:
+        def __init__(self) -> None:
+            self.enabled = True
+            self.cache = None
+            self.timeout_sec = 1.0
+            self.retries = 0
+            self.backoff_base_sec = 1.0
+            self.rate_limit_rps = 2.0
+
+    class DummyConfig:
+        def __init__(self) -> None:
+            self.http_cache = None
+            self.output = DummyOutputConfig()
+            self.uniprot = DummyUniProtConfig()
+            self.orthologs = DummyOrthologsConfig()
+
+    monkeypatch.setattr(
+        module,
+        "load_uniprot_target_config",
+        lambda *_args, **_kwargs: DummyConfig(),
+    )
+    monkeypatch.setattr(
+        "library.cli_common.analyze_table_quality", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        "library.cli_common.serialise_dataframe",
+        lambda df, list_format, *, inplace=False: df,
+    )
+    monkeypatch.setattr(
+        "library.http_client.CacheConfig.from_dict", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        "library.uniprot_normalize.extract_ensembl_gene_ids",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "library.uniprot_normalize.normalize_entry",
+        lambda data, include_seq, isoforms: {"uniprot_id": data["primaryAccession"]},
+    )
+    monkeypatch.setattr(
+        "library.uniprot_normalize.output_columns",
+        lambda *_args, **_kwargs: ["uniprot_id"],
+    )
+
+    class DummyClient:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def fetch_entries_json(
+            self, accessions: list[str], *, batch_size: int = 0
+        ) -> dict[str, dict[str, str]]:
+            return {
+                accession: {"primaryAccession": accession} for accession in accessions
+            }
+
+        def fetch_isoforms_fasta(self, _accession: str) -> list[str]:
+            return []
+
+    monkeypatch.setattr("library.uniprot_client.UniProtClient", DummyClient)
+
+    expected_warning = (
+        "Ortholog enrichment configuration conflict: CLI requested False but "
+        "configuration orthologs.enabled=True. Ortholog data will not be "
+        "retrieved. Use --orthologs-enabled/--no-orthologs-enabled to override "
+        "the configuration."
+    )
+
+    module.main(
+        [
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--no-with-orthologs",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert expected_warning in captured.err
+
+    meta_path = output_path.with_name(f"{output_path.name}.meta.yaml")
+    assert meta_path.exists()
+    metadata = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+    assert metadata["warnings"] == [expected_warning]


### PR DESCRIPTION
## Summary
- add CLI toggles for ortholog enrichment that honour configuration defaults and emit warnings when the CLI request and YAML configuration disagree
- persist warning messages in metadata sidecars via write_cli_metadata/write_meta_yaml so ortholog preference conflicts surface downstream
- cover the behaviour with a unit test that checks stderr and metadata when ortholog flags are mismatched

## Testing
- black scripts/get_uniprot_target_data.py library/cli_common.py library/metadata.py tests/test_get_uniprot_target_data.py
- ruff check scripts/get_uniprot_target_data.py library/cli_common.py library/metadata.py tests/test_get_uniprot_target_data.py
- mypy scripts/get_uniprot_target_data.py
- pytest tests/test_get_uniprot_target_data.py

------
https://chatgpt.com/codex/tasks/task_e_68cdca176e648324b00fe9743834e2c1