### PR TITLE
Add limit parameter to document retrieval

### DIFF
--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -400,7 +400,11 @@ def get_documents(
     records: list[dict[str, Any]] = []
 
     for chunk in _chunked(unique_ids, chunk_size):
-        url = f"{base}&document_chembl_id__in={','.join(chunk)}"
+        # Align the ``limit`` parameter with the chunk size so the API returns
+        # all requested records even when the server-side default is smaller.
+        limit = len(chunk)
+        ids_param = ",".join(chunk)
+        url = f"{base}&document_chembl_id__in={ids_param}&limit={limit}"
         data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("documents") or data.get("document") or []
         for item in items:

--- a/library/chembl_targets.py
+++ b/library/chembl_targets.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from itertools import islice
-from typing import Any, Dict, Iterable, Iterator, List, Sequence
+from typing import Any, Dict, Iterable, Iterator, List
 
 import pandas as pd
 import requests

--- a/library/hgnc_client.py
+++ b/library/hgnc_client.py
@@ -16,10 +16,9 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
- 
+
 from types import TracebackType
-from typing import Any,Dict, List
-import logging
+from typing import Any, Dict, List
 
 
 import pandas as pd

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -6,6 +6,7 @@ import logging
 import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 import requests  # type: ignore[import-untyped]
@@ -124,14 +125,23 @@ def test_get_documents_batches_requests_and_filters_duplicates() -> None:
 
     class _Recorder:
         def __init__(self) -> None:
-            self.calls: list[str] = []
+            self.calls: list[dict[str, Any]] = []
 
         def request_json(
             self, url: str, *, cfg: ApiCfg, timeout: float
         ) -> dict[str, Any]:
-            self.calls.append(url)
-            ids_part = url.split("document_chembl_id__in=")[1]
-            identifiers = ids_part.split(",")
+            parsed = urlparse(url)
+            params = parse_qs(parsed.query)
+            ids_raw = params.get("document_chembl_id__in", [""])[0]
+            identifiers = [value for value in ids_raw.split(",") if value]
+            limit_raw = params.get("limit", [None])[0]
+            self.calls.append(
+                {
+                    "url": url,
+                    "ids": identifiers,
+                    "limit": int(limit_raw) if limit_raw is not None else None,
+                }
+            )
             return {
                 "documents": [
                     {
@@ -164,11 +174,68 @@ def test_get_documents_batches_requests_and_filters_duplicates() -> None:
         chunk_size=2,
     )
 
-    assert [call.split("document_chembl_id__in=")[1] for call in recorder.calls] == [
+    assert [",".join(item["ids"]) for item in recorder.calls] == [
         "DOC1,DOC2",
         "DOC3",
     ]
+    assert [item["limit"] for item in recorder.calls] == [2, 1]
     assert df["document_chembl_id"].tolist() == ["DOC1", "DOC2", "DOC3"]
+
+
+def test_get_documents_returns_all_ids_when_chunk_exceeds_default_limit() -> None:
+    cfg = ApiCfg()
+    api_default_limit = 20
+    requested_ids = [f"DOC{i}" for i in range(api_default_limit + 5)]
+
+    class _LimitedRecorder:
+        def __init__(self) -> None:
+            self.limits: list[int] = []
+
+        def request_json(
+            self, url: str, *, cfg: ApiCfg, timeout: float
+        ) -> dict[str, Any]:
+            parsed = urlparse(url)
+            params = parse_qs(parsed.query)
+            ids_raw = params.get("document_chembl_id__in", [""])[0]
+            identifiers = [value for value in ids_raw.split(",") if value]
+            limit_raw = params.get("limit", [str(api_default_limit)])[0]
+            limit = int(limit_raw)
+            self.limits.append(limit)
+            subset = identifiers[:limit]
+            return {
+                "documents": [
+                    {
+                        "document_chembl_id": doc_id,
+                        "title": f"Title {doc_id}",
+                        "abstract": f"Abstract {doc_id}",
+                        "doi": f"10.{doc_id}/doi{doc_id}",
+                        "year": 2024,
+                        "journal_full_title": "Journal",
+                        "journal": "J",
+                        "volume": "1",
+                        "issue": "1",
+                        "first_page": "1",
+                        "last_page": "2",
+                        "pubmed_id": doc_id,
+                        "authors": "Author",
+                    }
+                    for doc_id in subset
+                ]
+            }
+
+    recorder = _LimitedRecorder()
+    client = ChemblClient(http_client=HttpClient(timeout=1.0, max_retries=1, rps=0))
+    client.request_json = recorder.request_json  # type: ignore[assignment]
+
+    df = get_documents(
+        requested_ids,
+        cfg=cfg,
+        client=client,
+        chunk_size=len(requested_ids),
+    )
+
+    assert recorder.limits == [len(requested_ids)]
+    assert df["document_chembl_id"].tolist() == requested_ids
 
 
 def test_fetch_assay_retries_on_429_without_retry_after(


### PR DESCRIPTION
## Summary
- set the document collection requests to include a limit that matches the chunk size so all requested IDs are returned
- extend the document client tests to assert the presence of the limit parameter and to cover requests that exceed the API default limit
- tidy up minor lint issues flagged by ruff in neighbouring modules

## Testing
- poetry run black library/chembl_client.py tests/test_chembl_client.py
- poetry run black library/chembl_targets.py library/hgnc_client.py
- poetry run ruff check
- poetry run mypy library/chembl_client.py tests/test_chembl_client.py
- poetry run pytest tests/test_chembl_client.py


------
https://chatgpt.com/codex/tasks/task_e_68cdeb47def08324a0e11f739cf586bc