### PR TITLE
Fix validation handling for activities and assays pipelines

### DIFF
--- a/scripts/chembl_activities_main.py
+++ b/scripts/chembl_activities_main.py
@@ -105,7 +105,9 @@ def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--user-agent", default=None, help="User-Agent header (defaults to config)"
     )
-    parser.add_argument("--sep", default=None, help="CSV delimiter (defaults to config)")
+    parser.add_argument(
+        "--sep", default=None, help="CSV delimiter (defaults to config)"
+    )
     parser.add_argument(
         "--encoding", default=None, help="CSV encoding (defaults to config)"
     )
@@ -283,8 +285,10 @@ def _prepare_activity_chunk(
     normalised = normalize_activities(chunk)
 
     temp_errors = errors_path.with_name(f"{errors_path.name}.part")
-    validated = validate_activities(normalised, errors_path=temp_errors)
+    validation_result = validate_activities(normalised, errors_path=temp_errors)
     error_accumulator.extend(_consume_error_file(temp_errors))
+
+    validated = validation_result.valid
 
     if validated.empty:
         return pd.DataFrame(), ordered_columns, None

--- a/tests/test_chembl_activities_pipeline.py
+++ b/tests/test_chembl_activities_pipeline.py
@@ -270,6 +270,8 @@ def test_activities_parse_args_allows_cli_overrides(tmp_path: Path) -> None:
     assert args.encoding == "utf-16"
     assert args.list_format == "json"
     assert args.chunk_size == 11
+
+
 def test_normalize_activities() -> None:
     raw = pd.DataFrame(
         [
@@ -329,7 +331,8 @@ def test_validate_activities_writes_errors(tmp_path: Path) -> None:
     )
 
     errors_path = tmp_path / "errors.json"
-    validated = validate_activities(df, errors_path=errors_path)
+    result = validate_activities(df, errors_path=errors_path)
+    validated = result.valid
 
     assert len(validated) == 1
     assert not validated["activity_chembl_id"].isna().any()
@@ -352,7 +355,8 @@ def test_validate_activities_handles_numpy_payloads(tmp_path: Path) -> None:
     )
 
     errors_path = tmp_path / "errors.json"
-    validated = validate_activities(df, errors_path=errors_path)
+    result = validate_activities(df, errors_path=errors_path)
+    validated = result.valid
 
     assert not errors_path.exists()
     assert validated.loc[0, "activity_properties"] == []


### PR DESCRIPTION
## Summary
- update the activity and assay pipelines to consume the new `ValidationResult` return type and keep metadata writing logic consistent
- ensure assay pipeline metadata is recorded via `write_cli_metadata` and retain validation column ordering when writing output
- adjust pipeline tests to work with the structured validation result helpers

## Testing
- `ruff check scripts/chembl_activities_main.py scripts/chembl_assays_main.py tests/test_chembl_activities_pipeline.py tests/scripts/test_chembl_assays_main.py`
- `mypy scripts/chembl_activities_main.py scripts/chembl_assays_main.py`
- `pytest tests/test_chembl_activities_pipeline.py::test_validate_activities_writes_errors tests/test_chembl_activities_pipeline.py::test_validate_activities_handles_numpy_payloads`
- `pytest tests/scripts/test_chembl_assays_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ce917331a48324b24312cc225b1717