### PR TITLE
Fix validation property tests and numpy flattening

### DIFF
--- a/library/activity_validation.py
+++ b/library/activity_validation.py
@@ -1,180 +1,193 @@
-"""Validation utilities for normalised activity tables."""
+"""Vectorised validation utilities for normalised activity tables."""
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
-from typing import Any, Iterable, List, Mapping, Type
+from typing import Any, Iterable
 
-import numpy as np
 import pandas as pd
-from pandas.api.types import is_scalar
-from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
+
+from .validation_core import (
+    ValidationResult,
+    build_error_frame,
+    coerce_dataframe,
+    combine_error_frames,
+    serialise_errors,
+)
 
 LOGGER = logging.getLogger(__name__)
 
-
-class ActivitiesSchema(BaseModel):
-    """Pydantic model describing a validated activity record."""
-
-    model_config = ConfigDict(extra="allow")
-
-    activity_chembl_id: str
-    assay_chembl_id: str
-    molecule_chembl_id: str | None = None
-    parent_molecule_chembl_id: str | None = None
-    document_chembl_id: str | None = None
-    target_chembl_id: str | None = None
-    record_id: int | None = None
-    activity_id: int | None = None
-    standard_type: str | None = None
-    standard_relation: str | None = None
-    standard_units: str | None = None
-    standard_value: float | None = None
-    standard_upper_value: float | None = None
-    standard_lower_value: float | None = None
-    pchembl_value: float | None = None
-    potential_duplicate: bool | None = None
-    data_validity_comment: str | None = None
-    data_validity_warning: bool | None = None
-    activity_comment: str | None = None
-    type: str | None = None
-    relation: str | None = None
-    units: str | None = None
-
-    @field_validator("activity_chembl_id", "assay_chembl_id", mode="before")
-    @classmethod
-    def _ensure_non_empty(cls, value: Any) -> str:
-        if not value:
-            msg = "value must not be empty"
-            raise ValueError(msg)
-        return str(value)
-
-    @classmethod
-    def ordered_columns(cls) -> List[str]:
-        """Return the columns defined by the schema in declaration order."""
-
-        return list(cls.model_fields.keys())
+_REQUIRED_STR_COLUMNS = ("activity_chembl_id", "assay_chembl_id")
+_INT_COLUMNS = ("record_id", "activity_id")
+_FLOAT_COLUMNS = (
+    "standard_value",
+    "standard_upper_value",
+    "standard_lower_value",
+    "pchembl_value",
+)
 
 
-def _is_missing_scalar(value: Any) -> bool:
-    """Return ``True`` when ``value`` represents a missing scalar."""
+class ActivitiesSchema:
+    """Schema shim providing the legacy column ordering."""
 
-    try:
-        result = pd.isna(value)
-    except (TypeError, ValueError):
-        return False
-    if isinstance(result, (bool, np.bool_)):
-        return bool(result)
-    return False
+    @staticmethod
+    def ordered_columns() -> list[str]:
+        """Return the ordered column list from the historic schema."""
 
