### PR TITLE
Handle validation results in testitem pipeline

### DIFF
--- a/scripts/chembl_testitems_main.py
+++ b/scripts/chembl_testitems_main.py
@@ -332,8 +332,17 @@ def run_pipeline(
         http_client_config=pubchem_http_client_config,
     )
     enriched = _ensure_output_columns(enriched, REQUIRED_ENRICHED_COLUMNS)
-    validated = validate_testitems(enriched, errors_path=errors_path)
-    validated = _ensure_output_columns(validated, REQUIRED_ENRICHED_COLUMNS)
+
+    validation_result = validate_testitems(enriched, errors_path=errors_path)
+    validation_errors = validation_result.errors
+    if not validation_errors.empty:
+        invalid_row_count = int(validation_errors["index"].nunique())
+        LOGGER.warning(
+            "Validation removed %d row(s) due to data quality issues", invalid_row_count
+        )
+    validated = _ensure_output_columns(
+        validation_result.valid, REQUIRED_ENRICHED_COLUMNS
+    )
 
     schema_columns = [
         column

--- a/stubs/_path_utils.pyi
+++ b/stubs/_path_utils.pyi
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def ensure_project_root(*, package_dir: str = ...) -> Path: ...


### PR DESCRIPTION
## Summary
- handle the `ValidationResult` returned by `validate_testitems` before enforcing required output columns
- log the number of rows removed during validation and continue with the validated frame
- provide a minimal `_path_utils` typing stub so mypy can resolve the helper used by CLI scripts

## Testing
- black scripts/chembl_testitems_main.py
- ruff check scripts/chembl_testitems_main.py
- mypy scripts/chembl_testitems_main.py
- pytest *(fails: IndentationError in tests/test_get_uniprot_target_data.py)*

------
https://chatgpt.com/codex/tasks/task_e_68cea0f09d288324ac5022776434db4b