### PR TITLE
Add context management support to ChemblClient

### DIFF
--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -8,6 +8,7 @@ import re
 
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from types import TracebackType
 from typing import Any, Callable, Dict, List
 
 import pandas as pd
@@ -144,6 +145,26 @@ class ChemblClient:
             rps=self.rps,
             cache_config=self.cache_config,
         )
+
+    def close(self) -> None:
+        """Close the underlying :class:`HttpClient` resources."""
+
+        self._http.close()
+
+    def __enter__(self) -> "ChemblClient":
+        """Return ``self`` to support ``with`` statements."""
+
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Ensure the HTTP client is closed after leaving a context block."""
+
+        self.close()
 
     def _fetch_resource(
         self, resource: str, identifier: str, *, id_field: str

--- a/scripts/chembl_activities_main.py
+++ b/scripts/chembl_activities_main.py
@@ -180,15 +180,14 @@ def run_pipeline(
 
     activity_ids = _limited_ids(input_path, args.column, csv_cfg, args.limit)
 
-    client = ChemblClient(
+    with ChemblClient(
         base_url=args.base_url,
         timeout=args.timeout,
         max_retries=args.max_retries,
         rps=args.rps,
         user_agent=args.user_agent,
-    )
-
-    activities_df = get_activities(client, activity_ids, chunk_size=args.chunk_size)
+    ) as client:
+        activities_df = get_activities(client, activity_ids, chunk_size=args.chunk_size)
     if activities_df.empty:
         LOGGER.warning("No activity data retrieved; writing empty output")
         activities_df = pd.DataFrame(columns=ActivitiesSchema.ordered_columns())

--- a/scripts/chembl_assays_main.py
+++ b/scripts/chembl_assays_main.py
@@ -154,14 +154,13 @@ def run_pipeline(
     )
     assay_ids = read_ids(input_path, args.column, csv_cfg)
 
-    client = ChemblClient(
+    with ChemblClient(
         base_url=args.base_url,
         timeout=args.timeout,
         max_retries=args.max_retries,
         rps=args.rps,
-    )
-
-    assays_df = get_assays(client, assay_ids, chunk_size=args.chunk_size)
+    ) as client:
+        assays_df = get_assays(client, assay_ids, chunk_size=args.chunk_size)
     if assays_df.empty:
         LOGGER.warning("No assay data retrieved; writing empty output")
         assays_df = pd.DataFrame(columns=AssaysSchema.ordered_columns())

--- a/scripts/chembl_testitems_main.py
+++ b/scripts/chembl_testitems_main.py
@@ -289,15 +289,14 @@ def run_pipeline(
 
     molecule_ids = _limited_ids(input_path, args.column, csv_cfg, args.limit)
 
-    client = ChemblClient(
+    with ChemblClient(
         base_url=args.base_url,
         timeout=args.timeout,
         max_retries=args.max_retries,
         rps=args.rps,
         user_agent=args.user_agent,
-    )
-
-    molecules_df = get_testitems(client, molecule_ids, chunk_size=args.chunk_size)
+    ) as client:
+        molecules_df = get_testitems(client, molecule_ids, chunk_size=args.chunk_size)
     if molecules_df.empty:
         LOGGER.warning("No molecule data retrieved; writing empty output")
         molecules_df = pd.DataFrame(columns=TestitemsSchema.ordered_columns())

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -6,6 +6,7 @@ import logging
 import sys
 from pathlib import Path
 from typing import Any
+from unittest.mock import create_autospec
 
 import pytest
 import requests  # type: ignore[import-untyped]
@@ -169,3 +170,21 @@ def test_get_documents_batches_requests_and_filters_duplicates() -> None:
         "DOC3",
     ]
     assert df["document_chembl_id"].tolist() == ["DOC1", "DOC2", "DOC3"]
+
+
+def test_close_delegates_to_http_client() -> None:
+    http_client = create_autospec(HttpClient, instance=True)
+    client = ChemblClient(http_client=http_client)
+
+    client.close()
+
+    http_client.close.assert_called_once_with()
+
+
+def test_context_manager_closes_http_client() -> None:
+    http_client = create_autospec(HttpClient, instance=True)
+
+    with ChemblClient(http_client=http_client):
+        http_client.close.assert_not_called()
+
+    http_client.close.assert_called_once_with()


### PR DESCRIPTION
## Summary
- add context manager support to `ChemblClient`, delegating resource cleanup to `HttpClient.close`
- update the assays, activities, and test items CLIs to use `ChemblClient` via `with` blocks
- extend the client tests to confirm that `close()` and context management forward to the HTTP client

## Testing
- python -m black library/chembl_client.py scripts/chembl_assays_main.py scripts/chembl_activities_main.py scripts/chembl_testitems_main.py tests/test_chembl_client.py
- python -m ruff check library/chembl_client.py scripts/chembl_assays_main.py scripts/chembl_activities_main.py scripts/chembl_testitems_main.py tests/test_chembl_client.py
- pytest tests/test_chembl_client.py


------
https://chatgpt.com/codex/tasks/task_e_68cde7c605fc83248b9c389c727ded0b