-
-def _coerce_value(value: Any) -> Any:
-    """Normalise ``value`` so it is JSON-serialisable and handles nulls."""
-
-    if value is None:
-        return None
-
-    if isinstance(value, np.ndarray):
-        dtype_kind = value.dtype.kind
-        if dtype_kind in {"O", "U", "S"}:
-            if value.size == 0:
-                return []
-            return [_coerce_value(item) for item in value.tolist()]
-        if value.size == 0:
-            return None
-        if value.size == 1:
-            return _coerce_value(value.item())
-        return [_coerce_value(item) for item in value.tolist()]
-
-    if isinstance(value, np.generic):
-        scalar_value = value.item()
-        return None if _is_missing_scalar(scalar_value) else scalar_value
-
-    if is_scalar(value):
-        return None if _is_missing_scalar(value) else value
-
-    return value
+        return [
+            "activity_chembl_id",
+            "assay_chembl_id",
+            "molecule_chembl_id",
+            "parent_molecule_chembl_id",
+            "document_chembl_id",
+            "target_chembl_id",
+            "record_id",
+            "activity_id",
+            "standard_type",
+            "standard_relation",
+            "standard_units",
+            "standard_value",
+            "standard_upper_value",
+            "standard_lower_value",
+            "pchembl_value",
+            "potential_duplicate",
+            "data_validity_comment",
+            "data_validity_warning",
+            "activity_comment",
+            "type",
+            "relation",
+            "units",
+        ]
 
 
-def _coerce_record(row: pd.Series) -> dict[str, Any]:
-    clean: dict[str, Any] = {}
-    for key, value in row.items():
-        clean[key] = _coerce_value(value)
-    return clean
+def _ensure_required_strings(df: pd.DataFrame) -> Iterable[pd.DataFrame]:
+    for column in _REQUIRED_STR_COLUMNS:
+        if column not in df.columns:
+            continue
+        original = df[column]
+        flattened = original.apply(
+            lambda value: (
+                value[0] if isinstance(value, list) and len(value) == 1 else value
+            )
+        )
+
+        def _is_falsey(value: Any) -> bool:
+            if pd.isna(value):
+                return True
+            try:
+                return not bool(value)
+            except TypeError:
+                return False
+
+        mask = flattened.apply(_is_falsey)
+        series = flattened.astype("string")
+        df[column] = series.mask(mask, other=pd.NA)
+        yield build_error_frame(
+            original,
+            mask.fillna(False),
+            column=column,
+            message="value must not be empty",
+        )
 
 
-def validate_activities(
-    df: pd.DataFrame,
-    schema: Type[ActivitiesSchema] = ActivitiesSchema,
-    *,
-    errors_path: Path,
-) -> pd.DataFrame:
-    """Validates rows in a DataFrame against the given schema and writes failures to a file.
+def _coerce_optional_int(df: pd.DataFrame, column: str) -> Iterable[pd.DataFrame]:
+    if column not in df.columns:
+        return []
+    original = df[column]
+    numeric = pd.to_numeric(original, errors="coerce")
+    mask_invalid = original.notna() & numeric.isna()
+    result = pd.Series(pd.NA, index=df.index, dtype="Int64")
+    valid_numeric = numeric.dropna()
+    if not valid_numeric.empty:
+        result.loc[valid_numeric.index] = valid_numeric.astype(int)
+    df[column] = result
+    return [
+        build_error_frame(
+            original,
+            mask_invalid.fillna(False),
+            column=column,
+            message="value must be an integer",
+        )
+    ]
 
-    Args:
-        df: The pandas DataFrame to validate.
-        schema: The Pydantic schema to validate against.
-        errors_path: The path to the file where validation errors will be written.
 
-    Returns:
-        A new DataFrame containing only the valid rows.
+def _coerce_optional_float(df: pd.DataFrame, column: str) -> Iterable[pd.DataFrame]:
+    if column not in df.columns:
+        return []
+    original = df[column]
+    numeric = pd.to_numeric(original, errors="coerce")
+    mask_invalid = original.notna() & numeric.isna()
+    df[column] = numeric.astype("Float64")
+    return [
+        build_error_frame(
+            original,
+            mask_invalid.fillna(False),
+            column=column,
+            message="value must be numeric",
+        )
+    ]
+
+
+def validate_activities(df: pd.DataFrame, *, errors_path: Path) -> ValidationResult:
+    """Validate the activity table and emit aggregated diagnostics.
+
+    Parameters
+    ----------
+    df:
+        Normalised activity DataFrame.
+    errors_path:
+        Output path for the JSON error report.
+
+    Returns
+    -------
+    ValidationResult
+        Container with validated rows and the aggregated error DataFrame.
     """
 
     if df.empty:
         LOGGER.info("Validation skipped because the DataFrame is empty")
-        return df
+        empty_errors = combine_error_frames([])
+        return ValidationResult(valid=df.copy(), errors=empty_errors)
 
-    required_fields = [
-        name
-        for name, field in schema.model_fields.items()
-        if field.is_required()  # type: ignore[attr-defined]
-    ]
-    missing_required = [field for field in required_fields if field not in df.columns]
+    missing_required = sorted(set(_REQUIRED_STR_COLUMNS) - set(df.columns))
     if missing_required:
         LOGGER.warning(
-            "Input data is missing required columns: %s",
-            ", ".join(sorted(missing_required)),
+            "Input data is missing required columns: %s", ", ".join(missing_required)
         )
 
-    valid_rows: List[dict[str, Any]] = []
-    errors: List[dict[str, Any]] = []
-
-    def _normalise_error_details(
-        details: Iterable[Mapping[str, Any]],
-    ) -> list[dict[str, Any]]:
-        normalised: list[dict[str, Any]] = []
-        for entry in details:
-            clean_entry = dict(entry)
-            ctx = clean_entry.get("ctx")
-            if isinstance(ctx, dict):
-                clean_entry["ctx"] = {key: str(value) for key, value in ctx.items()}
-            normalised.append(clean_entry)
-        return normalised
-
-    for index, row in df.iterrows():
-        payload = _coerce_record(row)
-        try:
-            record = schema(**payload)
-        except ValidationError as exc:
-            LOGGER.warning("Validation error for row %s: %s", index, exc)
-            errors.append(
-                {
-                    "index": int(index),
-                    "errors": _normalise_error_details(exc.errors()),
-                    "row": payload,
-                }
+    coerced = coerce_dataframe(df)
+    error_frames: list[pd.DataFrame] = []
+    if missing_required:
+        missing_mask = pd.Series(True, index=coerced.index)
+        for column in missing_required:
+            placeholder = pd.Series(pd.NA, index=coerced.index)
+            error_frames.append(
+                build_error_frame(
+                    placeholder,
+                    missing_mask,
+                    column=column,
+                    message="column is required",
+                    error_type="missing_error",
+                )
             )
-            continue
-        valid_rows.append(record.model_dump())
+    error_frames.extend(_ensure_required_strings(coerced))
+    for column in _INT_COLUMNS:
+        error_frames.extend(_coerce_optional_int(coerced, column))
+    for column in _FLOAT_COLUMNS:
+        error_frames.extend(_coerce_optional_float(coerced, column))
 
-    if errors:
-        errors_path.parent.mkdir(parents=True, exist_ok=True)
-        with errors_path.open("w", encoding="utf-8") as handle:
-            json.dump(errors, handle, ensure_ascii=False, indent=2)
-        LOGGER.info("Validation produced %d error records", len(errors))
-    elif errors_path.exists():
-        errors_path.unlink()
+    errors = combine_error_frames(error_frames)
+    serialise_errors(errors, coerced, errors_path=errors_path)
 
-    return pd.DataFrame(valid_rows)
+    if errors.empty:
+        valid = coerced.reset_index(drop=True)
+    else:
+        invalid_indices = pd.Index(errors["index"].unique())
+        mask_valid = ~coerced.index.isin(invalid_indices)
+        valid = coerced.loc[mask_valid].reset_index(drop=True)
+
+    return ValidationResult(valid=valid, errors=errors)
+
+
+__all__ = ["validate_activities", "ValidationResult", "ActivitiesSchema"]

--- a/library/legacy_validation.py
+++ b/library/legacy_validation.py
@@ -1,0 +1,425 @@
+"""Legacy Pydantic-based validators for benchmarking and regression tests."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Iterable, List, Mapping, Type
+
+import numpy as np
+import pandas as pd
+from pandas.api.types import is_scalar
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
+
+LOGGER = logging.getLogger(__name__)
+
+
+class LegacyActivitiesSchema(BaseModel):
+    """Historical schema describing a validated activity record."""
+
+    model_config = ConfigDict(extra="allow")
+
+    activity_chembl_id: str
+    assay_chembl_id: str
+    molecule_chembl_id: str | None = None
+    parent_molecule_chembl_id: str | None = None
+    document_chembl_id: str | None = None
+    target_chembl_id: str | None = None
+    record_id: int | None = None
+    activity_id: int | None = None
+    standard_type: str | None = None
+    standard_relation: str | None = None
+    standard_units: str | None = None
+    standard_value: float | None = None
+    standard_upper_value: float | None = None
+    standard_lower_value: float | None = None
+    pchembl_value: float | None = None
+    potential_duplicate: bool | None = None
+    data_validity_comment: str | None = None
+    data_validity_warning: bool | None = None
+    activity_comment: str | None = None
+    type: str | None = None
+    relation: str | None = None
+    units: str | None = None
+
+    @field_validator("activity_chembl_id", "assay_chembl_id", mode="before")
+    @classmethod
+    def _ensure_non_empty(cls, value: Any) -> str:
+        if not value:
+            msg = "value must not be empty"
+            raise ValueError(msg)
+        return str(value)
+
+    @classmethod
+    def ordered_columns(cls) -> List[str]:
+        """Return the columns defined by the schema in declaration order."""
+
+        return list(cls.model_fields.keys())
+
+
+class LegacyAssaysSchema(BaseModel):
+    """Historical schema describing a validated assay record."""
+
+    model_config = ConfigDict(extra="allow")
+
+    assay_chembl_id: str
+    document_chembl_id: str
+    target_chembl_id: str | None = None
+    assay_category: str | None = None
+    assay_group: str | None = None
+    assay_type: str | None = None
+    assay_type_description: str | None = None
+    assay_organism: str | None = None
+    assay_test_type: str | None = None
+    assay_cell_type: str | None = None
+    assay_tissue: str | None = None
+    assay_tax_id: str | None = None
+    assay_with_same_target: int
+    confidence_score: int | None = None
+    confidence_description: str | None = None
+    relationship_type: str | None = None
+    relationship_description: str | None = None
+    bao_format: str | None = None
+    bao_label: str | None = None
+
+    @field_validator("assay_chembl_id", mode="before")
+    @classmethod
+    def _ensure_non_empty(cls, value: Any) -> str:
+        if not value:
+            raise ValueError("assay_chembl_id must not be empty")
+        return str(value)
+
+    @field_validator("assay_with_same_target", mode="before")
+    @classmethod
+    def _ensure_positive(cls, value: Any) -> int:
+        if value is None:
+            raise ValueError("assay_with_same_target is required")
+        int_value = int(value)
+        if int_value < 0:
+            raise ValueError("assay_with_same_target must be non-negative")
+        return int_value
+
+    @classmethod
+    def ordered_columns(cls) -> List[str]:
+        """Return the columns defined by the schema in declaration order."""
+
+        return list(cls.model_fields.keys())
+
+
+class LegacyTestitemsSchema(BaseModel):
+    """Historical schema describing a validated molecule record."""
+
+    model_config = ConfigDict(extra="allow")
+
+    molecule_chembl_id: str
+    canonical_smiles: str
+    standard_inchi_key: str
+    pref_name: str | None = None
+    molecule_type: str | None = None
+    structure_type: str | None = None
+    salt_chembl_id: str | None = None
+    parent_chembl_id: str | None = None
+    max_phase: int | None = None
+    chembl_full_mwt: float | None = None
+    chembl_alogp: float | None = None
+    chembl_num_ro5_violations: int | None = None
+    chembl_molecular_species: str | None = None
+    pubchem_cid: int | None = None
+    pubchem_molecular_formula: str | None = None
+    pubchem_molecular_weight: float | None = None
+    pubchem_tpsa: float | None = None
+    pubchem_x_log_p: float | None = None
+    pubchem_h_bond_donor_count: int | None = None
+    pubchem_h_bond_acceptor_count: int | None = None
+    pubchem_rotatable_bond_count: int | None = None
+
+    @field_validator(
+        "molecule_chembl_id", "canonical_smiles", "standard_inchi_key", mode="before"
+    )
+    @classmethod
+    def _ensure_non_empty(cls, value: Any) -> str:
+        if value is None:
+            raise ValueError("value must not be empty")
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                raise ValueError("value must not be empty")
+            return stripped
+        return str(value)
+
+    @field_validator("max_phase", mode="before")
+    @classmethod
+    def _coerce_phase(cls, value: Any) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            try:
+                int_value = int(float(stripped))
+            except ValueError as exc:
+                raise ValueError("max_phase must be an integer") from exc
+            return int_value
+        try:
+            int_value = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("max_phase must be an integer") from exc
+        if int_value < 0:
+            raise ValueError("max_phase must be non-negative")
+        return int_value
+
+    @field_validator(
+        "chembl_full_mwt",
+        "chembl_alogp",
+        "chembl_num_ro5_violations",
+        "pubchem_cid",
+        "pubchem_molecular_weight",
+        "pubchem_tpsa",
+        "pubchem_x_log_p",
+        "pubchem_h_bond_donor_count",
+        "pubchem_h_bond_acceptor_count",
+        "pubchem_rotatable_bond_count",
+        mode="before",
+    )
+    @classmethod
+    def _coerce_numeric(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            if isinstance(value, float) and np.isnan(value):
+                return None
+            return value
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            try:
+                if any(char in stripped for char in [".", "e", "E"]):
+                    return float(stripped)
+                return int(stripped)
+            except ValueError:
+                return stripped
+        return value
+
+    @classmethod
+    def ordered_columns(cls) -> list[str]:
+        """Return the columns defined by the schema in declaration order."""
+
+        return list(cls.model_fields.keys())
+
+
+def _is_missing_scalar(value: Any) -> bool:
+    try:
+        result = pd.isna(value)
+    except (TypeError, ValueError):
+        return False
+    if isinstance(result, (bool, np.bool_)):
+        return bool(result)
+    return False
+
+
+def _coerce_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, np.ndarray):
+        dtype_kind = value.dtype.kind
+        if dtype_kind in {"O", "U", "S"}:
+            if value.size == 0:
+                return []
+            return [_coerce_value(item) for item in value.tolist()]
+        if value.size == 0:
+            return None
+        if value.size == 1:
+            return _coerce_value(value.item())
+        return [_coerce_value(item) for item in value.tolist()]
+    if isinstance(value, np.generic):
+        scalar_value = value.item()
+        return None if _is_missing_scalar(scalar_value) else scalar_value
+    if is_scalar(value):
+        return None if _is_missing_scalar(value) else value
+    return value
+
+
+def _coerce_record(row: pd.Series) -> dict[str, Any]:
+    clean: dict[str, Any] = {}
+    for key, value in row.items():
+        clean[key] = _coerce_value(value)
+    return clean
+
+
+def legacy_validate_activities(
+    df: pd.DataFrame,
+    schema: Type[LegacyActivitiesSchema] = LegacyActivitiesSchema,
+    *,
+    errors_path: Path,
+) -> pd.DataFrame:
+    if df.empty:
+        LOGGER.info("Validation skipped because the DataFrame is empty")
+        return df
+
+    required_fields = [
+        name for name, field in schema.model_fields.items() if field.is_required()
+    ]
+    missing_required = [field for field in required_fields if field not in df.columns]
+    if missing_required:
+        LOGGER.warning(
+            "Input data is missing required columns: %s",
+            ", ".join(sorted(missing_required)),
+        )
+
+    valid_rows: List[dict[str, Any]] = []
+    errors: List[dict[str, Any]] = []
+
+    def _normalise_error_details(
+        details: Iterable[Mapping[str, Any]],
+    ) -> list[dict[str, Any]]:
+        normalised: list[dict[str, Any]] = []
+        for entry in details:
+            clean_entry = dict(entry)
+            ctx = clean_entry.get("ctx")
+            if isinstance(ctx, dict):
+                clean_entry["ctx"] = {key: str(value) for key, value in ctx.items()}
+            normalised.append(clean_entry)
+        return normalised
+
+    for index, row in df.iterrows():
+        payload = _coerce_record(row)
+        try:
+            record = schema(**payload)
+        except ValidationError as exc:
+            LOGGER.warning("Validation error for row %s: %s", index, exc)
+            errors.append(
+                {
+                    "index": int(index),
+                    "errors": _normalise_error_details(exc.errors()),
+                    "row": payload,
+                }
+            )
+            continue
+        valid_rows.append(record.model_dump())
+
+    if errors:
+        errors_path.parent.mkdir(parents=True, exist_ok=True)
+        with errors_path.open("w", encoding="utf-8") as handle:
+            json.dump(errors, handle, ensure_ascii=False, indent=2)
+        LOGGER.info("Validation produced %d error records", len(errors))
+    elif errors_path.exists():
+        errors_path.unlink()
+
+    return pd.DataFrame(valid_rows)
+
+
+def legacy_validate_assays(
+    df: pd.DataFrame,
+    schema: Type[LegacyAssaysSchema] = LegacyAssaysSchema,
+    *,
+    errors_path: Path,
+) -> pd.DataFrame:
+    if df.empty:
+        LOGGER.info("Validation skipped because the DataFrame is empty")
+        return df
+
+    valid_rows: List[dict[str, Any]] = []
+    errors: List[dict[str, Any]] = []
+
+    def _normalise_error_details(
+        details: Iterable[Mapping[str, Any]],
+    ) -> list[dict[str, Any]]:
+        normalised: list[dict[str, Any]] = []
+        for entry in details:
+            clean_entry = dict(entry)
+            ctx = clean_entry.get("ctx")
+            if isinstance(ctx, dict):
+                clean_entry["ctx"] = {key: str(value) for key, value in ctx.items()}
+            normalised.append(clean_entry)
+        return normalised
+
+    for index, row in df.iterrows():
+        payload = _coerce_record(row)
+        try:
+            record = schema(**payload)
+        except ValidationError as exc:
+            LOGGER.warning("Validation error for row %s: %s", index, exc)
+            errors.append(
+                {
+                    "index": int(index),
+                    "errors": _normalise_error_details(exc.errors()),
+                    "row": payload,
+                }
+            )
+            continue
+        valid_rows.append(record.model_dump())
+
+    if errors:
+        errors_path.parent.mkdir(parents=True, exist_ok=True)
+        with errors_path.open("w", encoding="utf-8") as handle:
+            json.dump(errors, handle, ensure_ascii=False, indent=2)
+        LOGGER.info("Validation produced %d error records", len(errors))
+    elif errors_path.exists():
+        errors_path.unlink()
+
+    return pd.DataFrame(valid_rows)
+
+
+def legacy_validate_testitems(
+    df: pd.DataFrame,
+    schema: type[LegacyTestitemsSchema] = LegacyTestitemsSchema,
+    *,
+    errors_path: Path,
+) -> pd.DataFrame:
+    if df.empty:
+        LOGGER.info("Validation skipped because the DataFrame is empty")
+        return df
+
+    valid_rows: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+
+    def _normalise_error_details(
+        details: Iterable[Mapping[str, Any]],
+    ) -> list[dict[str, Any]]:
+        normalised: list[dict[str, Any]] = []
+        for entry in details:
+            clean_entry = dict(entry)
+            ctx = clean_entry.get("ctx")
+            if isinstance(ctx, dict):
+                clean_entry["ctx"] = {key: str(value) for key, value in ctx.items()}
+            normalised.append(clean_entry)
+        return normalised
+
+    for index, row in df.iterrows():
+        payload = _coerce_record(row)
+        try:
+            record = schema(**payload)
+        except ValidationError as exc:
+            LOGGER.warning("Validation error for row %s: %s", index, exc)
+            errors.append(
+                {
+                    "index": int(index),
+                    "errors": _normalise_error_details(exc.errors()),
+                    "row": payload,
+                }
+            )
+            continue
+        valid_rows.append(record.model_dump())
+
+    if errors:
+        errors_path.parent.mkdir(parents=True, exist_ok=True)
+        with errors_path.open("w", encoding="utf-8") as handle:
+            json.dump(errors, handle, ensure_ascii=False, indent=2)
+        LOGGER.info("Validation produced %d error records", len(errors))
+    elif errors_path.exists():
+        errors_path.unlink()
+
+    return pd.DataFrame(valid_rows)
+
+
+__all__ = [
+    "LegacyActivitiesSchema",
+    "LegacyAssaysSchema",
+    "LegacyTestitemsSchema",
+    "legacy_validate_activities",
+    "legacy_validate_assays",
+    "legacy_validate_testitems",
+]

