### PR TITLE
Expand CLI sidecar overrides to support user directories

### DIFF
--- a/library/cli_common.py
+++ b/library/cli_common.py
@@ -214,12 +214,12 @@ def resolve_cli_sidecar_paths(
         raise ValueError(msg)
 
     meta_path = (
-        Path(meta_output)
+        Path(meta_output).expanduser()
         if meta_output is not None
         else _append_suffix_to_name(destination, ".meta.yaml")
     )
     errors_path = (
-        Path(errors_output)
+        Path(errors_output).expanduser()
         if errors_output is not None
         else _append_suffix_to_name(destination, ".errors.json")
     )


### PR DESCRIPTION
## Summary
- expand custom metadata and error sidecar overrides using Path.expanduser so `~` is resolved
- harden the sidecar regression test to accept the CLI's non-zero exit code while still checking outputs
- add a focused unit test covering tilde expansion in resolve_cli_sidecar_paths

## Testing
- pytest tests/scripts/test_sidecar_outputs.py

------
https://chatgpt.com/codex/tasks/task_e_68cde7d44ea483248addd750a6548c6d