### PR TITLE
Handle YAML config errors in pipeline targets CLI

### DIFF
--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -1006,6 +1006,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         config_data = _load_yaml_mapping(preliminary.config)
     except FileNotFoundError:
         config_data = {}
+    except (yaml.YAMLError, TypeError) as exc:
+        message = f"Invalid configuration file '{preliminary.config}': {exc}"
+        config_parser.error(message)
     _apply_env_overrides(config_data, section="pipeline")
     orthologs_cfg = _ensure_mapping(config_data.get("orthologs"), context="orthologs")
     orthologs_default = _ensure_bool(

--- a/tests/test_pipeline_targets_cli.py
+++ b/tests/test_pipeline_targets_cli.py
@@ -138,6 +138,34 @@ def test_parse_args_inherits_env_ortholog_default(
     assert args.with_orthologs is True
 
 
+def test_parse_args_reports_yaml_errors(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Invalid configuration files should trigger a human-friendly error."""
+
+    module: Any = importlib.import_module("scripts.pipeline_targets_main")
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("pipeline: [broken\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        module.parse_args(
+            [
+                "--config",
+                str(config_path),
+                "--input",
+                "input.csv",
+                "--output",
+                "output.csv",
+            ]
+        )
+
+    assert excinfo.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "Invalid configuration file" in stderr
+    assert "Traceback" not in stderr
+
+
 def test_pipeline_targets_cli_writes_outputs(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- raise a concise parser error when pipeline configuration YAML cannot be loaded
- cover the regression with a CLI test that asserts the SystemExit message stays user friendly

## Testing
- ruff check scripts/pipeline_targets_main.py tests/test_pipeline_targets_cli.py
- pytest tests/test_pipeline_targets_cli.py::test_parse_args_reports_yaml_errors

------
https://chatgpt.com/codex/tasks/task_e_68cde7dc0b9c8324b47b059e60af94e8