### PR TITLE
Normalise pipeline env overrides with YAML parsing

### DIFF
--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -306,8 +306,8 @@ def _load_yaml_mapping(path: str) -> dict[str, Any]:
     return _ensure_mapping(data, context=f"{path} root", allow_none=False)
 
 
-def _coerce_env_value(raw_value: str) -> Any:
-    """Return a Python object parsed from ``raw_value`` when possible.
+def _normalise_env_override(raw_value: str) -> Any:
+    """Return ``raw_value`` parsed into a native Python object when possible.
 
     Parameters
     ----------
@@ -390,7 +390,7 @@ def _apply_env_overrides(
             ref = ref.setdefault(part, {})
         if not valid_path or not isinstance(ref, dict):
             continue
-        ref[path[-1]] = _coerce_env_value(value)
+        ref[path[-1]] = _normalise_env_override(value)
     return data
 
 

--- a/tests/test_pipeline_targets_cli.py
+++ b/tests/test_pipeline_targets_cli.py
@@ -138,6 +138,22 @@ def test_parse_args_inherits_env_ortholog_default(
     assert args.with_orthologs is True
 
 
+def test_apply_env_overrides_parses_species_sequence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """List-like environment overrides should be decoded using YAML parsing."""
+
+    module: Any = importlib.import_module("scripts.pipeline_targets_main")
+    monkeypatch.setenv(
+        "CHEMBL_DA__ORTHOLOGS__TARGET_SPECIES", '["Mouse","Rat"]'
+    )
+    data: dict[str, Any] = {"orthologs": {"target_species": ["human"]}}
+
+    module._apply_env_overrides(data, section="pipeline")
+
+    assert data["orthologs"]["target_species"] == ["Mouse", "Rat"]
+
+
 def test_pipeline_targets_cli_writes_outputs(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- normalised environment overrides via yaml.safe_load helper in the pipeline CLI
- added coverage ensuring ortholog species overrides parse list-valued YAML

## Testing
- pytest tests/test_pipeline_targets_cli.py::test_apply_env_overrides_parses_species_sequence

------
https://chatgpt.com/codex/tasks/task_e_68cde7d9e5a483249398f063aa11b9b3