### PR TITLE
Throttle Semantic Scholar requests and gate high throughput

### DIFF
--- a/config/documents.yaml
+++ b/config/documents.yaml
@@ -13,7 +13,7 @@ semantic_scholar:
   chunk_size: 50
   timeout: 30
   max_retries: 3
-  rps: 2.0
+  rps: 0.3
 
 openalex:
   rps: 1.0


### PR DESCRIPTION
## Summary
- reduce the Semantic Scholar RPS override in the bundled documents configuration so the public throttle is honoured
- add CLI/config controls that require an API key before unlocking higher Semantic Scholar throughput and redact secrets when printing config
- document the new workflow and expand tests covering clamping, high-throughput toggles, and API key sources

## Testing
- pytest tests/test_pubmed_main.py
- ruff check scripts/pubmed_main.py tests/test_pubmed_main.py
- python scripts/pubmed_main.py --input /tmp/scholar_sample.csv --output /tmp/scholar_output.csv scholar


------
https://chatgpt.com/codex/tasks/task_e_68cde9121f0c83249c13206ed9d38843