### PR TITLE
Stream ChEMBL CLI processing with resumable chunk support

### DIFF
--- a/library/cli_common.py
+++ b/library/cli_common.py
@@ -241,6 +241,7 @@ def write_cli_metadata(
     status: Literal["success", "error"] = "success",
     error: str | None = None,
     warnings: Sequence[str] | None = None,
+    extra: Mapping[str, Any] | None = None,
 ) -> Path:
     """Persists a `.meta.yaml` companion file next to the output file.
 
@@ -262,6 +263,9 @@ def write_cli_metadata(
         warnings: Optional sequence of warning messages to persist alongside the
             core metadata. Use this to surface non-fatal issues to downstream
             consumers.
+        extra: Additional mapping merged into the metadata payload. This is
+            typically used to store progress checkpoints such as the last
+            processed identifier for resumable jobs.
 
     Returns:
         The path to the written metadata file.
@@ -282,4 +286,5 @@ def write_cli_metadata(
         error=error,
         include_hash=include_hash,
         warnings=warnings,
+        extra=extra,
     )

--- a/library/metadata.py
+++ b/library/metadata.py
@@ -110,6 +110,7 @@ def write_meta_yaml(
     error: str | None = None,
     include_hash: bool = True,
     warnings: Sequence[str] | None = None,
+    extra: Mapping[str, Any] | None = None,
 ) -> Path:
     """Writes dataset metadata to a YAML file next to the output file.
 
