### PR TITLE
Handle ChEMBL batch fetch failures gracefully

### DIFF
--- a/tests/test_chembl_activities_pipeline.py
+++ b/tests/test_chembl_activities_pipeline.py
@@ -89,16 +89,19 @@ def test_get_activities_batches_requests() -> None:
     calls: List[List[str]] = []
 
     class DummyClient:
-        def fetch_many_activities(self, values: Iterable[str]) -> List[dict[str, str]]:
+        def fetch_many_activities(
+            self, values: Iterable[str]
+        ) -> tuple[List[dict[str, str]], List[str]]:
             batch = list(values)
             calls.append(batch)
-            return [
+            records = [
                 {
                     "activity_chembl_id": activity_id,
                     "assay_chembl_id": f"ASSAY-{activity_id}",
                 }
                 for activity_id in batch
             ]
+            return records, []
 
     df = get_activities(DummyClient(), ["CHEMBL1", "CHEMBL2", "CHEMBL3"], chunk_size=2)
     assert list(df["activity_chembl_id"]) == ["CHEMBL1", "CHEMBL2", "CHEMBL3"]

--- a/tests/test_chembl_assays_pipeline.py
+++ b/tests/test_chembl_assays_pipeline.py
@@ -51,10 +51,12 @@ def test_get_assays_batches_requests() -> None:
     calls: List[List[str]] = []
 
     class DummyClient:
-        def fetch_many(self, values: Iterable[str]) -> List[dict[str, str]]:
+        def fetch_many(
+            self, values: Iterable[str]
+        ) -> tuple[List[dict[str, str]], List[str]]:
             batch = list(values)
             calls.append(batch)
-            return [
+            records = [
                 {
                     "assay_chembl_id": assay_id,
                     "document_chembl_id": f"DOC-{assay_id}",
@@ -62,6 +64,7 @@ def test_get_assays_batches_requests() -> None:
                 }
                 for assay_id in batch
             ]
+            return records, []
 
     df = get_assays(DummyClient(), ["CHEMBL1", "CHEMBL2", "CHEMBL3"], chunk_size=2)
     assert list(df["assay_chembl_id"]) == ["CHEMBL1", "CHEMBL2", "CHEMBL3"]


### PR DESCRIPTION
## Summary
- add ChemblBatchFetchError and track failed identifiers when batch-fetching ChEMBL resources
- propagate failed identifier reporting through chembl_library consumers and update their tests
- align PubChem fallback tests with the HTTP client's retry behaviour

## Testing
- black library/chembl_client.py library/chembl_library.py tests/test_chembl_activities_pipeline.py tests/test_chembl_assays_pipeline.py tests/test_chembl_client.py tests/test_testitems_library.py
- ruff check library/chembl_client.py library/chembl_library.py tests/test_chembl_activities_pipeline.py tests/test_chembl_assays_pipeline.py tests/test_chembl_client.py tests/test_testitems_library.py
- mypy -p library.chembl_client -p library.chembl_library -m tests.test_chembl_client
- pytest tests/test_chembl_client.py tests/test_chembl_assays_pipeline.py tests/test_chembl_activities_pipeline.py tests/test_testitems_library.py

------
https://chatgpt.com/codex/tasks/task_e_68ce08dc585c8324823a6809c91315ec