--- a/library/validation_core.py
+++ b/library/validation_core.py
@@ -1,0 +1,190 @@
+"""Shared utilities for tabular validation routines."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+import pandas as pd
+from pandas.api.types import is_scalar
+
+LOGGER = logging.getLogger(__name__)
+
+ERROR_URL = "https://pandera.readthedocs.io/en/stable/error_handling.html"
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Container for validation results.
+
+    Attributes
+    ----------
+    valid:
+        DataFrame containing rows that passed validation.
+    errors:
+        Aggregated error report with one row per failure.
+    """
+
+    valid: pd.DataFrame
+    errors: pd.DataFrame
+
+
+def _is_missing_scalar(value: Any) -> bool:
+    """Return ``True`` when ``value`` is recognised as a missing scalar."""
+
+    try:
+        result = pd.isna(value)
+    except (TypeError, ValueError):
+        return False
+    if isinstance(result, (bool, np.bool_)):
+        return bool(result)
+    return False
+
+
+def coerce_value(value: Any) -> Any:
+    """Normalise ``value`` so it is JSON serialisable and handles nulls."""
+
+    if value is None:
+        return None
+    if isinstance(value, np.ndarray):
+        dtype_kind = value.dtype.kind
+        if dtype_kind in {"O", "U", "S"}:
+            if value.size == 0:
+                return []
+            converted = [coerce_value(item) for item in value.tolist()]
+            if len(converted) == 1:
+                single = converted[0]
+                if isinstance(single, dict):
+                    return converted
+                return single
+            return converted
+        if value.size == 0:
+            return None
+        if value.size == 1:
+            return coerce_value(value.item())
+        return [coerce_value(item) for item in value.tolist()]
+    if isinstance(value, np.generic):
+        scalar_value = value.item()
+        return None if _is_missing_scalar(scalar_value) else scalar_value
+    if is_scalar(value):
+        return None if _is_missing_scalar(value) else value
+    return value
+
+
+def coerce_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a DataFrame with values coerced via :func:`coerce_value`."""
+
+    if df.empty:
+        return df.copy()
+    return df.applymap(coerce_value)
+
+
+def build_error_frame(
+    source: pd.Series,
+    mask: pd.Series,
+    *,
+    column: str,
+    message: str,
+    error_type: str = "value_error",
+) -> pd.DataFrame:
+    """Construct a standard error report slice for a column.
+
+    Parameters
+    ----------
+    source:
+        Series containing the original values to report.
+    mask:
+        Boolean mask identifying failing rows.
+    column:
+        Column name that triggered the error.
+    message:
+        Human readable message describing the failure.
+    error_type:
+        Short error classification identifier.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns ``index``, ``column``, ``message``, ``value`` and
+        ``error_type``. Empty when ``mask`` selects no rows.
+    """
+
+    failing = source.loc[mask]
+    if failing.empty:
+        return pd.DataFrame(
+            columns=["index", "column", "message", "value", "error_type"]
+        )
+    frame = (
+        failing.to_frame(name="value")
+        .reset_index(names="index")
+        .assign(column=column, message=message, error_type=error_type)
+    )
+    return frame[["index", "column", "message", "value", "error_type"]]
+
+
+def combine_error_frames(frames: Iterable[pd.DataFrame]) -> pd.DataFrame:
+    """Combine error frames ensuring canonical ordering."""
+
+    materialised = [frame for frame in frames if not frame.empty]
+    if not materialised:
+        return pd.DataFrame(
+            columns=["index", "column", "message", "value", "error_type"]
+        )
+    combined = pd.concat(materialised, ignore_index=True)
+    combined = combined.sort_values(["index", "column", "message"]).reset_index(
+        drop=True
+    )
+    return combined
+
+
+def serialise_errors(
+    errors: pd.DataFrame,
+    data: pd.DataFrame,
+    *,
+    errors_path: Path,
+    error_url: str = ERROR_URL,
+) -> None:
+    """Write the aggregated error report to disk using the legacy JSON layout."""
+
+    if errors.empty:
+        if errors_path.exists():
+            errors_path.unlink()
+        return
+
+    payload: list[dict[str, Any]] = []
+    for index, group in errors.groupby("index", sort=True):
+        row = data.loc[index]
+        row_payload = {column: coerce_value(value) for column, value in row.items()}
+        error_entries = [
+            {
+                "type": str(item["error_type"]),
+                "loc": [str(item["column"])],
+                "msg": str(item["message"]),
+                "input": coerce_value(item["value"]),
+                "ctx": {"error": str(item["message"])},
+                "url": error_url,
+            }
+            for item in group.to_dict("records")
+        ]
+        payload.append(
+            {"index": int(index), "errors": error_entries, "row": row_payload}
+        )
+
+    errors_path.parent.mkdir(parents=True, exist_ok=True)
+    with errors_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+    LOGGER.info("Validation produced %d error records", len(payload))
+
+
+__all__ = [
+    "ValidationResult",
+    "build_error_frame",
+    "coerce_dataframe",
+    "coerce_value",
+    "combine_error_frames",
+    "serialise_errors",
+]

--- a/scripts/validation_benchmark_main.py
+++ b/scripts/validation_benchmark_main.py
@@ -1,0 +1,234 @@
+"""Command-line benchmark comparing vectorised and legacy validators."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Callable
+
+import numpy as np
+import pandas as pd
+
+from library import legacy_validation
+from library.activity_validation import validate_activities
+from library.assay_validation import validate_assays
+from library.testitem_validation import validate_testitems
+
+LOGGER = logging.getLogger(__name__)
+
+DatasetRunner = Callable[[pd.DataFrame, Path], Any]
+
+
+def _default_output_path(dataset: str) -> Path:
+    timestamp = datetime.now().strftime("%Y%m%d")
+    return Path(f"output_{dataset}_benchmark_{timestamp}.json")
+
+
+def _prepare_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper()), format="%(levelname)s: %(message)s"
+    )
+
+
+def _generate_sample(dataset: str, rows: int) -> pd.DataFrame:
+    rng = np.random.default_rng(42)
+    if dataset == "testitems":
+        data = {
+            "molecule_chembl_id": [f"CHEMBL{index}" for index in range(rows)],
+            "canonical_smiles": ["C" * ((index % 3) + 1) for index in range(rows)],
+            "standard_inchi_key": [f"KEY{index}" for index in range(rows)],
+            "max_phase": rng.integers(-1, 5, size=rows),
+            "chembl_full_mwt": rng.uniform(0, 500, size=rows),
+        }
+    elif dataset == "assays":
+        data = {
+            "assay_chembl_id": [f"ASSAY{index}" for index in range(rows)],
+            "document_chembl_id": [f"DOC{index}" for index in range(rows)],
+            "assay_with_same_target": rng.integers(-1, 5, size=rows),
+            "confidence_score": rng.integers(-1, 5, size=rows),
+        }
+    else:
+        data = {
+            "activity_chembl_id": [f"ACT{index}" for index in range(rows)],
+            "assay_chembl_id": [f"ASSAY{index}" for index in range(rows)],
+            "record_id": rng.integers(-5, 5, size=rows),
+            "activity_id": rng.integers(-5, 5, size=rows),
+            "standard_value": rng.uniform(-2, 2, size=rows),
+        }
+    return pd.DataFrame(data)
+
+
+def _load_dataset(path: Path) -> pd.DataFrame:
+    LOGGER.info("Loading dataset from %s", path)
+    return pd.read_csv(path)
+
+
+def _benchmark_runner(
+    df: pd.DataFrame,
+    *,
+    dataset: str,
+    runs: int,
+    tmpdir: Path,
+) -> dict[str, float]:
+    timings: dict[str, list[float]] = {"vectorised": [], "legacy": []}
+
+    if dataset == "testitems":
+
+        def vectorised_runner(frame: pd.DataFrame, errors: Path) -> Any:
+            return validate_testitems(frame, errors_path=errors)
+
+        def legacy_runner(frame: pd.DataFrame, errors: Path) -> pd.DataFrame:
+            return legacy_validation.legacy_validate_testitems(
+                frame, errors_path=errors
+            )
+
+    elif dataset == "assays":
+
+        def vectorised_runner(frame: pd.DataFrame, errors: Path) -> Any:
+            return validate_assays(frame, errors_path=errors)
+
+        def legacy_runner(frame: pd.DataFrame, errors: Path) -> pd.DataFrame:
+            return legacy_validation.legacy_validate_assays(frame, errors_path=errors)
+
+    else:
+
+        def vectorised_runner(frame: pd.DataFrame, errors: Path) -> Any:
+            return validate_activities(frame, errors_path=errors)
+
+        def legacy_runner(frame: pd.DataFrame, errors: Path) -> pd.DataFrame:
+            return legacy_validation.legacy_validate_activities(
+                frame, errors_path=errors
+            )
+
+    for label, runner in ("vectorised", vectorised_runner), ("legacy", legacy_runner):
+        for iteration in range(runs):
+            errors_path = tmpdir / f"{label}_{iteration}.json"
+            frame = df.copy(deep=True)
+            start = perf_counter()
+            result = runner(frame, errors_path)
+            elapsed = perf_counter() - start
+            timings[label].append(elapsed)
+            if label == "vectorised":
+                # Ensure side effects match expectations during benchmarking.
+                _ = getattr(result, "valid", result)
+            if errors_path.exists():
+                errors_path.unlink()
+
+    return {
+        "vectorised_mean": (
+            float(np.mean(timings["vectorised"])) if timings["vectorised"] else 0.0
+        ),
+        "legacy_mean": float(np.mean(timings["legacy"])) if timings["legacy"] else 0.0,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark validation implementations")
+    parser.add_argument(
+        "--dataset",
+        choices=("testitems", "assays", "activities"),
+        default="testitems",
+        help="Target dataset to benchmark",
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=None,
+        help="Optional CSV input file. When omitted, synthetic data is generated.",
+    )
+    parser.add_argument(
+        "--rows",
+        type=int,
+        default=1000,
+        help="Number of synthetic rows to generate when --input is not provided.",
+    )
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=5,
+        help="Number of repetitions per implementation.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional JSON path for persisting benchmark results.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
+        help="Logging verbosity level.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    _prepare_logging(args.log_level)
+
+    if args.input is not None and not args.input.exists():
+        LOGGER.error("Input file not found: %s", args.input)
+        return 1
+
+    if args.rows <= 0:
+        LOGGER.error("--rows must be positive; received %s", args.rows)
+        return 1
+
+    if args.runs <= 0:
+        LOGGER.error("--runs must be positive; received %s", args.runs)
+        return 1
+
+    dataset = (
+        _load_dataset(args.input)
+        if args.input is not None
+        else _generate_sample(args.dataset, args.rows)
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        tmpdir = Path(tmpdir_name)
+        timings = _benchmark_runner(
+            dataset,
+            dataset=args.dataset,
+            runs=args.runs,
+            tmpdir=tmpdir,
+        )
+
+    speedup = (
+        timings["legacy_mean"] / timings["vectorised_mean"]
+        if timings["vectorised_mean"] > 0
+        else float("nan")
+    )
+    summary = {
+        "dataset": args.dataset,
+        "rows": int(len(dataset)),
+        "columns": int(len(dataset.columns)),
+        "runs": args.runs,
+        "vectorised_mean": timings["vectorised_mean"],
+        "legacy_mean": timings["legacy_mean"],
+        "speedup": speedup,
+    }
+
+    LOGGER.info(
+        "Vectorised mean %.6fs vs legacy %.6fs (speedup %.2fx)",
+        summary["vectorised_mean"],
+        summary["legacy_mean"],
+        summary["speedup"],
+    )
+
+    output_path = args.output or _default_output_path(args.dataset)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    LOGGER.info("Benchmark results written to %s", output_path)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_validation_property.py
+++ b/tests/test_validation_property.py
@@ -1,0 +1,242 @@
+"""Property-based tests comparing vectorised validators to legacy Pydantic models."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+import pandas as pd
+from hypothesis import HealthCheck, given, settings, strategies as st
+
+from library import legacy_validation
+from library.activity_validation import ActivitiesSchema, validate_activities
+from library.assay_validation import AssaysSchema, validate_assays
+from library.testitem_validation import TestitemsSchema, validate_testitems
+from library.validation_core import coerce_value
+
+
+def _row_strategy(
+    columns: Iterable[str], value_strategies: dict[str, st.SearchStrategy[Any]]
+) -> st.SearchStrategy[dict[str, Any]]:
+    column_list = list(columns)
+    flag_strategy = st.lists(
+        st.booleans(), min_size=len(column_list), max_size=len(column_list)
+    )
+    value_tuple = st.tuples(*(value_strategies[name] for name in column_list))
+
+    def _build_row(flags: list[bool], values: tuple[Any, ...]) -> dict[str, Any]:
+        return {
+            name: values[index]
+            for index, (name, include) in enumerate(
+                zip(column_list, flags, strict=False)
+            )
+            if include
+        }
+
+    return st.builds(_build_row, flag_strategy, value_tuple)
+
+
+def _dataframe_strategy(
+    columns: Iterable[str], value_strategies: dict[str, st.SearchStrategy[Any]]
+) -> st.SearchStrategy[pd.DataFrame]:
+    row_strategy = _row_strategy(columns, value_strategies)
+    return st.lists(row_strategy, min_size=0, max_size=5).map(pd.DataFrame)
+
+
+def _ordered_view(df: pd.DataFrame, ordered_columns: list[str]) -> pd.DataFrame:
+    known = [column for column in ordered_columns if column in df.columns]
+    extras = sorted(column for column in df.columns if column not in known)
+    if not known and not extras:
+        return df.copy().reset_index(drop=True)
+    return df.reindex(columns=ordered_columns + extras).reset_index(drop=True)
+
+
+def _legacy_error_indices(path: Path) -> set[int]:
+    if not path.exists():
+        return set()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return {int(entry["index"]) for entry in payload}
+
+
+def _new_error_indices(errors: pd.DataFrame) -> set[int]:
+    if errors.empty:
+        return set()
+    return {int(index) for index in errors["index"].tolist()}
+
+
+def _canonicalise_frame(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return pd.DataFrame()
+    return df.apply(lambda column: column.map(coerce_value))
+
+
+_testitems_columns = [
+    "molecule_chembl_id",
+    "canonical_smiles",
+    "standard_inchi_key",
+    "max_phase",
+    "chembl_full_mwt",
+    "pubchem_cid",
+]
+_testitems_value_strategies = {
+    "molecule_chembl_id": st.one_of(
+        st.none(), st.text(min_size=0, max_size=5), st.integers(-5, 5)
+    ),
+    "canonical_smiles": st.one_of(st.none(), st.text(min_size=0, max_size=5)),
+    "standard_inchi_key": st.one_of(st.none(), st.text(min_size=0, max_size=5)),
+    "max_phase": st.one_of(
+        st.none(),
+        st.integers(-3, 5),
+        st.floats(min_value=-3, max_value=5, allow_nan=False, allow_infinity=False),
+        st.just(float("nan")),
+        st.text(min_size=0, max_size=5),
+    ),
+    "chembl_full_mwt": st.one_of(
+        st.none(),
+        st.floats(
+            min_value=-10.0, max_value=10.0, allow_nan=False, allow_infinity=False
+        ),
+        st.just(float("nan")),
+        st.text(min_size=0, max_size=5),
+    ),
+    "pubchem_cid": st.one_of(
+        st.none(),
+        st.integers(-10, 10),
+        st.floats(min_value=-10, max_value=10, allow_nan=False, allow_infinity=False),
+        st.just(float("nan")),
+        st.text(min_size=0, max_size=5),
+    ),
+}
+
+_assay_columns = [
+    "assay_chembl_id",
+    "document_chembl_id",
+    "assay_with_same_target",
+    "confidence_score",
+]
+_assay_value_strategies = {
+    "assay_chembl_id": st.one_of(st.none(), st.text(min_size=0, max_size=5)),
+    "document_chembl_id": st.one_of(st.none(), st.text(min_size=0, max_size=5)),
+    "assay_with_same_target": st.one_of(
+        st.none(),
+        st.integers(-2, 5),
+        st.floats(min_value=-2, max_value=5, allow_nan=False, allow_infinity=False),
+        st.just(float("nan")),
+        st.text(min_size=0, max_size=5),
+    ),
+    "confidence_score": st.one_of(
+        st.none(),
+        st.integers(-2, 5),
+        st.floats(min_value=-2, max_value=5, allow_nan=False, allow_infinity=False),
+        st.just(float("nan")),
+        st.text(min_size=0, max_size=5),
+    ),
+}
+
+_activity_columns = [
+    "activity_chembl_id",
+    "assay_chembl_id",
+    "record_id",
+    "activity_id",
+    "standard_value",
+]
+_activity_value_strategies = {
+    "activity_chembl_id": st.one_of(st.none(), st.text(min_size=0, max_size=5)),
+    "assay_chembl_id": st.one_of(st.none(), st.text(min_size=0, max_size=5)),
+    "record_id": st.one_of(
+        st.none(),
+        st.integers(-5, 5),
+        st.floats(min_value=-5, max_value=5, allow_nan=False, allow_infinity=False),
+        st.just(float("nan")),
+        st.text(min_size=0, max_size=5),
+    ),
+    "activity_id": st.one_of(
+        st.none(),
+        st.integers(-5, 5),
+        st.floats(min_value=-5, max_value=5, allow_nan=False, allow_infinity=False),
+        st.just(float("nan")),
+        st.text(min_size=0, max_size=5),
+    ),
+    "standard_value": st.one_of(
+        st.none(),
+        st.floats(min_value=-5.0, max_value=5.0, allow_nan=False, allow_infinity=False),
+        st.just(float("nan")),
+        st.text(min_size=0, max_size=5),
+    ),
+}
+
+
+@settings(max_examples=50, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(_dataframe_strategy(_testitems_columns, _testitems_value_strategies))
+def test_validate_testitems_matches_legacy(tmp_path: Path, df: pd.DataFrame) -> None:
+    new_errors = tmp_path / "new_testitems.json"
+    legacy_errors = tmp_path / "legacy_testitems.json"
+    new_errors.unlink(missing_ok=True)
+    legacy_errors.unlink(missing_ok=True)
+
+    result = validate_testitems(df.copy(deep=True), errors_path=new_errors)
+    legacy = legacy_validation.legacy_validate_testitems(
+        df.copy(deep=True), errors_path=legacy_errors
+    )
+
+    new_valid = _canonicalise_frame(
+        _ordered_view(result.valid, TestitemsSchema.ordered_columns())
+    )
+    legacy_valid = _canonicalise_frame(
+        _ordered_view(legacy, TestitemsSchema.ordered_columns())
+    )
+    pd.testing.assert_frame_equal(new_valid, legacy_valid, check_dtype=False)
+
+    assert new_errors.exists() == legacy_errors.exists()
+    assert _new_error_indices(result.errors) == _legacy_error_indices(legacy_errors)
+
+
+@settings(max_examples=50, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(_dataframe_strategy(_assay_columns, _assay_value_strategies))
+def test_validate_assays_matches_legacy(tmp_path: Path, df: pd.DataFrame) -> None:
+    new_errors = tmp_path / "new_assays.json"
+    legacy_errors = tmp_path / "legacy_assays.json"
+    new_errors.unlink(missing_ok=True)
+    legacy_errors.unlink(missing_ok=True)
+
+    result = validate_assays(df.copy(deep=True), errors_path=new_errors)
+    legacy = legacy_validation.legacy_validate_assays(
+        df.copy(deep=True), errors_path=legacy_errors
+    )
+
+    new_valid = _canonicalise_frame(
+        _ordered_view(result.valid, AssaysSchema.ordered_columns())
+    )
+    legacy_valid = _canonicalise_frame(
+        _ordered_view(legacy, AssaysSchema.ordered_columns())
+    )
+    pd.testing.assert_frame_equal(new_valid, legacy_valid, check_dtype=False)
+
+    assert new_errors.exists() == legacy_errors.exists()
+    assert _new_error_indices(result.errors) == _legacy_error_indices(legacy_errors)
+
+
+@settings(max_examples=50, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(_dataframe_strategy(_activity_columns, _activity_value_strategies))
+def test_validate_activities_matches_legacy(tmp_path: Path, df: pd.DataFrame) -> None:
+    new_errors = tmp_path / "new_activities.json"
+    legacy_errors = tmp_path / "legacy_activities.json"
+    new_errors.unlink(missing_ok=True)
+    legacy_errors.unlink(missing_ok=True)
+
+    result = validate_activities(df.copy(deep=True), errors_path=new_errors)
+    legacy = legacy_validation.legacy_validate_activities(
+        df.copy(deep=True), errors_path=legacy_errors
+    )
+
+    new_valid = _canonicalise_frame(
+        _ordered_view(result.valid, ActivitiesSchema.ordered_columns())
+    )
+    legacy_valid = _canonicalise_frame(
+        _ordered_view(legacy, ActivitiesSchema.ordered_columns())
+    )
+    pd.testing.assert_frame_equal(new_valid, legacy_valid, check_dtype=False)
+
+    assert new_errors.exists() == legacy_errors.exists()
+    assert _new_error_indices(result.errors) == _legacy_error_indices(legacy_errors)


### PR DESCRIPTION
## Summary
- fix vectorised validators to record missing required columns and align coercion with legacy behaviour
- adjust shared coercion to keep one-element object arrays containing dicts as lists
- normalise property-based regression tests to compare canonicalised outputs against the legacy implementation

## Testing
- pytest tests/test_chembl_assays_pipeline.py tests/test_chembl_activities_pipeline.py tests/test_testitems_validation.py tests/test_validation_property.py
- ruff check . (fails: tests/test_get_uniprot_target_data.py contains an invalid class stub)
- mypy . --config-file mypy.ini (fails: tests/test_get_uniprot_target_data.py missing class body)


------
https://chatgpt.com/codex/tasks/task_e_68ce08fcdd0c83249f1312da29c5cbdd