@@ -139,6 +140,10 @@ def write_meta_yaml(
         Optional collection of warning messages emitted during execution. The
         sequence is preserved as provided and intended for non-fatal issues that
         should be visible to downstream consumers of the metadata.
+    extra:
+        Additional key-value pairs appended to the metadata record. This is
+        useful for storing progress checkpoints that allow long-running jobs to
+        resume without starting from scratch.
     """
 
     default_meta_path = output_path.with_name(f"{output_path.name}.meta.yaml")
@@ -162,10 +167,15 @@ def write_meta_yaml(
     if warnings:
         metadata["warnings"] = list(warnings)
 
+    if extra:
+        for key, value in extra.items():
+            metadata[key] = value
+
     if include_hash:
         metadata["sha256"] = _file_sha256(output_path)
         metadata["determinism"] = _determinism_record(
-            current_sha=metadata["sha256"], previous_metadata=previous_metadata
+            current_sha=str(metadata["sha256"]),
+            previous_metadata=previous_metadata,
         )
     else:
         metadata["sha256"] = None

--- a/scripts/chembl_activities_main.py
+++ b/scripts/chembl_activities_main.py
@@ -3,20 +3,24 @@
 from __future__ import annotations
 
 if __package__ in {None, ""}:
-    from _path_utils import ensure_project_root as _ensure_project_root
+    from _path_utils import ensure_project_root as _ensure_project_root  # type: ignore[import-not-found]
 
     _ensure_project_root()
 
 import argparse
+import json
 import logging
 import sys
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable, Sequence, cast
+from typing import Any, cast
 
 import pandas as pd
+import yaml
 
 from library.cli_common import (
+    ListFormat,
     ensure_output_dir,
     resolve_cli_sidecar_paths,
     serialise_dataframe,
@@ -24,7 +28,7 @@ from library.cli_common import (
 )
 from library.activity_validation import ActivitiesSchema, validate_activities
 from library.chembl_client import ChemblClient
-from library.chembl_library import get_activities
+from library.chembl_library import stream_activities
 from library.data_profiling import analyze_table_quality
 from library.io import read_ids
 from library.io_utils import CsvConfig
@@ -146,6 +150,146 @@ def _limited_ids(
     return cast(Iterable[str], read_ids(path, column, cfg, limit=limit))
 
 
+def _load_existing_metadata(meta_path: Path) -> dict[str, Any]:
+    """Load a previously generated metadata file if it exists."""
+
+    if not meta_path.exists():
+        return {}
+    try:
+        with meta_path.open("r", encoding="utf-8") as handle:
+            payload = yaml.safe_load(handle) or {}
+    except FileNotFoundError:
+        return {}
+    except yaml.YAMLError as exc:
+        LOGGER.warning("Failed to parse metadata file %s: %s", meta_path, exc)
+        return {}
+    if isinstance(payload, Mapping):
+        return dict(payload)
+    LOGGER.warning("Metadata file %s does not contain a mapping", meta_path)
+    return {}
+
+
+def _load_existing_errors(errors_path: Path) -> list[dict[str, Any]]:
+    """Load validation errors from a previous run when resuming."""
+
+    if not errors_path.exists():
+        return []
+    try:
+        with errors_path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except FileNotFoundError:
+        return []
+    except json.JSONDecodeError as exc:
+        LOGGER.warning("Failed to parse validation report %s: %s", errors_path, exc)
+        return []
+    if isinstance(payload, list):
+        return [record for record in payload if isinstance(record, dict)]
+    LOGGER.warning("Validation report %s is not a list; ignoring", errors_path)
+    return []
+
+
+def _consume_error_file(path: Path) -> list[dict[str, Any]]:
+    """Return and remove a temporary error file produced during validation."""
+
+    if not path.exists():
+        return []
+    errors = _load_existing_errors(path)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    return errors
+
+
+def _skip_processed_ids(
+    loader: Callable[[], Iterable[str]], last_processed: str | None
+) -> Iterator[str]:
+    """Skip identifiers processed in a previous run using checkpoint metadata."""
+
+    if last_processed is None:
+        yield from loader()
+        return
+
+    iterator = iter(loader())
+    for identifier in iterator:
+        if identifier == last_processed:
+            LOGGER.info(
+                "Resuming after previously processed identifier %s", last_processed
+            )
+            break
+    else:
+        LOGGER.warning(
+            "Previously processed identifier %s not found; restarting from the beginning",
+            last_processed,
+        )
+        yield from loader()
+        return
+
+    # Continue from the element immediately after ``last_processed``.
+    for identifier in iterator:
+        yield identifier
+
+
+def _prepare_activity_chunk(
+    chunk: pd.DataFrame,
+    *,
+    list_format: ListFormat,
+    errors_path: Path,
+    error_accumulator: list[dict[str, Any]],
+    ordered_columns: list[str] | None,
+) -> tuple[pd.DataFrame, list[str] | None, str | None]:
+    """Normalise, validate, and serialise a single chunk of activity records."""
+
+    if chunk.empty:
+        return pd.DataFrame(), ordered_columns, None
+
+    normalised = normalize_activities(chunk)
+
+    temp_errors = errors_path.with_name(f"{errors_path.name}.part")
+    validated = validate_activities(normalised, errors_path=temp_errors)
+    error_accumulator.extend(_consume_error_file(temp_errors))
+
+    if validated.empty:
+        return pd.DataFrame(), ordered_columns, None
+
+    if ordered_columns is None:
+        schema_columns = [
+            column
+            for column in ActivitiesSchema.ordered_columns()
+            if column in validated.columns
+        ]
+        extra_columns = sorted(
+            [column for column in validated.columns if column not in schema_columns]
+        )
+        ordered_columns = schema_columns + extra_columns
+    else:
+        missing_columns = [
+            column for column in validated.columns if column not in ordered_columns
+        ]
+        if missing_columns:
+            ordered_columns = [*ordered_columns, *sorted(missing_columns)]
+
+    prepared = validated.reindex(
+        columns=ordered_columns, fill_value=cast(object, pd.NA)
+    )
+
+    sort_columns = [
+        column
+        for column in ["assay_chembl_id", "molecule_chembl_id", "activity_chembl_id"]
+        if column in prepared.columns
+    ]
+    if sort_columns:
+        prepared = prepared.sort_values(sort_columns).reset_index(drop=True)
+
+    serialised = serialise_dataframe(prepared, list_format, inplace=True)
+
+    last_identifier: str | None = None
+    if "activity_chembl_id" in serialised.columns and not serialised.empty:
+        last_identifier = str(serialised["activity_chembl_id"].iloc[-1])
+
+    return serialised, ordered_columns, last_identifier
+
+
 def run_pipeline(
     args: argparse.Namespace, *, command_parts: Sequence[str] | None = None
 ) -> int:
@@ -176,9 +320,9 @@ def run_pipeline(
         errors_output=args.errors_output,
     )
 
-    csv_cfg = CsvConfig(
-        sep=args.sep, encoding=args.encoding, list_format=args.list_format
-    )
+    list_format = cast(ListFormat, args.list_format)
+
+    csv_cfg = CsvConfig(sep=args.sep, encoding=args.encoding, list_format=list_format)
 
     if args.dry_run:
         count = sum(
@@ -187,7 +331,43 @@ def run_pipeline(
         LOGGER.info("Dry run complete: %d unique identifiers would be processed", count)
         return 0
 
-    activity_ids = _limited_ids(input_path, args.column, csv_cfg, args.limit)
+    def id_loader() -> Iterable[str]:
+        return _limited_ids(input_path, args.column, csv_cfg, args.limit)
+
+    existing_metadata = _load_existing_metadata(meta_path)
+    progress_meta = existing_metadata.get("progress")
+    resume_id: str | None = None
+    ordered_columns: list[str] | None = None
+    if isinstance(progress_meta, Mapping):
+        raw_last = progress_meta.get("last_id")
+        if isinstance(raw_last, str) and raw_last:
+            resume_id = raw_last
+        column_order = progress_meta.get("column_order")
+        if isinstance(column_order, list) and all(
+            isinstance(item, str) for item in column_order
+        ):
+            ordered_columns = list(column_order)
+
+    total_rows = existing_metadata.get("rows")
+    if not isinstance(total_rows, int) or resume_id is None:
+        total_rows = 0
+
+    aggregated_errors = _load_existing_errors(errors_path)
+    last_identifier = resume_id
+
+    if resume_id is None:
+        aggregated_errors = []
+        if errors_path.exists():
+            errors_path.unlink()
+
+    if resume_id is None and output_path.exists():
+        LOGGER.info("Starting fresh run and replacing existing output %s", output_path)
+        output_path.unlink()
+
+    ensure_output_dir(output_path)
+    header_written = output_path.exists() and output_path.stat().st_size > 0
+    if header_written and resume_id is None:
+        header_written = False
 
     client = ChemblClient(
         base_url=args.base_url,
@@ -198,48 +378,108 @@ def run_pipeline(
         retry_penalty_seconds=args.retry_penalty,
     )
 
-    activities_df = get_activities(client, activity_ids, chunk_size=args.chunk_size)
-    if activities_df.empty:
+    identifier_stream = _skip_processed_ids(id_loader, resume_id)
+
+    for chunk in stream_activities(
+        client, identifier_stream, chunk_size=args.chunk_size
+    ):
+        serialised, ordered_columns, chunk_last = _prepare_activity_chunk(
+            chunk,
+            list_format=list_format,
+            errors_path=errors_path,
+            error_accumulator=aggregated_errors,
+            ordered_columns=ordered_columns,
+        )
+
+        if serialised.empty:
+            if chunk_last is not None:
+                last_identifier = chunk_last
+            continue
+
+        serialised.to_csv(
+            output_path,
+            mode="a",
+            header=not header_written,
+            index=False,
+            sep=args.sep,
+            encoding=args.encoding,
+        )
+        header_written = True
+        total_rows += int(len(serialised))
+        if chunk_last is not None:
+            last_identifier = chunk_last
+
+        column_count = len(ordered_columns) if ordered_columns is not None else 0
+        progress_payload = {
+            "progress": {
+                "last_id": last_identifier,
+                "column_order": ordered_columns or [],
+            }
+        }
+        write_cli_metadata(
+            output_path,
+            row_count=total_rows,
+            column_count=column_count,
+            namespace=args,
+            command_parts=command_parts,
+            meta_path=meta_path,
+            extra=progress_payload,
+        )
+
+    if not header_written:
         LOGGER.warning("No activity data retrieved; writing empty output")
-        activities_df = pd.DataFrame(columns=ActivitiesSchema.ordered_columns())
+        empty_frame = pd.DataFrame(columns=ActivitiesSchema.ordered_columns())
+        empty_frame.to_csv(
+            output_path,
+            index=False,
+            sep=args.sep,
+            encoding=args.encoding,
+        )
+        ordered_columns = list(empty_frame.columns)
+        column_count = len(ordered_columns)
+        progress_payload = {
+            "progress": {"last_id": last_identifier, "column_order": ordered_columns}
+        }
+        write_cli_metadata(
+            output_path,
+            row_count=0,
+            column_count=column_count,
+            namespace=args,
+            command_parts=command_parts,
+            meta_path=meta_path,
+            extra=progress_payload,
+        )
+    else:
+        column_count = len(ordered_columns) if ordered_columns is not None else 0
+        progress_payload = {
+            "progress": {
+                "last_id": last_identifier,
+                "column_order": ordered_columns or [],
+            }
+        }
+        write_cli_metadata(
+            output_path,
+            row_count=total_rows,
+            column_count=column_count,
+            namespace=args,
+            command_parts=command_parts,
+            meta_path=meta_path,
+            extra=progress_payload,
+        )
 
-    normalised = normalize_activities(activities_df)
-    validated = validate_activities(normalised, errors_path=errors_path)
+    if aggregated_errors:
+        errors_path.parent.mkdir(parents=True, exist_ok=True)
+        with errors_path.open("w", encoding="utf-8") as handle:
+            json.dump(aggregated_errors, handle, ensure_ascii=False, indent=2)
+    elif errors_path.exists():
+        errors_path.unlink()
 
-    schema_columns = [
-        column
-        for column in ActivitiesSchema.ordered_columns()
-        if column in validated.columns
-    ]
-    extra_columns = sorted(
-        [column for column in validated.columns if column not in schema_columns]
-    )
-    ordered_columns = schema_columns + extra_columns
-    if ordered_columns:
-        validated = validated[ordered_columns]
-
-    sort_columns = [
-        column
-        for column in ["assay_chembl_id", "molecule_chembl_id", "activity_chembl_id"]
-        if column in validated.columns
-    ]
-    if sort_columns:
-        validated = validated.sort_values(sort_columns).reset_index(drop=True)
-
-    serialised = serialise_dataframe(validated, args.list_format, inplace=True)
-    ensure_output_dir(output_path)
-    serialised.to_csv(output_path, index=False, sep=args.sep, encoding=args.encoding)
-
-    write_cli_metadata(
+    analyze_table_quality(
         output_path,
-        row_count=int(len(serialised)),
-        column_count=int(len(serialised.columns)),
-        namespace=args,
-        command_parts=command_parts,
-        meta_path=meta_path,
+        table_name=str(quality_base),
+        separator=args.sep,
+        encoding=args.encoding,
     )
-
-    analyze_table_quality(serialised, table_name=str(quality_base))
 
     LOGGER.info("Activity table written to %s", output_path)
     return 0

--- a/tests/test_chembl_activities_pipeline.py
+++ b/tests/test_chembl_activities_pipeline.py
@@ -105,6 +105,82 @@ def test_get_activities_batches_requests() -> None:
     assert calls == [["CHEMBL1", "CHEMBL2"], ["CHEMBL3"]]
 
 
+def test_activity_pipeline_resume_after_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = chembl_activities_module
+
+    input_path = tmp_path / "activities.csv"
+    output_path = tmp_path / "output.csv"
+
+    ids = [f"CHEMBL{i}" for i in range(1, 6)]
+    input_lines = "activity_chembl_id\n" + "\n".join(ids) + "\n"
+    input_path.write_text(input_lines, encoding="utf-8")
+
+    failures = [2, None]
+
+    class DummyClient:
+        def __init__(self, **_: object) -> None:
+            self._fail_after = failures.pop(0)
+            self._calls = 0
+
+        def fetch_many_activities(self, values: Iterable[str]) -> List[dict[str, str]]:
+            batch = list(values)
+            if self._fail_after is not None and self._calls >= self._fail_after:
+                raise RuntimeError("Simulated failure")
+            self._calls += 1
+            return [
+                {
+                    "activity_chembl_id": value,
+                    "assay_chembl_id": f"ASSAY-{value}",
+                }
+                for value in batch
+            ]
+
+    def fake_analyse(_table: object, *_: object, **__: object) -> None:
+        """Skip quality analysis during testing."""
+
+    monkeypatch.setattr(module, "ChemblClient", DummyClient)
+    monkeypatch.setattr(module, "analyze_table_quality", fake_analyse)
+
+    argv = [
+        "--input",
+        str(input_path),
+        "--output",
+        str(output_path),
+        "--chunk-size",
+        "2",
+        "--base-url",
+        "https://example.org/api",
+    ]
+    args = module.parse_args(argv)
+
+    with pytest.raises(RuntimeError):
+        module.run_pipeline(args, command_parts=["chembl_activities_main.py", *argv])
+
+    interim = pd.read_csv(output_path)
+    assert list(interim["activity_chembl_id"]) == ids[:4]
+    meta_path = output_path.with_name(f"{output_path.name}.meta.yaml")
+    meta_data = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+    assert meta_data["rows"] == 4
+    assert meta_data["progress"]["last_id"] == "CHEMBL4"
+
+    # Second run should resume and process the remaining identifier without duplicates.
+    args_resume = module.parse_args(argv)
+    exit_code = module.run_pipeline(
+        args_resume,
+        command_parts=["chembl_activities_main.py", *argv],
+    )
+    assert exit_code == 0
+
+    final = pd.read_csv(output_path)
+    assert list(final["activity_chembl_id"]) == ids
+    assert final["activity_chembl_id"].is_unique
+    meta_data_final = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+    assert meta_data_final["rows"] == 5
+    assert meta_data_final["progress"]["last_id"] == "CHEMBL5"
+
+
 @pytest.mark.parametrize("chunk_size", [0, -5])
 def test_parse_args_rejects_non_positive_chunk_sizes(chunk_size: int) -> None:
     with pytest.raises(SystemExit) as excinfo:


### PR DESCRIPTION
## Summary
- convert the shared ChEMBL fetch helper into a chunked generator and expose streaming helpers for CLI consumption
- stream the activities and assays CLIs so they append CSV chunks, persist progress metadata, and resume safely after failures
- extend metadata utilities to carry progress checkpoints and add regression coverage for resumable activity downloads

## Testing
- poetry run ruff check scripts/chembl_activities_main.py scripts/chembl_assays_main.py library/chembl_library.py library/cli_common.py library/metadata.py tests/test_chembl_activities_pipeline.py tests/scripts/test_chembl_assays_main.py
- poetry run mypy library/chembl_library.py library/cli_common.py library/metadata.py scripts/chembl_activities_main.py scripts/chembl_assays_main.py
- poetry run pytest tests/test_chembl_activities_pipeline.py tests/scripts/test_chembl_assays_main.py

------
https://chatgpt.com/codex/tasks/task_e_68ce08ecec98832481554fa803ded3c5