### PR TITLE
Stream ChEMBL document retrieval and chunked exports

### DIFF
--- a/tests/test_pubmed_main.py
+++ b/tests/test_pubmed_main.py
@@ -6,7 +6,7 @@ import argparse
 import sys
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Iterable, Sequence
 
 import pandas as pd
 import pytest
@@ -300,8 +300,8 @@ def test_run_all_merges_chembl(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
 
     def fake_get_documents(
         ids: Sequence[str], *, cfg: Any, client: Any, chunk_size: int, timeout: float
-    ) -> pd.DataFrame:  # type: ignore[override]
-        return chembl_df
+    ) -> Iterable[pd.DataFrame]:  # type: ignore[override]
+        yield chembl_df
 
     def fake_gather(
         pmids: Sequence[str], *, cfg: dict[str, Any]
@@ -469,14 +469,18 @@ def test_semantic_scholar_cli_overrides() -> None:
     assert config["semantic_scholar"]["chunk_size"] == 50
 
 
-def test_semantic_scholar_rps_clamped_without_flag(caplog: pytest.LogCaptureFixture) -> None:
+def test_semantic_scholar_rps_clamped_without_flag(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """High RPS overrides should be clamped unless explicitly enabled."""
 
-    args = pm.parse_args([
-        "--semantic-scholar-rps",
-        "0.9",
-        "scholar",
-    ])
+    args = pm.parse_args(
+        [
+            "--semantic-scholar-rps",
+            "0.9",
+            "scholar",
+        ]
+    )
     config = deepcopy(pm.DEFAULT_CONFIG)
 
     with caplog.at_level("WARNING"):


### PR DESCRIPTION
## Summary
- stream `get_documents` responses in `library.chembl_client` without materialising all IDs
- write ChEMBL CSV output chunk-by-chunk in `pubmed_main`, including progress tracking and incremental quality metrics
- adapt CLI tests to the generator interface and add a tracemalloc-based memory regression test

## Testing
- pytest tests/test_chembl_client.py tests/test_pubmed_main.py
- ruff check library/chembl_client.py scripts/pubmed_main.py tests/test_chembl_client.py tests/test_pubmed_main.py
- black library/chembl_client.py scripts/pubmed_main.py tests/test_chembl_client.py tests/test_pubmed_main.py

------
https://chatgpt.com/codex/tasks/task_e_68ce090b54c08324bd8824db436ee31e